### PR TITLE
fix(e2e): add warmup to idempotency tests to fix CI flakiness

### DIFF
--- a/e2e/critical/01-idempotency.spec.ts
+++ b/e2e/critical/01-idempotency.spec.ts
@@ -161,6 +161,17 @@ async function fillBookingFormToStep4(
 
 // ─── Setup / Teardown ─────────────────────────────────────────────────────────
 
+// Warmup: aquecer o Vercel serverless antes do primeiro teste.
+// Sem isso, o cold start (~5-10s no CI) consome parte do timeout de 45s
+// do toBeVisible, causando falhas flaky no primeiro teste que roda.
+test.beforeAll(async ({ request }) => {
+  // Dispara 2 requests em paralelo para aquecer diferentes serverless functions
+  await Promise.allSettled([
+    request.get(`${BASE}/${BOOKING_SLUG}`).catch(() => {}),
+    request.get(`${BASE}/api/available-slots?professional_id=${TEST.PROFESSIONAL_ID}&date=2026-01-01&service_id=dummy`).catch(() => {}),
+  ]);
+});
+
 test.beforeEach(async () => {
   await cleanIdempotencyBookings();
   // Garantir que require_deposit está false — o job de pagamentos (paralelo no CI)


### PR DESCRIPTION
## Summary
- Add `test.beforeAll` warmup in `e2e/critical/01-idempotency.spec.ts` that sends HTTP requests to warm up Vercel serverless functions before browser tests run
- Root cause: Vercel cold start (~5-10s) consumed part of the 45s `toBeVisible` timeout, causing a **different test to fail on every CI run** (test 1 in one run, test 2 in the next, test 3 in another)

## Evidence of the pattern
| CI Run | Failed test | Notes |
|--------|------------|-------|
| PR #50 (issue-27) | Test 1 (duplo-clique) | First test hit cold start |
| PR #51 (issue-28) | Test 2 (reload) | Test 1 warmed it, test 2 hit timing edge |
| PR #53 (issue-3)  | Test 3 (back/forward) | Same pattern |

## Fix
```typescript
test.beforeAll(async ({ request }) => {
  await Promise.allSettled([
    request.get(`${BASE}/${BOOKING_SLUG}`),
    request.get(`${BASE}/api/available-slots?...`),
  ]);
});
```

## Test plan
- [ ] CI green — specifically the "idempotência crítica" job that has failed on every PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)