### PR TITLE
fix(instagram): use professionals.id instead of auth user.id in callback

### DIFF
--- a/src/__tests__/integrations/instagram-callback.test.ts
+++ b/src/__tests__/integrations/instagram-callback.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const AUTH_USER_ID = 'auth-user-uuid-1234';
+const PROFESSIONAL_ID = 'prof-uuid-5678';
+
+const mockGetUser = vi.fn();
+const mockSingle = vi.fn();
+const mockUpsert = vi.fn();
+const mockSelect = vi.fn(() => ({
+  eq: vi.fn(() => ({
+    single: mockSingle,
+  })),
+}));
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'professionals') {
+    return { select: mockSelect };
+  }
+  if (table === 'integrations') {
+    return { upsert: mockUpsert };
+  }
+  return {};
+});
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+vi.mock('@/lib/integrations/instagram', () => ({
+  exchangeCodeForToken: vi.fn(async () => ({
+    accessToken: 'short-token',
+    userId: 'ig-user-123',
+  })),
+  getLongLivedToken: vi.fn(async () => ({
+    accessToken: 'long-lived-token',
+    expiresIn: 5184000,
+  })),
+  getUserProfile: vi.fn(async () => ({
+    username: 'testuser',
+    accountType: 'PERSONAL',
+    mediaCount: 42,
+  })),
+}));
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Instagram callback route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://test.example.com';
+    process.env.INSTAGRAM_CLIENT_ID = 'test-client-id';
+    process.env.INSTAGRAM_CLIENT_SECRET = 'test-client-secret';
+  });
+
+  it('uses professionals.id (not user.id) as professional_id in upsert', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: AUTH_USER_ID } },
+    });
+    mockSingle.mockResolvedValue({
+      data: { id: PROFESSIONAL_ID },
+      error: null,
+    });
+    mockUpsert.mockResolvedValue({ error: null });
+
+    const { GET } = await import(
+      '@/app/api/integrations/instagram/callback/route'
+    );
+
+    const request = new Request(
+      `https://test.example.com/api/integrations/instagram/callback?code=test-auth-code`
+    );
+    await GET(request as any);
+
+    // Verify upsert was called with professional.id, NOT auth user.id
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const upsertArg = mockUpsert.mock.calls[0][0];
+    expect(upsertArg.professional_id).toBe(PROFESSIONAL_ID);
+    expect(upsertArg.professional_id).not.toBe(AUTH_USER_ID);
+  });
+
+  it('redirects to onboarding if professional not found', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: AUTH_USER_ID } },
+    });
+    mockSingle.mockResolvedValue({
+      data: null,
+      error: { message: 'not found' },
+    });
+
+    const { GET } = await import(
+      '@/app/api/integrations/instagram/callback/route'
+    );
+
+    const request = new Request(
+      `https://test.example.com/api/integrations/instagram/callback?code=test-auth-code`
+    );
+    const response = await GET(request as any);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/onboarding');
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('redirects to login if user not authenticated', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+    });
+
+    const { GET } = await import(
+      '@/app/api/integrations/instagram/callback/route'
+    );
+
+    const request = new Request(
+      `https://test.example.com/api/integrations/instagram/callback?code=test-auth-code`
+    );
+    const response = await GET(request as any);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/login');
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/integrations/instagram/callback/route.ts
+++ b/src/app/api/integrations/instagram/callback/route.ts
@@ -12,6 +12,19 @@ export async function GET(request: NextRequest) {
     )
   }
 
+  // Buscar professional_id (consistente com Google Calendar callback)
+  const { data: professional } = await supabase
+    .from('professionals')
+    .select('id')
+    .eq('user_id', user.id)
+    .single()
+
+  if (!professional) {
+    return NextResponse.redirect(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/onboarding?redirect=/integrations`
+    )
+  }
+
   const { searchParams } = new URL(request.url)
   const code = searchParams.get('code')
   const error = searchParams.get('error')
@@ -55,7 +68,7 @@ export async function GET(request: NextRequest) {
     const { error: dbError } = await supabase
       .from('integrations')
       .upsert({
-        professional_id: user.id,
+        professional_id: professional.id,
         type: 'instagram',
         access_token: longToken,
         refresh_token: null,

--- a/supabase/migrations/20260303000004_fix_instagram_professional_id.sql
+++ b/supabase/migrations/20260303000004_fix_instagram_professional_id.sql
@@ -1,0 +1,8 @@
+-- Fix existing instagram integrations where professional_id = auth.users.id
+-- instead of professionals.id
+UPDATE integrations i
+SET professional_id = p.id
+FROM professionals p
+WHERE i.type = 'instagram'
+  AND i.professional_id = p.user_id
+  AND i.professional_id != p.id;


### PR DESCRIPTION
## Summary

Fixes #10 — [R1] CRITICAL: Instagram callback usa user.id em vez de professional.id

- **Bug**: `src/app/api/integrations/instagram/callback/route.ts:58` stored `user.id` (from `auth.users`) as `professional_id` in the `integrations` table, instead of looking up `professionals.id`
- **Impact**: Instagram integrations were orphaned — queries filtering `integrations.professional_id = professionals.id` returned empty
- **Fix**: Added professional lookup via `user_id` before upsert (consistent with Google Calendar callback pattern)
- **Data migration**: `20260303000004_fix_instagram_professional_id.sql` corrects existing rows

## Changes

| File | Change |
|---|---|
| `src/app/api/integrations/instagram/callback/route.ts` | Lookup `professionals.id` via `user_id` before upsert; redirect to onboarding if not found |
| `supabase/migrations/20260303000004_fix_instagram_professional_id.sql` | Fix existing rows where `professional_id = auth.users.id` |
| `src/__tests__/integrations/instagram-callback.test.ts` | 3 unit tests: correct ID, onboarding redirect, auth redirect |

## Evidência

```
vitest run src/__tests__/integrations/
 ✓ src/__tests__/integrations/instagram-callback.test.ts (3 tests) 56ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Full suite (excluding issue #9 tests not on this branch):
```
 Test Files  18 passed (18)
      Tests  213 passed (213)
```

## Test plan

- [x] Unit test: mock callback → verify `integrations.professional_id === professionals.id`
- [x] Unit test: professional not found → redirect to onboarding
- [x] Unit test: unauthenticated → redirect to login
- [x] Data migration for existing rows
- [x] Consistent with Google Calendar callback pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)