### PR TITLE
fix(db): replace booking_time with start_time in broken triggers (#27)

### DIFF
--- a/src/__tests__/migrations/fix-booking-time-references.test.ts
+++ b/src/__tests__/migrations/fix-booking-time-references.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  process.cwd(),
+  'supabase/migrations/20260303000001_fix_booking_time_references.sql'
+);
+
+const migrationSQL = readFileSync(MIGRATION_PATH, 'utf-8');
+
+describe('Migration: fix booking_time references (#27)', () => {
+  it('does NOT reference booking_time as a column (NEW.booking_time or b.booking_time)', () => {
+    // The only allowed occurrence is the JSON key 'booking_time' in jsonb_build_object
+    const lines = migrationSQL.split('\n');
+    const violations: string[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Skip comments
+      if (line.trim().startsWith('--')) continue;
+      // Skip the JSON key in jsonb_build_object (this is a data key, not a column reference)
+      if (line.includes("'booking_time'")) continue;
+
+      if (/\bNEW\.booking_time\b/.test(line)) {
+        violations.push(`Line ${i + 1}: ${line.trim()}`);
+      }
+      if (/\bOLD\.booking_time\b/.test(line)) {
+        violations.push(`Line ${i + 1}: ${line.trim()}`);
+      }
+      if (/\bb\.booking_time\b/.test(line)) {
+        violations.push(`Line ${i + 1}: ${line.trim()}`);
+      }
+      if (/\bbs\.booking_time\b/.test(line)) {
+        violations.push(`Line ${i + 1}: ${line.trim()}`);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('uses NEW.start_time in notify_waitlist_on_cancellation', () => {
+    expect(migrationSQL).toContain('NEW.start_time');
+    expect(migrationSQL).toContain('notify_waitlist_on_cancellation');
+  });
+
+  it('uses b.start_time in get_available_slots', () => {
+    expect(migrationSQL).toContain('b.start_time::time AS booking_start');
+    expect(migrationSQL).toContain('get_available_slots');
+  });
+
+  it('uses b.start_time and b.end_time in check_calendar_conflicts', () => {
+    expect(migrationSQL).toContain('b.start_time::time');
+    expect(migrationSQL).toContain('b.end_time::time');
+    expect(migrationSQL).toContain('check_calendar_conflicts');
+  });
+
+  it('uses client_name instead of contact_name in check_calendar_conflicts', () => {
+    expect(migrationSQL).toContain('b.client_name');
+    expect(migrationSQL).not.toMatch(/b\.contact_name/);
+  });
+
+  it('fixes all three functions with CREATE OR REPLACE', () => {
+    const createOrReplace = migrationSQL.match(/CREATE OR REPLACE FUNCTION/g);
+    expect(createOrReplace).toHaveLength(3);
+  });
+
+  it('keeps the booking_time JSON key in waitlist notification data', () => {
+    // The JSON key 'booking_time' is intentional — it's data for the notification template,
+    // but the VALUE should reference start_time
+    expect(migrationSQL).toContain("'booking_time', NEW.start_time");
+  });
+
+  it('original migration has no remaining booking_time column references', () => {
+    // Verify the original problematic migration file still has the bugs
+    // (this confirms our fix is necessary)
+    const originalPath = join(
+      process.cwd(),
+      'supabase/migrations/20250217000000_sprint7_automations.sql'
+    );
+    const original = readFileSync(originalPath, 'utf-8');
+    expect(original).toContain('NEW.booking_time');
+    expect(original).toMatch(/\bbooking_time\b/);
+  });
+});

--- a/supabase/migrations/20260303000001_fix_booking_time_references.sql
+++ b/supabase/migrations/20260303000001_fix_booking_time_references.sql
@@ -1,0 +1,175 @@
+-- =====================================================
+-- FIX: Corrigir funções que referenciam booking_time (coluna inexistente)
+-- Data: 2026-03-03
+-- Issue: #27
+-- Problema: Triggers/funções usam booking_time mas coluna real é start_time
+--   Também: contact_name → client_name em check_calendar_conflicts
+-- Funções afetadas:
+--   1. notify_waitlist_on_cancellation() — trigger AFTER UPDATE on bookings
+--   2. get_available_slots() — função auxiliar
+--   3. check_calendar_conflicts() — função auxiliar
+-- =====================================================
+
+-- Fix 1: notify_waitlist_on_cancellation
+-- Trigger que notifica waitlist quando booking é cancelado
+CREATE OR REPLACE FUNCTION notify_waitlist_on_cancellation()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_waitlist_record RECORD;
+  v_professional RECORD;
+BEGIN
+  -- Só processa se mudou de confirmado para cancelado
+  IF OLD.status = 'confirmed' AND NEW.status = 'cancelled' THEN
+
+    -- Busca profissional
+    SELECT * INTO v_professional FROM professionals WHERE id = NEW.professional_id;
+
+    -- Busca primeiro da waitlist para este serviço e data
+    SELECT * INTO v_waitlist_record
+    FROM waitlist
+    WHERE professional_id = NEW.professional_id
+      AND service_id = NEW.service_id
+      AND NEW.booking_date = ANY(preferred_dates)
+      AND status = 'active'
+      AND notified = false
+    ORDER BY created_at ASC
+    LIMIT 1;
+
+    -- Se encontrou alguém na waitlist, adiciona na fila de notificações
+    IF v_waitlist_record.id IS NOT NULL THEN
+      INSERT INTO notification_queue (
+        professional_id,
+        type,
+        recipient_name,
+        recipient_phone,
+        recipient_email,
+        message_template,
+        message_data,
+        language
+      ) VALUES (
+        NEW.professional_id,
+        'waitlist_available',
+        v_waitlist_record.contact_name,
+        v_waitlist_record.contact_phone,
+        v_waitlist_record.contact_email,
+        'waitlist_available',
+        jsonb_build_object(
+          'waitlist_id', v_waitlist_record.id,
+          'booking_date', NEW.booking_date,
+          'booking_time', NEW.start_time,
+          'service_id', NEW.service_id,
+          'professional_name', v_professional.business_name,
+          'professional_slug', v_professional.slug
+        ),
+        'pt'
+      );
+
+      -- Marca waitlist como notificado
+      UPDATE waitlist
+      SET
+        notified = true,
+        notified_at = now(),
+        notification_expires_at = now() + interval '24 hours',
+        status = 'notified'
+      WHERE id = v_waitlist_record.id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Fix 2: get_available_slots
+-- Função auxiliar para buscar horários disponíveis
+CREATE OR REPLACE FUNCTION get_available_slots(
+  p_professional_id uuid,
+  p_date date,
+  p_duration_minutes integer
+)
+RETURNS TABLE (
+  time_slot time,
+  is_available boolean
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH all_slots AS (
+    SELECT generate_series(
+      '09:00'::time,
+      '18:00'::time,
+      '30 minutes'::interval
+    )::time AS slot
+  ),
+  booked_slots AS (
+    SELECT
+      b.start_time::time AS booking_start,
+      CASE
+        WHEN b.package_id IS NOT NULL THEN
+          (SELECT duration_minutes FROM service_packages WHERE id = b.package_id)
+        ELSE
+          (SELECT duration_minutes FROM services WHERE id = b.service_id)
+      END as duration
+    FROM bookings b
+    WHERE b.professional_id = p_professional_id
+      AND b.booking_date = p_date
+      AND b.status IN ('pending', 'confirmed')
+  )
+  SELECT
+    s.slot,
+    NOT EXISTS (
+      SELECT 1 FROM booked_slots bs
+      WHERE s.slot >= bs.booking_start
+        AND s.slot < bs.booking_start + (bs.duration || ' minutes')::interval
+    ) as is_available
+  FROM all_slots s
+  ORDER BY s.slot;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Fix 3: check_calendar_conflicts
+-- Função auxiliar para detectar conflitos de horário
+CREATE OR REPLACE FUNCTION check_calendar_conflicts(
+  p_professional_id uuid,
+  p_start_time timestamptz,
+  p_end_time timestamptz,
+  p_exclude_booking_id uuid DEFAULT NULL
+)
+RETURNS TABLE(
+  conflict_type text,
+  conflict_source text,
+  event_title text,
+  event_start timestamptz,
+  event_end timestamptz
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    'booking_conflict'::text,
+    'circlehood'::text,
+    b.client_name,
+    (b.booking_date::date + b.start_time::time)::timestamptz,
+    (b.booking_date::date + b.end_time::time)::timestamptz
+  FROM bookings b
+  WHERE b.professional_id = p_professional_id
+    AND b.status IN ('confirmed', 'pending')
+    AND (p_exclude_booking_id IS NULL OR b.id != p_exclude_booking_id)
+    AND (
+      (b.booking_date::date + b.start_time::time)::timestamptz < p_end_time
+      AND (b.booking_date::date + b.end_time::time)::timestamptz > p_start_time
+    )
+
+  UNION ALL
+
+  SELECT
+    'calendar_conflict'::text,
+    ce.source::text,
+    ce.title,
+    ce.start_time,
+    ce.end_time
+  FROM calendar_events ce
+  WHERE ce.professional_id = p_professional_id
+    AND ce.status = 'confirmed'
+    AND ce.booking_id IS NULL -- Eventos externos
+    AND ce.start_time < p_end_time
+    AND ce.end_time > p_start_time;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- Three DB functions referenced non-existent `booking_time` column, causing silent trigger failures
- `notify_waitlist_on_cancellation()`: `NEW.booking_time` → `NEW.start_time`
- `get_available_slots()`: `booking_time` → `b.start_time`
- `check_calendar_conflicts()`: `b.booking_time` → `b.start_time`/`b.end_time`, `b.contact_name` → `b.client_name`

## Test plan
- [x] 8 unit tests validating migration correctness
- [x] Full suite: 213/213 tests pass
- [x] TypeScript: `tsc --noEmit` clean
- [ ] CI green
- [ ] Apply migration to production DB via `supabase db push`

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)