### PR TITLE
fix(bot): use atomic RPC for reschedule to prevent booking loss

### DIFF
--- a/src/__tests__/bot/reschedule-transaction.test.ts
+++ b/src/__tests__/bot/reschedule-transaction.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Tests that reschedule uses an atomic RPC transaction instead of
+ * separate cancel + insert operations with manual rollback.
+ *
+ * Bug: If insert fails AND rollback also fails, client loses their booking.
+ * Fix: Use Supabase RPC `reschedule_booking` that runs cancel + insert
+ * in a single PostgreSQL transaction with automatic rollback.
+ */
+
+describe('reschedule atomic transaction (issue #7)', () => {
+  const chatbotSource = fs.readFileSync(
+    path.resolve('src/lib/ai/chatbot.ts'),
+    'utf-8',
+  );
+
+  const migrationSource = fs.readFileSync(
+    path.resolve(
+      'supabase/migrations/20260303000004_reschedule_booking_rpc.sql',
+    ),
+    'utf-8',
+  );
+
+  describe('chatbot.ts uses RPC instead of manual operations', () => {
+    it('calls reschedule_booking RPC', () => {
+      expect(chatbotSource).toContain(".rpc('reschedule_booking'");
+    });
+
+    it('does NOT manually cancel + insert in rescheduleAppointment', () => {
+      // Extract only the rescheduleAppointment method body
+      const methodStart = chatbotSource.indexOf(
+        'private async rescheduleAppointment(',
+      );
+      const methodEnd = chatbotSource.indexOf(
+        'private async cancelAppointment(',
+      );
+      const methodBody = chatbotSource.slice(methodStart, methodEnd);
+
+      // Should NOT have separate update to cancelled status
+      expect(methodBody).not.toContain(
+        ".update({\n          status: 'cancelled',",
+      );
+
+      // Should NOT have manual rollback to confirmed
+      expect(methodBody).not.toContain(
+        ".update({ status: 'confirmed', cancelled_by: null",
+      );
+
+      // Should NOT have separate insert for new booking
+      expect(methodBody).not.toMatch(
+        /\.insert\(\{[^}]*professional_id:\s*professionalId/,
+      );
+    });
+
+    it('handles RPC error responses correctly', () => {
+      const methodStart = chatbotSource.indexOf(
+        'private async rescheduleAppointment(',
+      );
+      const methodEnd = chatbotSource.indexOf(
+        'private async cancelAppointment(',
+      );
+      const methodBody = chatbotSource.slice(methodStart, methodEnd);
+
+      // Handles not_found from RPC
+      expect(methodBody).toContain("result.error === 'not_found'");
+
+      // Handles not_confirmed from RPC
+      expect(methodBody).toContain("result.error === 'not_confirmed'");
+
+      // Handles slot_taken (unique violation) from RPC
+      expect(methodBody).toContain("result.error === 'slot_taken'");
+    });
+  });
+
+  describe('RPC migration ensures atomicity', () => {
+    it('creates reschedule_booking function', () => {
+      expect(migrationSource).toContain(
+        'CREATE OR REPLACE FUNCTION reschedule_booking(',
+      );
+    });
+
+    it('uses FOR UPDATE lock to prevent race conditions', () => {
+      expect(migrationSource).toContain('FOR UPDATE');
+    });
+
+    it('validates booking exists and is confirmed', () => {
+      expect(migrationSource).toContain('IF NOT FOUND THEN');
+      expect(migrationSource).toContain("v_existing.status != 'confirmed'");
+    });
+
+    it('cancels old booking within transaction', () => {
+      expect(migrationSource).toContain("SET status = 'cancelled'");
+    });
+
+    it('inserts new booking within transaction', () => {
+      expect(migrationSource).toContain('INSERT INTO bookings');
+      expect(migrationSource).toContain('RETURNING id INTO v_new_id');
+    });
+
+    it('handles unique_violation (23505) with automatic rollback', () => {
+      expect(migrationSource).toContain('WHEN unique_violation THEN');
+      expect(migrationSource).toContain("'error', 'slot_taken'");
+    });
+
+    it('catches unexpected errors with automatic rollback', () => {
+      expect(migrationSource).toContain('WHEN OTHERS THEN');
+      expect(migrationSource).toContain("'error', 'unexpected'");
+    });
+
+    it('uses SECURITY DEFINER for service-role access', () => {
+      expect(migrationSource).toContain('SECURITY DEFINER');
+    });
+
+    it('returns success with new_booking_id on happy path', () => {
+      expect(migrationSource).toContain("'success', true");
+      expect(migrationSource).toContain("'new_booking_id', v_new_id");
+    });
+  });
+});

--- a/src/lib/ai/chatbot.ts
+++ b/src/lib/ai/chatbot.ts
@@ -1538,53 +1538,36 @@ PROIBIDO ao rejeitar data/horário:
       const endTotal = h * 60 + m + duration;
       const endTime = `${String(Math.floor(endTotal / 60) % 24).padStart(2, '0')}:${String(endTotal % 60).padStart(2, '0')}:00`;
 
-      // 4. Cancelar agendamento antigo
-      const { error: cancelErr } = await this.supabase
-        .from('bookings')
-        .update({
-          status: 'cancelled',
-          cancelled_by: 'client',
-          cancelled_at: new Date().toISOString(),
-          cancellation_reason: 'Reagendado pelo cliente via WhatsApp',
-        })
-        .eq('id', bookingId);
+      // 4. Reschedule atômico via RPC (cancel + insert numa única transação)
+      const { data: rpcResult, error: rpcErr } = await this.supabase
+        .rpc('reschedule_booking', {
+          p_booking_id: bookingId,
+          p_professional_id: professionalId,
+          p_new_date: normalizedDate,
+          p_new_start_time: `${normalizedTime}:00`,
+          p_new_end_time: endTime,
+        });
 
-      if (cancelErr) {
-        return { success: false, error: 'cancel_failed', message: 'Erro ao cancelar o agendamento anterior.' };
+      if (rpcErr) {
+        return { success: false, error: 'rpc_failed', message: 'Erro ao reagendar. O horário anterior foi mantido.' };
       }
 
-      // 5. Criar novo agendamento (sem verificação de duplicata — é um reagendamento explícito)
-      const { data: newBooking, error: insertErr } = await this.supabase
-        .from('bookings')
-        .insert({
-          professional_id: professionalId,
-          service_id: existing.service_id,
-          booking_date: normalizedDate,
-          start_time: `${normalizedTime}:00`,
-          end_time: endTime,
-          client_name: existing.client_name,
-          client_phone: existing.client_phone,
-          client_email: existing.client_email ?? null,
-          notes: existing.notes ?? null,
-          status: 'confirmed',
-          service_location: existing.service_location ?? 'in_salon',
-          customer_address: existing.customer_address ?? null,
-        })
-        .select('id')
-        .single();
+      const result = rpcResult as { success: boolean; error?: string; new_booking_id?: string; old_date?: string; old_time?: string; current_status?: string; detail?: string };
 
-      if (insertErr || !newBooking) {
-        // Rollback: restaurar agendamento antigo
-        await this.supabase
-          .from('bookings')
-          .update({ status: 'confirmed', cancelled_by: null, cancelled_at: null, cancellation_reason: null })
-          .eq('id', bookingId);
-
-        if (insertErr?.code === '23505') {
+      if (!result.success) {
+        if (result.error === 'not_found') {
+          return { success: false, error: 'not_found', message: 'Agendamento não encontrado.' };
+        }
+        if (result.error === 'not_confirmed') {
+          return { success: false, error: 'not_confirmed', message: `Agendamento não está confirmado (status: ${result.current_status}).` };
+        }
+        if (result.error === 'slot_taken') {
           return { success: false, error: 'slot_taken_race', message: 'O novo horário foi ocupado durante o processamento. Escolha outro horário.' };
         }
-        return { success: false, error: 'insert_failed', message: 'Erro ao criar novo agendamento. O horário anterior foi mantido.' };
+        return { success: false, error: result.error ?? 'unknown', message: 'Erro ao reagendar. O horário anterior foi mantido.' };
       }
+
+      const newBooking = { id: result.new_booking_id! };
 
       const oldDateFmt = new Date(existing.booking_date + 'T12:00:00Z')
         .toLocaleDateString('pt-BR', { weekday: 'long', day: 'numeric', month: 'long', timeZone: 'UTC' });

--- a/supabase/migrations/20260303000004_reschedule_booking_rpc.sql
+++ b/supabase/migrations/20260303000004_reschedule_booking_rpc.sql
@@ -1,0 +1,76 @@
+-- Reschedule atômico: cancela booking antigo e cria novo numa única transação.
+-- Se qualquer step falha, toda operação reverte automaticamente (rollback implícito).
+-- Retorna JSON com resultado da operação.
+
+CREATE OR REPLACE FUNCTION reschedule_booking(
+  p_booking_id UUID,
+  p_professional_id UUID,
+  p_new_date DATE,
+  p_new_start_time TIME,
+  p_new_end_time TIME
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_existing RECORD;
+  v_new_id UUID;
+BEGIN
+  -- 1. Buscar e validar booking existente (com lock para evitar race condition)
+  SELECT id, booking_date, start_time, service_id, client_name, client_phone,
+         client_email, notes, service_location, customer_address, status
+    INTO v_existing
+    FROM bookings
+   WHERE id = p_booking_id
+     AND professional_id = p_professional_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'not_found');
+  END IF;
+
+  IF v_existing.status != 'confirmed' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'not_confirmed', 'current_status', v_existing.status);
+  END IF;
+
+  -- 2. Cancelar booking antigo
+  UPDATE bookings
+     SET status = 'cancelled',
+         cancelled_by = 'client',
+         cancelled_at = NOW(),
+         cancellation_reason = 'Reagendado pelo cliente via WhatsApp'
+   WHERE id = p_booking_id;
+
+  -- 3. Inserir novo booking (pode lançar 23505 se slot já ocupado → transação reverte)
+  INSERT INTO bookings (
+    professional_id, service_id, booking_date, start_time, end_time,
+    client_name, client_phone, client_email, notes,
+    service_location, customer_address, status
+  ) VALUES (
+    p_professional_id, v_existing.service_id, p_new_date, p_new_start_time, p_new_end_time,
+    v_existing.client_name, v_existing.client_phone, v_existing.client_email, v_existing.notes,
+    COALESCE(v_existing.service_location, 'in_salon'), v_existing.customer_address, 'confirmed'
+  )
+  RETURNING id INTO v_new_id;
+
+  -- 4. Sucesso — ambas operações commitadas juntas
+  RETURN jsonb_build_object(
+    'success', true,
+    'new_booking_id', v_new_id,
+    'old_date', v_existing.booking_date,
+    'old_time', v_existing.start_time
+  );
+
+EXCEPTION
+  WHEN unique_violation THEN
+    -- Slot já ocupado (23505) → transação INTEIRA reverte (old booking fica confirmed)
+    RETURN jsonb_build_object('success', false, 'error', 'slot_taken');
+  WHEN OTHERS THEN
+    -- Qualquer outro erro → transação INTEIRA reverte
+    RETURN jsonb_build_object('success', false, 'error', 'unexpected', 'detail', SQLERRM);
+END;
+$$;
+
+COMMENT ON FUNCTION reschedule_booking IS
+  'Transactional reschedule: cancels old booking and creates new one atomically. If any step fails, everything rolls back.';


### PR DESCRIPTION
## Summary
- Replaces separate cancel + insert + manual rollback in `rescheduleAppointment()` with a single PostgreSQL RPC (`reschedule_booking`) that runs both operations in one transaction
- If any step fails (insert error, unique violation, unexpected error), the entire transaction rolls back automatically — the client **never** loses their booking
- Adds `FOR UPDATE` row lock to prevent race conditions during reschedule

## Changes
- **Migration** `20260303000004_reschedule_booking_rpc.sql`: atomic `reschedule_booking()` function with `SECURITY DEFINER`, `FOR UPDATE` lock, and `EXCEPTION` handlers for `unique_violation` and `OTHERS`
- **`src/lib/ai/chatbot.ts`**: replaced 3 separate Supabase calls with single `.rpc('reschedule_booking', ...)` call
- **`src/__tests__/bot/reschedule-transaction.test.ts`**: 12 tests covering RPC usage, no manual operations, error handling, and migration correctness

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npx vitest run` — 12/12 new tests passing
- [x] Unit: chatbot uses `.rpc('reschedule_booking')` instead of manual cancel+insert
- [x] Unit: no manual rollback code in `rescheduleAppointment()`
- [x] Unit: handles `not_found`, `not_confirmed`, `slot_taken` errors from RPC
- [x] Unit: migration has `FOR UPDATE`, `unique_violation` handler, `SECURITY DEFINER`
- [ ] CI green

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)