### PR TITLE
fix(webhook): make booking+payment update atomic via Supabase RPC

### DIFF
--- a/src/__tests__/payments/atomic-webhook.test.ts
+++ b/src/__tests__/payments/atomic-webhook.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+describe('Atomic webhook — code verification (#4)', () => {
+  const webhookPath = join(
+    process.cwd(),
+    'src/app/api/webhooks/stripe-deposit/route.ts',
+  );
+  const migrationPath = join(
+    process.cwd(),
+    'supabase/migrations/20260303000002_confirm_booking_payment_atomic.sql',
+  );
+
+  it('webhook uses .rpc() instead of separate .update() calls for checkout.session.completed', () => {
+    const source = readFileSync(webhookPath, 'utf-8');
+    expect(source).toContain("supabase.rpc(");
+    expect(source).toContain("'confirm_booking_payment'");
+  });
+
+  it('webhook does NOT use separate booking + payment updates in checkout.session.completed', () => {
+    const source = readFileSync(webhookPath, 'utf-8');
+
+    // Find the checkout.session.completed case block
+    const checkoutStart = source.indexOf("case 'checkout.session.completed':");
+    const checkoutEnd = source.indexOf('break;', checkoutStart);
+    const checkoutBlock = source.slice(checkoutStart, checkoutEnd);
+
+    // Should NOT have .from('bookings').update() or .from('payments').update() in this block
+    expect(checkoutBlock).not.toMatch(/\.from\(['"]bookings['"]\)\s*\n\s*\.update/);
+    expect(checkoutBlock).not.toMatch(/\.from\(['"]payments['"]\)\s*\n\s*\.update/);
+  });
+
+  it('webhook returns 500 on RPC error (so Stripe retries)', () => {
+    const source = readFileSync(webhookPath, 'utf-8');
+    expect(source).toContain('rpcError');
+    expect(source).toContain("status: 500");
+  });
+
+  it('migration file exists with confirm_booking_payment function', () => {
+    expect(existsSync(migrationPath)).toBe(true);
+    const sql = readFileSync(migrationPath, 'utf-8');
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION confirm_booking_payment');
+    expect(sql).toContain('p_booking_id uuid');
+    expect(sql).toContain('p_checkout_session_id text');
+  });
+
+  it('RPC function updates both bookings and payments in same transaction', () => {
+    const sql = readFileSync(migrationPath, 'utf-8');
+    expect(sql).toContain("UPDATE bookings");
+    expect(sql).toContain("SET status = 'confirmed'");
+    expect(sql).toContain("UPDATE payments");
+    expect(sql).toContain("SET status = 'succeeded'");
+  });
+
+  it('RPC function only confirms bookings with pending_payment status', () => {
+    const sql = readFileSync(migrationPath, 'utf-8');
+    expect(sql).toContain("AND status = 'pending_payment'");
+  });
+});

--- a/src/__tests__/payments/webhook-payments.test.ts
+++ b/src/__tests__/payments/webhook-payments.test.ts
@@ -3,11 +3,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
 const mockSupabaseFrom = vi.fn();
+const mockSupabaseRpc = vi.fn();
 const mockConstructEvent = vi.fn();
 
 vi.mock('@/lib/supabase/admin', () => ({
   createAdminClient: vi.fn(() => ({
     from: mockSupabaseFrom,
+    rpc: mockSupabaseRpc,
     auth: {
       admin: {
         getUserById: vi.fn().mockResolvedValue({ data: { user: { email: 'pro@test.com' } } }),
@@ -68,7 +70,7 @@ describe('stripe-deposit webhook: checkout.session.completed', () => {
     process.env.STRIPE_DEPOSIT_WEBHOOK_SECRET = 'whsec_test';
   });
 
-  it('confirma booking e atualiza payment', async () => {
+  it('confirma booking e atualiza payment atomicamente via RPC', async () => {
     const bookingId = '00000000-0000-4000-a000-000000000001';
 
     const sessionEvent = {
@@ -84,8 +86,12 @@ describe('stripe-deposit webhook: checkout.session.completed', () => {
 
     mockConstructEvent.mockReturnValue(sessionEvent);
 
-    const bookingUpdateChain = makeChain({ data: { id: bookingId }, error: null });
-    const paymentUpdateChain = makeChain({ data: {}, error: null });
+    // RPC succeeds
+    mockSupabaseRpc.mockResolvedValue({
+      data: { booking_updated: true, payment_updated: true },
+      error: null,
+    });
+
     const bookingSelectChain = makeChain({
       data: {
         id: bookingId,
@@ -106,18 +112,8 @@ describe('stripe-deposit webhook: checkout.session.completed', () => {
     mockSupabaseFrom.mockImplementation((table: string) => {
       if (table === 'bookings') {
         return {
-          update: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: {}, error: null }) }),
-          }),
           select: vi.fn().mockReturnValue({
             eq: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue(bookingSelectChain) }),
-          }),
-        };
-      }
-      if (table === 'payments') {
-        return {
-          update: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({ data: {}, error: null }),
           }),
         };
       }
@@ -138,6 +134,47 @@ describe('stripe-deposit webhook: checkout.session.completed', () => {
 
     expect(res.status).toBe(200);
     expect(json.received).toBe(true);
+
+    // Verify RPC was called with correct args
+    expect(mockSupabaseRpc).toHaveBeenCalledWith(
+      'confirm_booking_payment',
+      {
+        p_booking_id: bookingId,
+        p_checkout_session_id: 'cs_test_123',
+        p_payment_intent_id: 'pi_test_456',
+      },
+    );
+  });
+
+  it('returns 500 when RPC transaction fails (Stripe will retry)', async () => {
+    const bookingId = '00000000-0000-4000-a000-000000000002';
+
+    const sessionEvent = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_test_fail',
+          payment_intent: 'pi_test_fail',
+          metadata: { type: 'deposit', booking_id: bookingId },
+        },
+      },
+    };
+
+    mockConstructEvent.mockReturnValue(sessionEvent);
+
+    // RPC fails — simulates DB error
+    mockSupabaseRpc.mockResolvedValue({
+      data: null,
+      error: { message: 'connection timeout', code: 'PGRST301' },
+    });
+
+    const { POST } = await import('@/app/api/webhooks/stripe-deposit/route');
+    const req = makeRequest('{}', 'sig_test');
+    const res = await POST(req as any);
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe('Transaction failed');
   });
 
   it('rejeita assinatura inválida', async () => {

--- a/src/app/api/webhooks/stripe-deposit/route.ts
+++ b/src/app/api/webhooks/stripe-deposit/route.ts
@@ -109,21 +109,20 @@ export async function POST(request: NextRequest) {
       const bookingId = session.metadata.booking_id;
       if (!bookingId) break;
 
-      // Confirmar booking
-      await supabase
-        .from('bookings')
-        .update({ status: 'confirmed' })
-        .eq('id', bookingId)
-        .eq('status', 'pending_payment');
+      // Confirmar booking + atualizar payment atomicamente (transação DB)
+      const { error: rpcError } = await supabase.rpc(
+        'confirm_booking_payment' as never,
+        {
+          p_booking_id: bookingId,
+          p_checkout_session_id: session.id,
+          p_payment_intent_id: (session.payment_intent as string) || null,
+        } as never,
+      );
 
-      // Atualizar payment
-      await supabase
-        .from('payments')
-        .update({
-          status: 'succeeded',
-          stripe_payment_intent_id: session.payment_intent as string | null,
-        })
-        .eq('stripe_checkout_session_id', session.id);
+      if (rpcError) {
+        console.error('[Webhook] confirm_booking_payment RPC failed:', rpcError);
+        return NextResponse.json({ error: 'Transaction failed' }, { status: 500 });
+      }
 
       // Disparar notificações (fire-and-forget)
       void (async () => {

--- a/supabase/migrations/20260303000002_confirm_booking_payment_atomic.sql
+++ b/supabase/migrations/20260303000002_confirm_booking_payment_atomic.sql
@@ -1,0 +1,43 @@
+-- =====================================================
+-- Transação atômica: confirmar booking + atualizar payment
+-- Data: 2026-03-03
+-- Issue: #4
+-- Problema: Webhook Stripe faz 2 queries separadas sem transação.
+--   Se a segunda falha, booking fica confirmed sem payment succeeded.
+-- Solução: RPC function que faz ambos os updates numa transação.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION confirm_booking_payment(
+  p_booking_id uuid,
+  p_checkout_session_id text,
+  p_payment_intent_id text DEFAULT NULL
+)
+RETURNS jsonb AS $$
+DECLARE
+  v_booking_updated boolean;
+  v_payment_updated boolean;
+BEGIN
+  -- Update booking: pending_payment → confirmed
+  UPDATE bookings
+  SET status = 'confirmed', updated_at = now()
+  WHERE id = p_booking_id
+    AND status = 'pending_payment';
+
+  v_booking_updated := FOUND;
+
+  -- Update payment: pending → succeeded
+  UPDATE payments
+  SET status = 'succeeded',
+      stripe_payment_intent_id = COALESCE(p_payment_intent_id, stripe_payment_intent_id),
+      updated_at = now()
+  WHERE stripe_checkout_session_id = p_checkout_session_id;
+
+  v_payment_updated := FOUND;
+
+  -- Se nenhum dos dois atualizou, não é erro (idempotência — webhook retry)
+  RETURN jsonb_build_object(
+    'booking_updated', v_booking_updated,
+    'payment_updated', v_payment_updated
+  );
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Fixes #4

O webhook `checkout.session.completed` fazia 2 queries Supabase independentes para confirmar booking e atualizar payment. Se a segunda falhasse (timeout, cold start), o booking ficava `confirmed` com payment `pending` — estado inconsistente.

- Substituídas as 2 queries separadas por uma chamada `supabase.rpc('confirm_booking_payment')` que executa ambos UPDATEs numa transação atômica PL/pgSQL
- Webhook retorna 500 se a RPC falha, permitindo retry automático do Stripe
- Idempotência preservada (`AND status = 'pending_payment'` no booking)

## Arquivos alterados

| Arquivo | Mudança |
|---|---|
| `src/app/api/webhooks/stripe-deposit/route.ts` | 2 queries → 1 RPC atômica + return 500 on error |
| `supabase/migrations/20260303000002_confirm_booking_payment_atomic.sql` | Função PL/pgSQL `confirm_booking_payment` |
| `src/__tests__/payments/atomic-webhook.test.ts` | 6 testes de verificação estrutural (code + SQL) |
| `src/__tests__/payments/webhook-payments.test.ts` | Testes atualizados: RPC sucesso + RPC falha → 500 |

## Evidências

```
vitest run — 222 tests passed (19 files)
tsc --noEmit — 0 errors
ESLint — 0 new errors (259 pre-existing on main)
```

## Test plan

- [x] Unit test: RPC sucesso → booking confirmed + payment succeeded (200)
- [x] Unit test: RPC falha → webhook retorna 500 (Stripe retry)
- [x] Unit test: webhook não usa .from('bookings').update() nem .from('payments').update() no bloco checkout.session.completed
- [x] Unit test: migration contém UPDATE bookings + UPDATE payments na mesma função
- [x] Unit test: migration filtra `AND status = 'pending_payment'` (idempotência)
- [x] `npx vitest run` passando
- [x] `tsc --noEmit` passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)