### PR TITLE
fix(email-campaigns): use professionals.id instead of auth user.id

### DIFF
--- a/src/__tests__/email-campaigns/email-campaigns-route.test.ts
+++ b/src/__tests__/email-campaigns/email-campaigns-route.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const AUTH_USER_ID = 'auth-user-uuid-1234';
+const PROFESSIONAL_ID = 'prof-uuid-5678';
+
+const mockGetUser = vi.fn();
+const mockRpc = vi.fn();
+const mockSingle = vi.fn();
+const mockSelectChain = vi.fn();
+const mockInsertSelect = vi.fn(() => ({ single: vi.fn(() => ({ data: { id: 'campaign-1' }, error: null })) }));
+const mockInsert = vi.fn(() => ({ select: mockInsertSelect }));
+const mockOrder = vi.fn(() => ({ eq: vi.fn(() => ({ data: [], error: null })), data: [], error: null }));
+const mockEq = vi.fn();
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'professionals') {
+    return {
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: mockSingle,
+        })),
+      })),
+    };
+  }
+  if (table === 'email_campaigns') {
+    return {
+      select: vi.fn(() => ({
+        eq: mockEq.mockReturnValue({
+          order: mockOrder,
+        }),
+      })),
+      insert: mockInsert,
+    };
+  }
+  return {};
+});
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+    rpc: mockRpc,
+  })),
+}));
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('email-campaigns route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: AUTH_USER_ID } } });
+    mockSingle.mockResolvedValue({ data: { id: PROFESSIONAL_ID }, error: null });
+    mockRpc.mockResolvedValue({ data: [], error: null });
+  });
+
+  describe('GET', () => {
+    it('uses professionals.id (not user.id) to filter campaigns', async () => {
+      const { GET } = await import('@/app/api/email-campaigns/route');
+      const request = new Request('https://test.example.com/api/email-campaigns');
+      await GET(request as any);
+
+      // Verify eq was called with professional.id
+      expect(mockEq).toHaveBeenCalledWith('professional_id', PROFESSIONAL_ID);
+      expect(mockEq).not.toHaveBeenCalledWith('professional_id', AUTH_USER_ID);
+    });
+
+    it('returns 404 if professional not found', async () => {
+      mockSingle.mockResolvedValue({ data: null, error: { message: 'not found' } });
+
+      const { GET } = await import('@/app/api/email-campaigns/route');
+      const request = new Request('https://test.example.com/api/email-campaigns');
+      const response = await GET(request as any);
+
+      expect(response.status).toBe(404);
+    });
+
+    it('returns 401 if not authenticated', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+
+      const { GET } = await import('@/app/api/email-campaigns/route');
+      const request = new Request('https://test.example.com/api/email-campaigns');
+      const response = await GET(request as any);
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('POST', () => {
+    const validBody = {
+      name: 'Test Campaign',
+      subject: 'Hello',
+      fromName: 'Test',
+      fromEmail: 'test@example.com',
+      htmlContent: '<p>Hello</p>',
+    };
+
+    it('uses professionals.id (not user.id) in insert and RPC', async () => {
+      const { POST } = await import('@/app/api/email-campaigns/route');
+      const request = new Request('https://test.example.com/api/email-campaigns', {
+        method: 'POST',
+        body: JSON.stringify(validBody),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      await POST(request as any);
+
+      // Verify RPC uses professional.id
+      expect(mockRpc).toHaveBeenCalledWith('get_contacts_by_segment', expect.objectContaining({
+        p_professional_id: PROFESSIONAL_ID,
+      }));
+
+      // Verify insert uses professional.id
+      expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({
+        professional_id: PROFESSIONAL_ID,
+      }));
+      expect(mockInsert).not.toHaveBeenCalledWith(expect.objectContaining({
+        professional_id: AUTH_USER_ID,
+      }));
+    });
+
+    it('returns 404 if professional not found', async () => {
+      mockSingle.mockResolvedValue({ data: null, error: { message: 'not found' } });
+
+      const { POST } = await import('@/app/api/email-campaigns/route');
+      const request = new Request('https://test.example.com/api/email-campaigns', {
+        method: 'POST',
+        body: JSON.stringify(validBody),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const response = await POST(request as any);
+
+      expect(response.status).toBe(404);
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/email-campaigns/route.ts
+++ b/src/app/api/email-campaigns/route.ts
@@ -10,13 +10,23 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const { data: professional } = await supabase
+    .from('professionals')
+    .select('id')
+    .eq('user_id', user.id)
+    .single()
+
+  if (!professional) {
+    return NextResponse.json({ error: 'Professional not found' }, { status: 404 })
+  }
+
   const { searchParams } = new URL(request.url)
   const status = searchParams.get('status')
 
   let query = supabase
     .from('email_campaigns')
     .select('*')
-    .eq('professional_id', user.id)
+    .eq('professional_id', professional.id)
     .order('created_at', { ascending: false })
 
   if (status && status !== 'all') {
@@ -40,6 +50,16 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: professional } = await supabase
+    .from('professionals')
+    .select('id')
+    .eq('user_id', user.id)
+    .single()
+
+  if (!professional) {
+    return NextResponse.json({ error: 'Professional not found' }, { status: 404 })
   }
 
   const body = await request.json()
@@ -78,7 +98,7 @@ export async function POST(request: NextRequest) {
   const { data: contactsCount } = await supabase.rpc(
     'get_contacts_by_segment',
     {
-      p_professional_id: user.id,
+      p_professional_id: professional.id,
       p_segment: targetSegment || 'all',
       p_custom_filters: customFilters || {}
     }
@@ -90,7 +110,7 @@ export async function POST(request: NextRequest) {
   const { data: campaign, error } = await supabase
     .from('email_campaigns')
     .insert({
-      professional_id: user.id,
+      professional_id: professional.id,
       name,
       subject,
       from_name: fromName,

--- a/supabase/migrations/20260303000005_fix_email_campaigns_professional_id.sql
+++ b/supabase/migrations/20260303000005_fix_email_campaigns_professional_id.sql
@@ -1,0 +1,7 @@
+-- Fix existing email_campaigns where professional_id = auth.users.id
+-- instead of professionals.id
+UPDATE email_campaigns ec
+SET professional_id = p.id
+FROM professionals p
+WHERE ec.professional_id = p.user_id
+  AND ec.professional_id != p.id;


### PR DESCRIPTION
## Summary

Fixes #11 — [R2] CRITICAL: Email campaigns filtra por user.id em vez de professional.id

**Bug**: `src/app/api/email-campaigns/route.ts` used `user.id` (from `auth.users`) as `professional_id` in 3 places:
- Line 19 (GET): `.eq('professional_id', user.id)`
- Line 81 (RPC): `p_professional_id: user.id`
- Line 93 (POST insert): `professional_id: user.id`

**Impact**: Campaigns created with wrong ID, GET returns empty, data orphaned.

## Changes

| File | Change |
|---|---|
| `src/app/api/email-campaigns/route.ts` | Add professional lookup in GET + POST; use `professional.id` in all 3 places |
| `supabase/migrations/20260303000005_fix_email_campaigns_professional_id.sql` | Fix existing rows |
| `src/__tests__/email-campaigns/email-campaigns-route.test.ts` | 5 unit tests |

## Evidência

```
vitest run src/__tests__/email-campaigns/
 ✓ src/__tests__/email-campaigns/email-campaigns-route.test.ts (5 tests) 62ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Full suite (excluding unrelated issue #9 tests not on this branch):
```
 Test Files  19 passed (19)
      Tests  220 passed (220)
```

## Test plan

- [x] GET uses `professionals.id` to filter campaigns
- [x] POST uses `professionals.id` in insert and RPC call
- [x] GET returns 404 if professional not found
- [x] POST returns 404 if professional not found
- [x] Returns 401 if not authenticated
- [x] Data migration for existing rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)