### PR TITLE
fix(db): add NOT NULL constraint to bookings.service_id

### DIFF
--- a/src/__tests__/migrations/bookings-service-id-not-null.test.ts
+++ b/src/__tests__/migrations/bookings-service-id-not-null.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('bookings.service_id NOT NULL constraint', () => {
+  const migrationDir = path.resolve('supabase/migrations');
+
+  it('migration adds NOT NULL constraint to service_id', () => {
+    const sql = fs.readFileSync(
+      path.join(migrationDir, '20260303000007_bookings_service_id_not_null.sql'),
+      'utf-8'
+    );
+
+    expect(sql).toContain('ALTER TABLE bookings ALTER COLUMN service_id SET NOT NULL');
+  });
+
+  it('migration cleans up NULL service_id rows before adding constraint', () => {
+    const sql = fs.readFileSync(
+      path.join(migrationDir, '20260303000007_bookings_service_id_not_null.sql'),
+      'utf-8'
+    );
+
+    // DELETE must come BEFORE ALTER to avoid constraint violation
+    const deleteIdx = sql.indexOf('DELETE FROM bookings WHERE service_id IS NULL');
+    const alterIdx = sql.indexOf('ALTER TABLE bookings ALTER COLUMN service_id SET NOT NULL');
+
+    expect(deleteIdx).toBeGreaterThan(-1);
+    expect(alterIdx).toBeGreaterThan(-1);
+    expect(deleteIdx).toBeLessThan(alterIdx);
+  });
+
+  it('original init migration has service_id without NOT NULL', () => {
+    const initSql = fs.readFileSync(
+      path.join(migrationDir, '20250101000000_init.sql'),
+      'utf-8'
+    );
+
+    // Confirm the bug: service_id FK without NOT NULL
+    const match = initSql.match(/service_id\s+UUID\s+REFERENCES\s+services\(id\)/);
+    expect(match).toBeTruthy();
+
+    // Should NOT have NOT NULL on the same line
+    const line = initSql.split('\n').find(l => l.includes('service_id') && l.includes('REFERENCES services'));
+    expect(line).toBeDefined();
+    expect(line).not.toMatch(/NOT\s+NULL/i);
+  });
+});

--- a/supabase/migrations/20260303000007_bookings_service_id_not_null.sql
+++ b/supabase/migrations/20260303000007_bookings_service_id_not_null.sql
@@ -1,0 +1,9 @@
+-- Fix: bookings.service_id was nullable, allowing bookings without a service.
+-- This causes NULL in analytics/revenue queries and "undefined" in UI.
+
+-- Safety: delete any orphaned bookings with NULL service_id
+-- (these are invalid and should not exist)
+DELETE FROM bookings WHERE service_id IS NULL;
+
+-- Add NOT NULL constraint
+ALTER TABLE bookings ALTER COLUMN service_id SET NOT NULL;


### PR DESCRIPTION
## Summary
- `bookings.service_id` was nullable (FK without NOT NULL)
- Allowed bookings without a service, causing NULL in analytics and "undefined" in UI
- Migration deletes orphaned rows then adds NOT NULL constraint

## Changes
- `supabase/migrations/20260303000007_bookings_service_id_not_null.sql`
- `src/__tests__/migrations/bookings-service-id-not-null.test.ts` — 3 tests

## Test plan
- [x] Migration adds NOT NULL constraint
- [x] DELETE runs before ALTER (safe order)
- [x] Original init.sql confirmed to have the bug

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)