### PR TITLE
fix(payment): add Stripe idempotency keys (#26)

### DIFF
--- a/src/__tests__/payments/idempotency-key.test.ts
+++ b/src/__tests__/payments/idempotency-key.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockStripePaymentIntentsCreate = vi.fn();
+const mockStripeCheckoutSessionsCreate = vi.fn();
+
+vi.mock('@/lib/stripe/server', () => ({
+  getStripeServer: vi.fn(() => ({
+    paymentIntents: { create: mockStripePaymentIntentsCreate },
+    checkout: { sessions: { create: mockStripeCheckoutSessionsCreate } },
+  })),
+}));
+
+const mockFrom = vi.fn();
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock('@/lib/payment/calculate-deposit', () => ({
+  calculateDeposit: vi.fn(() => 30),
+  toCents: vi.fn((v: number) => v * 100),
+}));
+
+vi.mock('@/lib/validation/booking-schema', () => ({
+  bookingSchema: {
+    safeParse: vi.fn((data: Record<string, unknown>) => ({
+      success: true,
+      data: {
+        professional_id: data.professional_id,
+        service_id: data.service_id,
+        booking_date: data.booking_date || '2026-03-10',
+        start_time: data.start_time || '10:00',
+        client_name: data.client_name || 'Test',
+        client_phone: data.client_phone || '353800000001',
+      },
+    })),
+  },
+  sanitizeString: vi.fn((s: string) => s),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function mockSupabase(overrides: Record<string, unknown> = {}) {
+  const professional = {
+    id: 'prof-1',
+    require_deposit: true,
+    deposit_type: 'percentage',
+    deposit_value: 30,
+    currency: 'EUR',
+    subscription_status: 'active',
+    trial_ends_at: '2027-01-01',
+    stripe_account_id: 'acct_test',
+    ...overrides,
+  };
+  const service = { id: 'svc-1', name: 'Corte', price: 100, duration_minutes: 30 };
+  const booking = { id: 'booking-123' };
+
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'professionals') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: professional, error: null }),
+          }),
+        }),
+      };
+    }
+    if (table === 'services') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: service, error: null }),
+            }),
+          }),
+        }),
+      };
+    }
+    if (table === 'bookings') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              in: vi.fn().mockReturnValue({
+                lt: vi.fn().mockReturnValue({
+                  gt: vi.fn().mockResolvedValue({ data: [], error: null }),
+                }),
+              }),
+            }),
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: booking, error: null }),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      };
+    }
+    if (table === 'payments') {
+      return {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      };
+    }
+    return {};
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockStripePaymentIntentsCreate.mockResolvedValue({
+    id: 'pi_test',
+    client_secret: 'cs_test',
+  });
+  mockStripeCheckoutSessionsCreate.mockResolvedValue({
+    id: 'ses_test',
+    url: 'https://checkout.stripe.com/test',
+  });
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Idempotency keys — create-intent', () => {
+  it('passes idempotencyKey to stripe.paymentIntents.create', async () => {
+    mockSupabase();
+
+    const { POST } = await import('@/app/api/payment/create-intent/route');
+    const req = new Request('http://localhost/api/payment/create-intent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ professional_id: 'prof-1', service_id: 'svc-1' }),
+    }) as any;
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // Verify Stripe was called with idempotencyKey option
+    expect(mockStripePaymentIntentsCreate).toHaveBeenCalledTimes(1);
+    const [, options] = mockStripePaymentIntentsCreate.mock.calls[0];
+    expect(options).toHaveProperty('idempotencyKey');
+    expect(options.idempotencyKey).toMatch(/^pi:prof-1:svc-1:/);
+  });
+
+  it('uses client-provided idempotency_key when sent', async () => {
+    mockSupabase();
+
+    const { POST } = await import('@/app/api/payment/create-intent/route');
+    const req = new Request('http://localhost/api/payment/create-intent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        professional_id: 'prof-1',
+        service_id: 'svc-1',
+        idempotency_key: 'client-key-abc',
+      }),
+    }) as any;
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const [, options] = mockStripePaymentIntentsCreate.mock.calls[0];
+    expect(options.idempotencyKey).toBe('client-key-abc');
+  });
+
+  it('generates different keys for different requests', async () => {
+    mockSupabase();
+
+    const { POST } = await import('@/app/api/payment/create-intent/route');
+
+    const req1 = new Request('http://localhost/api/payment/create-intent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ professional_id: 'prof-1', service_id: 'svc-1' }),
+    }) as any;
+    await POST(req1);
+
+    const req2 = new Request('http://localhost/api/payment/create-intent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ professional_id: 'prof-1', service_id: 'svc-1' }),
+    }) as any;
+    await POST(req2);
+
+    const key1 = mockStripePaymentIntentsCreate.mock.calls[0][1].idempotencyKey;
+    const key2 = mockStripePaymentIntentsCreate.mock.calls[1][1].idempotencyKey;
+    expect(key1).not.toBe(key2);
+  });
+});
+
+describe('Idempotency keys — checkout session', () => {
+  it('passes idempotencyKey based on booking.id to stripe.checkout.sessions.create', async () => {
+    mockSupabase();
+
+    const { POST } = await import('@/app/api/bookings/checkout/route');
+    const req = new Request('http://localhost/api/bookings/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        professional_id: 'prof-1',
+        service_id: 'svc-1',
+        booking_date: '2026-03-10',
+        start_time: '10:00',
+        client_name: 'Test Client',
+        client_phone: '353800000001',
+      }),
+    }) as any;
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    expect(mockStripeCheckoutSessionsCreate).toHaveBeenCalledTimes(1);
+    const [, options] = mockStripeCheckoutSessionsCreate.mock.calls[0];
+    expect(options).toHaveProperty('idempotencyKey');
+    expect(options.idempotencyKey).toBe('cs:booking-123');
+  });
+});

