### PR TITLE
fix(cron): only mark reminder_sent=true after confirmed delivery

### DIFF
--- a/src/__tests__/cron/send-reminders.test.ts
+++ b/src/__tests__/cron/send-reminders.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockUpdate = vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) }));
+const mockInsert = vi.fn(() => Promise.resolve({ error: null }));
+const mockFrom = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const PROF_ID = 'prof-1';
+const USER_ID = 'user-1';
+
+const tomorrow = new Date();
+tomorrow.setDate(tomorrow.getDate() + 1);
+const tomorrowStr = tomorrow.toISOString().split('T')[0];
+
+function makeBooking(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'booking-1',
+    booking_date: tomorrowStr,
+    start_time: '10:00:00',
+    client_name: 'Test Client',
+    client_phone: '+353800000001',
+    client_email: null,
+    status: 'confirmed',
+    professional_id: PROF_ID,
+    service_id: 'svc-1',
+    services: { name: 'Corte', price: 50 },
+    professionals: { business_name: 'Salão', slug: 'salao', city: 'Dublin', address: 'Rua 1' },
+    ...overrides,
+  };
+}
+
+function setupMocks(bookings: unknown[] = [makeBooking()]) {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'bookings') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(function () { return this; }),
+          ...(function () {
+            const chain: Record<string, any> = {};
+            chain.eq = vi.fn(() => chain);
+            (chain as any).then = (resolve: (v: unknown) => void) =>
+              Promise.resolve({ data: bookings, error: null }).then(resolve);
+            return chain;
+          })(),
+        })),
+        update: mockUpdate,
+      };
+    }
+    if (table === 'professionals') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn(() =>
+            Promise.resolve({ data: [{ id: PROF_ID, user_id: USER_ID }], error: null })
+          ),
+        })),
+      };
+    }
+    if (table === 'whatsapp_config') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn(() => ({
+            eq: vi.fn(() =>
+              Promise.resolve({
+                data: [{
+                  user_id: USER_ID,
+                  provider: 'evolution',
+                  evolution_api_url: 'https://evo.test.com',
+                  evolution_api_key: 'key',
+                  evolution_instance: 'inst',
+                  is_active: true,
+                }],
+                error: null,
+              })
+            ),
+          })),
+        })),
+      };
+    }
+    if (table === 'reschedule_tokens') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+          })),
+        })),
+      };
+    }
+    // cron_logs, notification_logs
+    return { insert: mockInsert };
+  });
+}
+
+function makeRequest() {
+  return new Request('https://test.example.com/api/cron/send-reminders', {
+    method: 'POST',
+    headers: { authorization: 'Bearer test-cron-secret' },
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('send-reminders cron', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.CRON_SECRET = 'test-cron-secret';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+  });
+
+  it('marks reminder_sent=true ONLY when Evolution API returns 200', async () => {
+    setupMocks();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('OK', { status: 200 })
+    );
+
+    const { POST } = await import('@/app/api/cron/send-reminders/route');
+    const response = await POST(makeRequest() as any);
+    const json = await response.json();
+
+    expect(json.success).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledWith({
+      reminder_sent: true,
+      reminder_sent_at: expect.any(String),
+    });
+
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT mark reminder_sent=true when Evolution API returns 500', async () => {
+    setupMocks();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Internal Server Error', { status: 500 })
+    );
+
+    const { POST } = await import('@/app/api/cron/send-reminders/route');
+    const response = await POST(makeRequest() as any);
+    const json = await response.json();
+
+    expect(json.success).toBe(true);
+    // reminder_sent should NOT have been updated
+    expect(mockUpdate).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT mark reminder_sent=true when fetch throws (network error)', async () => {
+    setupMocks();
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+      new Error('Network timeout')
+    );
+
+    const { POST } = await import('@/app/api/cron/send-reminders/route');
+    const response = await POST(makeRequest() as any);
+    const json = await response.json();
+
+    expect(json.success).toBe(true);
+    expect(mockUpdate).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('logs failed status in notification_logs when send fails', async () => {
+    setupMocks();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Error', { status: 503 })
+    );
+
+    const { POST } = await import('@/app/api/cron/send-reminders/route');
+    await POST(makeRequest() as any);
+
+    // notification_logs insert should have status 'failed'
+    const notifCalls = mockInsert.mock.calls.filter(
+      (call) => call[0]?.type === 'reminder' && call[0]?.status === 'failed'
+    );
+    expect(notifCalls.length).toBe(1);
+
+    vi.restoreAllMocks();
+  });
+});

--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -233,14 +233,16 @@ export async function POST(request: NextRequest) {
           }
         }
 
-        // Marcar lembrete como enviado
-        await supabase
-          .from('bookings')
-          .update({
-            reminder_sent: true,
-            reminder_sent_at: new Date().toISOString(),
-          })
-          .eq('id', booking.id);
+        // Marcar lembrete como enviado — SOMENTE se envio confirmado
+        if (sent) {
+          await supabase
+            .from('bookings')
+            .update({
+              reminder_sent: true,
+              reminder_sent_at: new Date().toISOString(),
+            })
+            .eq('id', booking.id);
+        }
 
         // Registrar log
         await supabase.from('notification_logs').insert({


### PR DESCRIPTION
## Summary
- `reminder_sent=true` was set unconditionally in send-reminders cron, even when Evolution API returned 500 or fetch threw
- Now only marks `reminder_sent=true` when `sent === true` (API confirmed delivery)
- Failed reminders will be retried on the next cron run

## Changes
- `src/app/api/cron/send-reminders/route.ts` — wrap update in `if (sent)` guard
- `src/__tests__/cron/send-reminders.test.ts` — 4 tests covering success, API 500, network error, and failed log

## Test plan
- [x] API 200 → `reminder_sent=true` updated
- [x] API 500 → `reminder_sent` NOT updated (remains false for retry)
- [x] Network error → `reminder_sent` NOT updated
- [x] Failed sends logged as `status: 'failed'` in notification_logs

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)