### PR TITLE
fix(bot): escape SQL wildcards in ilike service name query

### DIFF
--- a/src/__tests__/bot/ilike-wildcard-injection.test.ts
+++ b/src/__tests__/bot/ilike-wildcard-injection.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Tests that SQL wildcard characters are escaped before ilike queries
+ * in chatbot.ts to prevent wildcard injection attacks.
+ *
+ * Attack vector: user says "quero agendar um %" → bot calls
+ * createAppointment({ service_name: "%" }) → ilike('name', '%%%')
+ * matches ALL services → books wrong service.
+ */
+
+describe('ilike wildcard injection prevention', () => {
+  const chatbotSource = fs.readFileSync(
+    path.resolve('src/lib/ai/chatbot.ts'),
+    'utf-8'
+  );
+
+  it('escapes % and _ wildcards before ilike query', () => {
+    // The fix: data.service_name.replace(/[%_\\]/g, '\\$&')
+    expect(chatbotSource).toContain("replace(/[%_\\\\]/g, '\\\\$&')");
+  });
+
+  it('uses escaped variable (safeName) in ilike, not raw service_name', () => {
+    // Should use safeName in the ilike, not data.service_name
+    expect(chatbotSource).toContain('.ilike(\'name\', `%${safeName}%`)');
+    expect(chatbotSource).not.toContain('.ilike(\'name\', `%${data.service_name}%`)');
+  });
+
+  it('escape function correctly sanitizes wildcards', () => {
+    // Replicate the same escape logic used in chatbot.ts
+    const escape = (s: string) => s.replace(/[%_\\]/g, '\\$&');
+
+    // "%" → "\%" (literal percent, no wildcard)
+    expect(escape('%')).toBe('\\%');
+
+    // "_" → "\_" (literal underscore, no single-char wildcard)
+    expect(escape('_')).toBe('\\_');
+
+    // "\\" → "\\\\" (escape the escape char)
+    expect(escape('\\')).toBe('\\\\');
+
+    // Normal service names pass through unchanged
+    expect(escape('Corte')).toBe('Corte');
+    expect(escape('Corte e Barba')).toBe('Corte e Barba');
+
+    // Mixed input
+    expect(escape('50% off_special')).toBe('50\\% off\\_special');
+  });
+});

--- a/src/lib/ai/chatbot.ts
+++ b/src/lib/ai/chatbot.ts
@@ -638,11 +638,13 @@ NUNCA chame cancel_appointment + create_appointment separadamente para reagendar
       }
 
       // 1. Buscar serviço por nome (parcial)
+      // Escape SQL wildcards to prevent wildcard injection (% matches all)
+      const safeName = data.service_name.replace(/[%_\\]/g, '\\$&');
       const { data: service, error: serviceError } = await this.supabase
         .from('services')
         .select('id, name, price, duration_minutes')
         .eq('professional_id', professionalId)
-        .ilike('name', `%${data.service_name}%`)
+        .ilike('name', `%${safeName}%`)
         .limit(1)
         .maybeSingle();
 


### PR DESCRIPTION
## Summary
- `data.service_name` from AI tool output was used directly in `.ilike('name', '%${...}%')` without escaping
- Input like `%` matched ALL services → bot booked wrong service
- Now escapes `%`, `_`, and `\` before the ilike query

## Changes
- `src/lib/ai/chatbot.ts:642` — added `safeName` with wildcard escaping
- `src/__tests__/bot/ilike-wildcard-injection.test.ts` — 3 tests

## Test plan
- [x] Source code escapes `%` and `_` before ilike
- [x] Uses `safeName` variable (not raw `data.service_name`) in query
- [x] Escape function: `%` → `\%`, `_` → `\_`, normal names unchanged

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)