### PR TITLE
fix(security): drop public RLS policies on reschedule_tokens

### DIFF
--- a/src/__tests__/security/reschedule-tokens-rls.test.ts
+++ b/src/__tests__/security/reschedule-tokens-rls.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('reschedule_tokens RLS security', () => {
+  const migrationDir = path.resolve('supabase/migrations');
+
+  it('public USING(true) policy is dropped by fix migration', () => {
+    const fixMigration = fs.readFileSync(
+      path.join(migrationDir, '20260303000006_fix_reschedule_tokens_rls.sql'),
+      'utf-8'
+    );
+
+    expect(fixMigration).toContain('DROP POLICY IF EXISTS "Acesso público via token"');
+    expect(fixMigration).toContain('DROP POLICY IF EXISTS "Sistema pode criar tokens"');
+    expect(fixMigration).toContain('DROP POLICY IF EXISTS "Sistema pode atualizar tokens"');
+  });
+
+  it('reschedule route uses createAdminClient (not anon createClient)', () => {
+    const routeSource = fs.readFileSync(
+      path.resolve('src/app/api/reschedule/[token]/route.ts'),
+      'utf-8'
+    );
+
+    expect(routeSource).toContain("createAdminClient");
+    expect(routeSource).not.toMatch(/from '@\/lib\/supabase\/server'/);
+  });
+
+  it('reschedule change route uses createAdminClient (not anon createClient)', () => {
+    const changeSource = fs.readFileSync(
+      path.resolve('src/app/api/reschedule/[token]/change/route.ts'),
+      'utf-8'
+    );
+
+    expect(changeSource).toContain("createAdminClient");
+    expect(changeSource).not.toMatch(/from '@\/lib\/supabase\/server'/);
+  });
+
+  it('reschedule cancel route already uses createAdminClient', () => {
+    const cancelSource = fs.readFileSync(
+      path.resolve('src/app/api/reschedule/[token]/cancel/route.ts'),
+      'utf-8'
+    );
+
+    expect(cancelSource).toContain("createAdminClient");
+  });
+});

--- a/src/app/api/reschedule/[token]/change/route.ts
+++ b/src/app/api/reschedule/[token]/change/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(
@@ -9,7 +9,7 @@ export async function POST(
   const body = await request.json();
   const { new_date, new_time } = body;
 
-  const supabase = await createClient();
+  const supabase = createAdminClient();
 
   try {
     // Validar token

--- a/src/app/api/reschedule/[token]/route.ts
+++ b/src/app/api/reschedule/[token]/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
@@ -6,7 +6,7 @@ export async function GET(
   { params }: { params: Promise<{ token: string }> }
 ) {
   const { token } = await params;
-  const supabase = await createClient();
+  const supabase = createAdminClient();
 
   try {
     // Buscar token

--- a/supabase/migrations/20260303000006_fix_reschedule_tokens_rls.sql
+++ b/supabase/migrations/20260303000006_fix_reschedule_tokens_rls.sql
@@ -1,0 +1,10 @@
+-- Fix: reschedule_tokens had USING(true) policies allowing any anon user
+-- to list all tokens. Drop public policies since all access is now via
+-- service role (createAdminClient) in API routes.
+
+DROP POLICY IF EXISTS "Acesso público via token" ON reschedule_tokens;
+DROP POLICY IF EXISTS "Sistema pode criar tokens" ON reschedule_tokens;
+DROP POLICY IF EXISTS "Sistema pode atualizar tokens" ON reschedule_tokens;
+
+-- Service role bypasses RLS, so no replacement policies needed.
+-- RLS remains enabled to block anon/authenticated key access.


### PR DESCRIPTION
## Summary
- `reschedule_tokens` had `USING(true)` RLS policies allowing any anon user to list all tokens
- Attacker could enumerate tokens and reschedule other clients' bookings
- Migrated `reschedule/[token]/route.ts` and `change/route.ts` from `createClient` (anon) to `createAdminClient` (service role)
- Dropped all 3 public policies (SELECT, INSERT, UPDATE) via migration
- RLS stays enabled — anon/authenticated keys now get 0 rows

## Changes
- `src/app/api/reschedule/[token]/route.ts` — `createAdminClient`
- `src/app/api/reschedule/[token]/change/route.ts` — `createAdminClient`
- `supabase/migrations/20260303000006_fix_reschedule_tokens_rls.sql` — DROP 3 policies
- `src/__tests__/security/reschedule-tokens-rls.test.ts` — 4 tests

## Test plan
- [x] Fix migration drops all 3 public policies
- [x] GET route uses `createAdminClient` (not anon)
- [x] Change route uses `createAdminClient` (not anon)
- [x] Cancel route already uses `createAdminClient`

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)