### PR TITLE
fix(checkout): validate deposit amount before charging Stripe

### DIFF
--- a/src/__tests__/payments/checkout-amount-validation.test.ts
+++ b/src/__tests__/payments/checkout-amount-validation.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockCalculateDeposit = vi.fn();
+const mockStripeCreate = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/stripe/server', () => ({
+  getStripeServer: vi.fn(() => ({
+    checkout: { sessions: { create: mockStripeCreate } },
+  })),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock('@/lib/payment/calculate-deposit', () => ({
+  calculateDeposit: (...args: unknown[]) => mockCalculateDeposit(...args),
+  toCents: vi.fn((v: number) => v * 100),
+}));
+
+vi.mock('@/lib/validation/booking-schema', () => ({
+  bookingSchema: {
+    safeParse: vi.fn((data: Record<string, unknown>) => ({
+      success: true,
+      data: {
+        professional_id: data.professional_id ?? 'prof-1',
+        service_id: data.service_id ?? 'svc-1',
+        booking_date: '2026-04-01',
+        start_time: '10:00',
+        client_name: 'Test Client',
+        client_phone: '+353800000000',
+      },
+    })),
+  },
+  sanitizeString: vi.fn((s: string) => s),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeChain(returnValue: unknown = { data: null, error: null }) {
+  const chain: Record<string, unknown> = {};
+  const methods = ['select', 'eq', 'in', 'lt', 'gt', 'update', 'insert', 'single', 'maybeSingle', 'order'];
+  methods.forEach((m) => {
+    chain[m] = vi.fn(() => chain);
+  });
+  (chain as any).then = (resolve: (v: unknown) => void) =>
+    Promise.resolve(returnValue).then(resolve);
+  return chain;
+}
+
+const PROF = {
+  subscription_status: 'active',
+  trial_ends_at: '2099-01-01',
+  stripe_account_id: 'acct_test',
+  currency: 'eur',
+  require_deposit: true,
+  deposit_type: 'percentage',
+  deposit_value: 30,
+};
+
+const SERVICE = { duration_minutes: 60, name: 'Corte', price: 100 };
+const BOOKING = { id: 'booking-uuid-1' };
+
+function setupMocks() {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'professionals') return makeChain({ data: PROF, error: null });
+    if (table === 'services') return makeChain({ data: SERVICE, error: null });
+    if (table === 'bookings') {
+      const chain = makeChain({ data: [], error: null });
+      chain.insert = vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(() => Promise.resolve({ data: BOOKING, error: null })),
+        })),
+      }));
+      chain.update = vi.fn(() => ({
+        eq: vi.fn(() => Promise.resolve({ error: null })),
+      }));
+      return chain;
+    }
+    if (table === 'payments') return { insert: vi.fn(() => Promise.resolve({ error: null })) };
+    return makeChain();
+  });
+}
+
+function makeRequest() {
+  return new Request('https://test.example.com/api/bookings/checkout', {
+    method: 'POST',
+    body: JSON.stringify({
+      professional_id: 'prof-1',
+      service_id: 'svc-1',
+      booking_date: '2026-04-01',
+      start_time: '10:00',
+      client_name: 'Test Client',
+      client_phone: '+353800000000',
+    }),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('checkout amount validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://test.example.com';
+    setupMocks();
+  });
+
+  it('rejects deposit amount = 0', async () => {
+    mockCalculateDeposit.mockReturnValue(0);
+
+    const { POST } = await import('@/app/api/bookings/checkout/route');
+    const response = await POST(makeRequest() as any);
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toContain('maior que zero');
+  });
+
+  it('rejects negative deposit amount', async () => {
+    mockCalculateDeposit.mockReturnValue(-5);
+
+    const { POST } = await import('@/app/api/bookings/checkout/route');
+    const response = await POST(makeRequest() as any);
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toContain('maior que zero');
+  });
+
+  it('rejects deposit amount exceeding service price', async () => {
+    mockCalculateDeposit.mockReturnValue(150); // service.price = 100
+
+    const { POST } = await import('@/app/api/bookings/checkout/route');
+    const response = await POST(makeRequest() as any);
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toContain('exceder');
+  });
+
+  it('allows valid deposit amount', async () => {
+    mockCalculateDeposit.mockReturnValue(30);
+    mockStripeCreate.mockResolvedValue({
+      id: 'cs_test',
+      url: 'https://checkout.stripe.com/test',
+      payment_intent: 'pi_test',
+    });
+
+    const { POST } = await import('@/app/api/bookings/checkout/route');
+    const response = await POST(makeRequest() as any);
+
+    expect(response.status).toBe(200);
+  });
+
+  it('allows deposit equal to service price', async () => {
+    mockCalculateDeposit.mockReturnValue(100); // exactly service.price
+
+    mockStripeCreate.mockResolvedValue({
+      id: 'cs_test',
+      url: 'https://checkout.stripe.com/test',
+      payment_intent: 'pi_test',
+    });
+
+    const { POST } = await import('@/app/api/bookings/checkout/route');
+    const response = await POST(makeRequest() as any);
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/app/api/bookings/checkout/route.ts
+++ b/src/app/api/bookings/checkout/route.ts
@@ -177,6 +177,17 @@ export async function POST(request: NextRequest) {
     prof.deposit_type as 'percentage' | 'fixed',
     prof.deposit_value as number
   );
+
+  if (depositAmount <= 0) {
+    await supabase.from('bookings').update({ status: 'cancelled' }).eq('id', booking.id);
+    return NextResponse.json({ error: 'Valor do sinal deve ser maior que zero.' }, { status: 400 });
+  }
+
+  if (depositAmount > service.price) {
+    await supabase.from('bookings').update({ status: 'cancelled' }).eq('id', booking.id);
+    return NextResponse.json({ error: 'Valor do sinal não pode exceder o preço do serviço.' }, { status: 400 });
+  }
+
   const depositCents = toCents(depositAmount);
   const applicationFeeCents = Math.round(depositCents * 0.05);
 


### PR DESCRIPTION
## Summary

Fixes #33 — [PAYMENTS][CRITICAL] Sem validação de amount antes de cobrar no Stripe

**Bug**: `checkout/route.ts` passed `depositAmount` directly to Stripe without validation:
- `depositAmount = 0` → Stripe API error (amount must be > 0)
- `depositAmount > service.price` → customer overcharged
- Negative values could pass through

**Fix**: Bounds check after `calculateDeposit()`, before Stripe session creation. Invalid amounts roll back the booking.

## Changes

| File | Change |
|---|---|
| `src/app/api/bookings/checkout/route.ts` | Add `<= 0` and `> service.price` checks with booking rollback |
| `src/__tests__/payments/checkout-amount-validation.test.ts` | 5 tests |

## Evidência

```
vitest run src/__tests__/payments/checkout-amount-validation.test.ts
 ✓ (5 tests) 72ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Full suite:
```
 Test Files  19 passed (19)
      Tests  220 passed (220)
```

## Test plan

- [x] amount = 0 → 400
- [x] amount < 0 → 400
- [x] amount > service price → 400
- [x] valid amount (30) → 200
- [x] amount == service price → 200 (full prepayment allowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)