--- a/src/app/api/bookings/checkout/route.ts
+++ b/src/app/api/bookings/checkout/route.ts
@@ -190,35 +190,41 @@ export async function POST(request: NextRequest) {
 
   const currencyCode = (prof.currency as string)?.toLowerCase() || 'eur';
 
-  const session = await stripe.checkout.sessions.create({
-    mode: 'payment',
-    line_items: [
-      {
-        price_data: {
-          currency: currencyCode,
-          product_data: {
-            name: `Sinal — ${service.name}`,
-            description: `Agendamento ${booking_date} às ${start_time}`,
+  // Idempotency key baseada no booking.id: retry-safe (mesmo booking = mesma session)
+  const idempotencyKey = `cs:${booking.id}`;
+
+  const session = await stripe.checkout.sessions.create(
+    {
+      mode: 'payment',
+      line_items: [
+        {
+          price_data: {
+            currency: currencyCode,
+            product_data: {
+              name: `Sinal — ${service.name}`,
+              description: `Agendamento ${booking_date} às ${start_time}`,
+            },
+            unit_amount: depositCents,
           },
-          unit_amount: depositCents,
+          quantity: 1,
         },
-        quantity: 1,
+      ],
+      payment_intent_data: {
+        application_fee_amount: applicationFeeCents,
+        transfer_data: {
+          destination: prof.stripe_account_id as string,
+        },
       },
-    ],
-    payment_intent_data: {
-      application_fee_amount: applicationFeeCents,
-      transfer_data: {
-        destination: prof.stripe_account_id as string,
+      metadata: {
+        booking_id: booking.id,
+        type: 'deposit',
       },
+      customer_email: client_email,
+      success_url: `${BASE_URL}/booking/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${BASE_URL}/booking/cancel`,
     },
-    metadata: {
-      booking_id: booking.id,
-      type: 'deposit',
-    },
-    customer_email: client_email,
-    success_url: `${BASE_URL}/booking/success?session_id={CHECKOUT_SESSION_ID}`,
-    cancel_url: `${BASE_URL}/booking/cancel`,
-  });
+    { idempotencyKey }
+  );
 
   // ─── 12. INSERT payment ──────────────────────────────────────────────────
   await supabase.from('payments').insert({

--- a/src/app/api/payment/create-intent/route.ts
+++ b/src/app/api/payment/create-intent/route.ts
@@ -11,9 +11,10 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Payload inválido' }, { status: 400 });
   }
 
-  const { professional_id, service_id } = body as {
+  const { professional_id, service_id, idempotency_key: clientKey } = body as {
     professional_id?: string;
     service_id?: string;
+    idempotency_key?: string;
   };
 
   if (!professional_id || !service_id) {
@@ -83,19 +84,25 @@ export async function POST(request: NextRequest) {
   const currency = (professional.currency ?? 'EUR').toLowerCase();
 
   try {
-    const paymentIntent = await stripe.paymentIntents.create({
-      amount: toCents(depositAmount),
-      currency,
-      metadata: {
-        professional_id,
-        service_id,
-        service_name: service.name,
-        deposit_type: professional.deposit_type,
-        deposit_value: String(professional.deposit_value),
+    // Idempotency key: usa key do frontend se enviada (retry-safe), senão gera UUID
+    const idempotencyKey = clientKey || `pi:${professional_id}:${service_id}:${crypto.randomUUID()}`;
+
+    const paymentIntent = await stripe.paymentIntents.create(
+      {
+        amount: toCents(depositAmount),
+        currency,
+        metadata: {
+          professional_id,
+          service_id,
+          service_name: service.name,
+          deposit_type: professional.deposit_type,
+          deposit_value: String(professional.deposit_value),
+        },
+        // Permite cards e outros métodos automaticamente
+        automatic_payment_methods: { enabled: true },
       },
-      // Permite cards e outros métodos automaticamente
-      automatic_payment_methods: { enabled: true },
-    });
+      { idempotencyKey }
+    );
 
     // Salvar registro de pagamento pendente
     await supabase.from('payments').insert({


### PR DESCRIPTION
## Summary
- Add idempotency keys to `stripe.paymentIntents.create()` in `/api/payment/create-intent` — accepts client-provided key or generates `pi:{prof}:{svc}:{uuid}`
- Add idempotency key `cs:{booking.id}` to `stripe.checkout.sessions.create()` in `/api/bookings/checkout`
- 4 unit tests covering both endpoints (key presence, client override, uniqueness, checkout key format)

## Test plan
- [x] Unit tests: 4 tests pass (`idempotency-key.test.ts`)
- [x] Full suite: 188/188 tests pass
- [x] TypeScript: `tsc --noEmit` clean
- [ ] CI green

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)