### PR TITLE
fix(auth): ensure complete session invalidation on signout

### DIFF
--- a/src/__tests__/auth/signout.test.ts
+++ b/src/__tests__/auth/signout.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockSignOut = vi.fn();
+const deletedCookies: Array<{ name: string; path?: string }> = [];
+
+const mockCookies = {
+  getAll: vi.fn(() => [
+    { name: 'sb-ibkkxykcrwhncvqxzynt-auth-token.0', value: 'chunk0' },
+    { name: 'sb-ibkkxykcrwhncvqxzynt-auth-token.1', value: 'chunk1' },
+    { name: 'sb-ibkkxykcrwhncvqxzynt-auth-token', value: 'main' },
+    { name: 'other-cookie', value: 'keep' },
+  ]),
+  delete: vi.fn((arg: string | { name: string; path?: string }) => {
+    if (typeof arg === 'string') {
+      deletedCookies.push({ name: arg });
+    } else {
+      deletedCookies.push(arg);
+    }
+  }),
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { signOut: mockSignOut },
+  })),
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => mockCookies),
+}));
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('signout route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deletedCookies.length = 0;
+    mockSignOut.mockResolvedValue({ error: null });
+    mockCookies.getAll.mockReturnValue([
+      { name: 'sb-ibkkxykcrwhncvqxzynt-auth-token.0', value: 'chunk0' },
+      { name: 'sb-ibkkxykcrwhncvqxzynt-auth-token.1', value: 'chunk1' },
+      { name: 'sb-ibkkxykcrwhncvqxzynt-auth-token', value: 'main' },
+      { name: 'other-cookie', value: 'keep' },
+    ]);
+    mockCookies.delete.mockImplementation((arg: string | { name: string; path?: string }) => {
+      if (typeof arg === 'string') {
+        deletedCookies.push({ name: arg });
+      } else {
+        deletedCookies.push(arg);
+      }
+    });
+  });
+
+  it('calls signOut with scope local BEFORE deleting cookies', async () => {
+    const callOrder: string[] = [];
+    mockSignOut.mockImplementation(async () => {
+      callOrder.push('signOut');
+      return { error: null };
+    });
+    mockCookies.delete.mockImplementation(() => {
+      callOrder.push('delete');
+    });
+
+    const { POST } = await import('@/app/api/auth/signout/route');
+    const request = new Request('https://test.example.com/api/auth/signout', {
+      method: 'POST',
+    });
+    await POST(request);
+
+    expect(mockSignOut).toHaveBeenCalledWith({ scope: 'local' });
+    expect(callOrder[0]).toBe('signOut');
+    expect(callOrder.filter(c => c === 'delete').length).toBeGreaterThan(0);
+  });
+
+  it('deletes only Supabase cookies (sb-* prefix), not others', async () => {
+    const { POST } = await import('@/app/api/auth/signout/route');
+    const request = new Request('https://test.example.com/api/auth/signout', {
+      method: 'POST',
+    });
+    await POST(request);
+
+    const deletedNames = deletedCookies.map(c => c.name);
+    expect(deletedNames).toContain('sb-ibkkxykcrwhncvqxzynt-auth-token.0');
+    expect(deletedNames).toContain('sb-ibkkxykcrwhncvqxzynt-auth-token.1');
+    expect(deletedNames).toContain('sb-ibkkxykcrwhncvqxzynt-auth-token');
+    expect(deletedNames).not.toContain('other-cookie');
+  });
+
+  it('deletes cookies with path=/ to ensure removal', async () => {
+    const { POST } = await import('@/app/api/auth/signout/route');
+    const request = new Request('https://test.example.com/api/auth/signout', {
+      method: 'POST',
+    });
+    await POST(request);
+
+    for (const deleted of deletedCookies) {
+      expect(deleted.path).toBe('/');
+    }
+  });
+
+  it('redirects to /login with 303 status', async () => {
+    const { POST } = await import('@/app/api/auth/signout/route');
+    const request = new Request('https://test.example.com/api/auth/signout', {
+      method: 'POST',
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toContain('/login');
+  });
+
+  it('still clears cookies even if signOut fails', async () => {
+    mockSignOut.mockResolvedValue({ error: { message: 'session_not_found' } });
+
+    const { POST } = await import('@/app/api/auth/signout/route');
+    const request = new Request('https://test.example.com/api/auth/signout', {
+      method: 'POST',
+    });
+    await POST(request);
+
+    expect(deletedCookies.length).toBe(3); // 3 sb-* cookies
+  });
+});

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -3,14 +3,23 @@ import { createClient } from '@/lib/supabase/server';
 import { cookies } from 'next/headers';
 
 export async function POST(request: Request) {
+  // 1. Invalidate session server-side FIRST (while cookies still exist)
   const supabase = await createClient();
-  await supabase.auth.signOut();
+  await supabase.auth.signOut({ scope: 'local' });
 
-  // Clear all cookies
+  // 2. Explicitly clear Supabase auth cookies with correct path
+  //    Supabase SSR uses chunked cookies: sb-<ref>-auth-token, .0, .1, etc.
   const cookieStore = await cookies();
-  cookieStore.getAll().forEach(cookie => {
-    cookieStore.delete(cookie.name);
-  });
+  const allCookies = cookieStore.getAll();
+
+  for (const cookie of allCookies) {
+    if (
+      cookie.name.startsWith('sb-') ||
+      cookie.name.includes('supabase')
+    ) {
+      cookieStore.delete({ name: cookie.name, path: '/' });
+    }
+  }
 
   const url = new URL('/login', request.url);
   // Use 303 to force GET method on redirect (prevents 405 on /login)


### PR DESCRIPTION
## Summary
- Signout deleted all cookies generically, missing HttpOnly Supabase SSR cookies with specific path
- Now calls `signOut({ scope: 'local' })` first, then explicitly deletes only `sb-*` cookies with `path: '/'`
- Non-Supabase cookies preserved, chunked cookies (`.0`, `.1`) properly handled

## Changes
- `src/app/api/auth/signout/route.ts` — targeted cookie deletion with path
- `src/__tests__/auth/signout.test.ts` — 5 tests

## Test plan
- [x] signOut called BEFORE cookie deletion (order matters)
- [x] Only sb-* cookies deleted, others preserved
- [x] Cookies deleted with `path: '/'` for correct removal
- [x] Redirects to /login with 303
- [x] Cookies cleared even if signOut fails

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)