### PR TITLE
fix(e2e): skip bot tests in security suite when Anthropic API is off

### DIFF
--- a/e2e/security/04-tenant-isolation.spec.ts
+++ b/e2e/security/04-tenant-isolation.spec.ts
@@ -93,7 +93,8 @@ test.describe('Isolamento Multi-tenant', () => {
   });
 
   // ── 1: Bot de A não cancela agendamento de B ─────────────────────────────
-  test('bot de A não afeta booking de B com mesmo phone', async ({ request }) => {
+  test('bot de A não afeta booking de B com mesmo phone @bot', async ({ request }) => {
+    test.skip(!process.env.ANTHROPIC_API_KEY, 'Requer ANTHROPIC_API_KEY (bot test)');
     test.setTimeout(90_000);
 
     const monday = nextWeekday(1);
@@ -133,7 +134,8 @@ test.describe('Isolamento Multi-tenant', () => {
   });
 
   // ── 2: Bot de A não lista agendamentos de B ──────────────────────────────
-  test('get_my_appointments de A não retorna dados de B', async ({ request }) => {
+  test('get_my_appointments de A não retorna dados de B @bot', async ({ request }) => {
+    test.skip(!process.env.ANTHROPIC_API_KEY, 'Requer ANTHROPIC_API_KEY (bot test)');
     test.setTimeout(90_000);
 
     const thursday = nextWeekday(4);


### PR DESCRIPTION
## Summary
- Tests 1-2 in `04-tenant-isolation.spec.ts` call `sendBotMessage()` which triggers the Anthropic API via the WhatsApp webhook → Claude chatbot
- Unlike the dedicated bot jobs (`bot-e2e`, `bot-reschedule`, etc.), these run in the `security-e2e` job which has **no `BOT_E2E_ENABLED` guard**
- Add `test.skip(!process.env.ANTHROPIC_API_KEY)` and `@bot` tag so they are skipped when the API key is absent

## Test plan
- [ ] CI `security-e2e` job passes with tests 1-2 skipped
- [ ] No Anthropic API calls when `BOT_E2E_ENABLED` is OFF

🤖 Generated with [Claude Code](https://claude.com/claude-code)