### PR TITLE
fix(security): encrypt OAuth tokens at rest with AES-256-GCM

### DIFF
--- a/src/__tests__/integrations/token-encryption.test.ts
+++ b/src/__tests__/integrations/token-encryption.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { randomBytes } from 'crypto';
+
+// Generate a deterministic test key (32 bytes = 64 hex chars)
+const TEST_KEY = randomBytes(32).toString('hex');
+
+describe('token-encryption', () => {
+  beforeAll(() => {
+    process.env.OAUTH_TOKEN_ENCRYPTION_KEY = TEST_KEY;
+  });
+
+  afterAll(() => {
+    delete process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+  });
+
+  // Dynamic import to pick up env var after setting it
+  async function getModule() {
+    // Clear module cache to re-evaluate with current env
+    const mod = await import('@/lib/integrations/token-encryption');
+    return mod;
+  }
+
+  it('encryptToken produces output different from input', async () => {
+    const { encryptToken } = await getModule();
+    const raw = 'IGQVJWZAkFtV3BSZA0NlMF9xN2RlYTBGWXFhc2';
+    const encrypted = encryptToken(raw);
+    expect(encrypted).not.toBe(raw);
+  });
+
+  it('encryptToken output starts with enc: prefix', async () => {
+    const { encryptToken } = await getModule();
+    const encrypted = encryptToken('some_token_value');
+    expect(encrypted.startsWith('enc:')).toBe(true);
+  });
+
+  it('encryptToken output has format enc:<iv>:<authTag>:<ciphertext>', async () => {
+    const { encryptToken } = await getModule();
+    const encrypted = encryptToken('test_token');
+    const parts = encrypted.slice(4).split(':'); // remove 'enc:' prefix
+    expect(parts).toHaveLength(3);
+    // IV = 12 bytes = 24 hex chars
+    expect(parts[0]).toHaveLength(24);
+    // Auth tag = 16 bytes = 32 hex chars
+    expect(parts[1]).toHaveLength(32);
+    // Ciphertext length > 0
+    expect(parts[2].length).toBeGreaterThan(0);
+  });
+
+  it('decryptToken(encryptToken(raw)) === raw (roundtrip)', async () => {
+    const { encryptToken, decryptToken } = await getModule();
+    const raw = 'ya29.a0AfB_byBZK2VYH-long-google-token-12345';
+    expect(decryptToken(encryptToken(raw))).toBe(raw);
+  });
+
+  it('decryptToken returns plaintext as-is (legacy backwards compat)', async () => {
+    const { decryptToken } = await getModule();
+    const legacy = 'IGQVJWZAkFtV3BSZA0NlMF9xN2RlYTBG';
+    expect(decryptToken(legacy)).toBe(legacy);
+  });
+
+  it('encrypting same token twice produces different ciphertexts (random IV)', async () => {
+    const { encryptToken } = await getModule();
+    const raw = 'same_token_value';
+    const a = encryptToken(raw);
+    const b = encryptToken(raw);
+    expect(a).not.toBe(b); // different IVs
+  });
+
+  it('isEncrypted correctly identifies encrypted vs plaintext', async () => {
+    const { encryptToken, isEncrypted } = await getModule();
+    expect(isEncrypted('plain_token')).toBe(false);
+    expect(isEncrypted(encryptToken('plain_token'))).toBe(true);
+  });
+
+  it('decryptToken throws on tampered ciphertext', async () => {
+    const { encryptToken, decryptToken } = await getModule();
+    const encrypted = encryptToken('secret_token');
+    // Flip last hex char to corrupt ciphertext
+    const tampered =
+      encrypted.slice(0, -1) + (encrypted.at(-1) === 'a' ? 'b' : 'a');
+    expect(() => decryptToken(tampered)).toThrow();
+  });
+
+  it('throws when OAUTH_TOKEN_ENCRYPTION_KEY is missing', async () => {
+    const saved = process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+    delete process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+    try {
+      const { encryptToken } = await getModule();
+      expect(() => encryptToken('token')).toThrow(
+        'OAUTH_TOKEN_ENCRYPTION_KEY',
+      );
+    } finally {
+      process.env.OAUTH_TOKEN_ENCRYPTION_KEY = saved;
+    }
+  });
+
+  it('handles empty string token', async () => {
+    const { encryptToken, decryptToken } = await getModule();
+    const encrypted = encryptToken('');
+    expect(encrypted.startsWith('enc:')).toBe(true);
+    expect(decryptToken(encrypted)).toBe('');
+  });
+
+  it('handles unicode characters in token', async () => {
+    const { encryptToken, decryptToken } = await getModule();
+    const raw = 'token_with_émojis_🔑_and_ñ';
+    expect(decryptToken(encryptToken(raw))).toBe(raw);
+  });
+});
+
+describe('callbacks store encrypted tokens (source verification)', () => {
+  const fs = require('fs');
+  const path = require('path');
+
+  const instagramCallback = fs.readFileSync(
+    path.resolve(
+      'src/app/api/integrations/instagram/callback/route.ts',
+    ),
+    'utf-8',
+  );
+
+  const googleCallback = fs.readFileSync(
+    path.resolve(
+      'src/app/api/integrations/google-calendar/callback/route.ts',
+    ),
+    'utf-8',
+  );
+
+  const instagramPost = fs.readFileSync(
+    path.resolve('src/app/api/integrations/instagram/post/route.ts'),
+    'utf-8',
+  );
+
+  const googleCalendar = fs.readFileSync(
+    path.resolve('src/lib/integrations/google-calendar.ts'),
+    'utf-8',
+  );
+
+  it('Instagram callback encrypts token before saving', () => {
+    expect(instagramCallback).toContain('encryptToken(longToken)');
+    expect(instagramCallback).toContain(
+      "import { encryptToken } from '@/lib/integrations/token-encryption'",
+    );
+  });
+
+  it('Instagram callback does NOT store plaintext token', () => {
+    // Should NOT have `access_token: longToken` (without encryptToken wrapper)
+    expect(instagramCallback).not.toMatch(/access_token:\s*longToken[,\s]/);
+  });
+
+  it('Google Calendar callback encrypts both tokens before saving', () => {
+    expect(googleCallback).toContain('encryptToken(tokens.access_token!)');
+    expect(googleCallback).toContain('encryptToken(tokens.refresh_token!)');
+  });
+
+  it('Instagram post route decrypts token before use', () => {
+    expect(instagramPost).toContain('decryptToken(integration.access_token)');
+  });
+
+  it('Google Calendar decrypts tokens when reading from DB', () => {
+    expect(googleCalendar).toContain(
+      'decryptToken(credentials.access_token)',
+    );
+    expect(googleCalendar).toContain(
+      'decryptToken(credentials.refresh_token)',
+    );
+  });
+
+  it('Google Calendar encrypts tokens on refresh before saving back', () => {
+    expect(googleCalendar).toContain('encryptToken(tokens.access_token)');
+    expect(googleCalendar).toContain('encryptToken(tokens.refresh_token)');
+  });
+});

--- a/src/app/api/admin/encrypt-existing-tokens/route.ts
+++ b/src/app/api/admin/encrypt-existing-tokens/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { encryptToken, isEncrypted } from '@/lib/integrations/token-encryption';
+
+// One-time endpoint to encrypt existing plaintext OAuth tokens in the DB.
+// Protected: only runs if SETUP_SECRET matches.
+// Call: POST /api/admin/encrypt-existing-tokens  { "secret": "<SETUP_SECRET>" }
+
+export async function POST(request: Request) {
+  const { secret } = await request.json();
+
+  if (secret !== process.env.SETUP_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  let encrypted = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  // 1. Encrypt Instagram access_token (stored as top-level column)
+  const { data: instagramRows } = await supabase
+    .from('integrations')
+    .select('id, access_token')
+    .eq('type', 'instagram')
+    .not('access_token', 'is', null);
+
+  for (const row of instagramRows ?? []) {
+    if (!row.access_token || isEncrypted(row.access_token)) {
+      skipped++;
+      continue;
+    }
+    try {
+      await supabase
+        .from('integrations')
+        .update({ access_token: encryptToken(row.access_token) })
+        .eq('id', row.id);
+      encrypted++;
+    } catch {
+      errors++;
+    }
+  }
+
+  // 2. Encrypt Google Calendar credentials JSONB (access_token + refresh_token)
+  const { data: googleRows } = await supabase
+    .from('integrations')
+    .select('id, credentials')
+    .eq('integration_type', 'google_calendar')
+    .not('credentials', 'is', null);
+
+  for (const row of googleRows ?? []) {
+    const creds = row.credentials as Record<string, unknown> | null;
+    if (!creds?.access_token || !creds?.refresh_token) {
+      skipped++;
+      continue;
+    }
+    if (
+      isEncrypted(creds.access_token as string) &&
+      isEncrypted(creds.refresh_token as string)
+    ) {
+      skipped++;
+      continue;
+    }
+    try {
+      await supabase
+        .from('integrations')
+        .update({
+          credentials: {
+            ...creds,
+            access_token: isEncrypted(creds.access_token as string)
+              ? creds.access_token
+              : encryptToken(creds.access_token as string),
+            refresh_token: isEncrypted(creds.refresh_token as string)
+              ? creds.refresh_token
+              : encryptToken(creds.refresh_token as string),
+          },
+        })
+        .eq('id', row.id);
+      encrypted++;
+    } catch {
+      errors++;
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    encrypted,
+    skipped,
+    errors,
+  });
+}

--- a/src/app/api/integrations/google-calendar/callback/route.ts
+++ b/src/app/api/integrations/google-calendar/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { getTokensFromCode } from '@/lib/integrations/google-calendar';
+import { encryptToken } from '@/lib/integrations/token-encryption';
 
 /**
  * Callback do OAuth Google Calendar
@@ -64,7 +65,7 @@ export async function GET(request: NextRequest) {
       throw new Error('Failed to get tokens from Google');
     }
 
-    // Salvar tokens no banco (encriptados - TODO: adicionar encriptação)
+    // Salvar tokens no banco (criptografados com AES-256-GCM)
     const { error: dbError } = await supabase.from('integrations').upsert(
       {
         professional_id: professional.id,
@@ -72,8 +73,8 @@ export async function GET(request: NextRequest) {
         is_active: true,
         is_configured: true,
         credentials: {
-          access_token: tokens.access_token,
-          refresh_token: tokens.refresh_token,
+          access_token: encryptToken(tokens.access_token!),
+          refresh_token: encryptToken(tokens.refresh_token!),
           expiry_date: tokens.expiry_date,
           scope: tokens.scope,
           token_type: tokens.token_type,

--- a/src/app/api/integrations/instagram/callback/route.ts
+++ b/src/app/api/integrations/instagram/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { exchangeCodeForToken, getLongLivedToken, getUserProfile } from '@/lib/integrations/instagram'
+import { encryptToken } from '@/lib/integrations/token-encryption'
 
 export async function GET(request: NextRequest) {
   const supabase = await createClient()
@@ -57,7 +58,7 @@ export async function GET(request: NextRequest) {
       .upsert({
         professional_id: user.id,
         type: 'instagram',
-        access_token: longToken,
+        access_token: encryptToken(longToken),
         refresh_token: null,
         token_expires_at: expiresAt.toISOString(),
         instagram_user_id: userId,

--- a/src/app/api/integrations/instagram/post/route.ts
+++ b/src/app/api/integrations/instagram/post/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { postPhoto, postStory } from '@/lib/integrations/instagram'
+import { decryptToken } from '@/lib/integrations/token-encryption'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
@@ -40,11 +41,13 @@ export async function POST(request: NextRequest) {
   try {
     let result: { id: string; permalink?: string }
 
+    const accessToken = decryptToken(integration.access_token);
+
     if (postType === 'story') {
       // Postar story
       result = await postStory(
         integration.instagram_user_id,
-        integration.access_token,
+        accessToken,
         {
           imageUrl,
           link // Requer 10K+ followers
@@ -54,7 +57,7 @@ export async function POST(request: NextRequest) {
       // Postar foto no feed
       result = await postPhoto(
         integration.instagram_user_id,
-        integration.access_token,
+        accessToken,
         {
           imageUrl,
           caption

--- a/src/lib/integrations/google-calendar.ts
+++ b/src/lib/integrations/google-calendar.ts
@@ -1,6 +1,7 @@
 import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
 import { createClient } from '@/lib/supabase/server';
+import { encryptToken, decryptToken } from '@/lib/integrations/token-encryption';
 
 const SCOPES = [
   'https://www.googleapis.com/auth/calendar',
@@ -66,27 +67,26 @@ export async function getAuthenticatedClient(professionalId: string): Promise<OA
     return null;
   }
 
-  // Decriptar credenciais (TODO: implementar encriptação)
   const credentials = integration.credentials as any;
 
   const oauth2Client = getOAuth2Client();
   oauth2Client.setCredentials({
-    access_token: credentials.access_token,
-    refresh_token: credentials.refresh_token,
+    access_token: decryptToken(credentials.access_token),
+    refresh_token: decryptToken(credentials.refresh_token),
     expiry_date: credentials.expiry_date,
   });
 
   // Refresh token automaticamente se expirado
   oauth2Client.on('tokens', async (tokens) => {
     if (tokens.refresh_token) {
-      // Atualizar no banco
+      // Atualizar no banco (criptografado)
       await supabase
         .from('integrations')
         .update({
           credentials: {
             ...credentials,
-            access_token: tokens.access_token,
-            refresh_token: tokens.refresh_token || credentials.refresh_token,
+            access_token: tokens.access_token ? encryptToken(tokens.access_token) : credentials.access_token,
+            refresh_token: tokens.refresh_token ? encryptToken(tokens.refresh_token) : credentials.refresh_token,
             expiry_date: tokens.expiry_date,
           },
           updated_at: new Date().toISOString(),

--- a/src/lib/integrations/token-encryption.ts
+++ b/src/lib/integrations/token-encryption.ts
@@ -1,0 +1,86 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // GCM standard
+const AUTH_TAG_LENGTH = 16;
+const PREFIX = 'enc:';
+
+/**
+ * Returns the 32-byte encryption key from env var.
+ * Throws if not configured — fail loud, not silent.
+ */
+function getKey(): Buffer {
+  const raw = process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+  if (!raw) {
+    throw new Error(
+      'OAUTH_TOKEN_ENCRYPTION_KEY env var is required for token encryption',
+    );
+  }
+  // Accept hex (64 chars) or base64 (44 chars) encoded 32-byte key
+  if (raw.length === 64 && /^[0-9a-fA-F]+$/.test(raw)) {
+    return Buffer.from(raw, 'hex');
+  }
+  const buf = Buffer.from(raw, 'base64');
+  if (buf.length !== 32) {
+    throw new Error(
+      'OAUTH_TOKEN_ENCRYPTION_KEY must be a 32-byte key (64 hex chars or 44 base64 chars)',
+    );
+  }
+  return buf;
+}
+
+/**
+ * Encrypt a plaintext token → `enc:<iv>:<authTag>:<ciphertext>` (all hex).
+ */
+export function encryptToken(plaintext: string): string {
+  const key = getKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return `${PREFIX}${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+/**
+ * Decrypt an `enc:...` string back to plaintext.
+ * If the value is NOT prefixed with `enc:`, returns it as-is (legacy plaintext).
+ */
+export function decryptToken(value: string): string {
+  if (!value.startsWith(PREFIX)) {
+    // Legacy plaintext token — return as-is for backwards compat during migration
+    return value;
+  }
+
+  const key = getKey();
+  const parts = value.slice(PREFIX.length).split(':');
+  if (parts.length !== 3) {
+    throw new Error('Invalid encrypted token format');
+  }
+
+  const [ivHex, authTagHex, ciphertextHex] = parts;
+  const iv = Buffer.from(ivHex, 'hex');
+  const authTag = Buffer.from(authTagHex, 'hex');
+  const ciphertext = Buffer.from(ciphertextHex, 'hex');
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  const decrypted = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]);
+
+  return decrypted.toString('utf8');
+}
+
+/**
+ * Check if a token value is already encrypted.
+ */
+export function isEncrypted(value: string): boolean {
+  return value.startsWith(PREFIX);
+}

--- a/supabase/migrations/20260303000006_encrypt_existing_tokens.sql
+++ b/supabase/migrations/20260303000006_encrypt_existing_tokens.sql
@@ -1,0 +1,12 @@
+-- Placeholder migration: existing plaintext tokens must be encrypted via a one-time script.
+--
+-- PostgreSQL does not have access to the OAUTH_TOKEN_ENCRYPTION_KEY env var,
+-- so encryption must happen at the application level.
+--
+-- Run the following after deploying the new code:
+--   POST /api/admin/encrypt-existing-tokens (with SETUP_SECRET)
+--
+-- This migration exists to document the requirement and maintain migration order.
+
+-- No-op: encryption happens in the application layer.
+SELECT 1;


### PR DESCRIPTION
## Summary
- OAuth tokens (Instagram long-lived, Google Calendar access+refresh) were stored in **plaintext** in the `integrations` table — if DB is compromised, attacker gets full access to all connected accounts
- Now encrypted with **AES-256-GCM** before saving and decrypted just-in-time on use
- Legacy plaintext tokens handled transparently (`decryptToken` returns as-is if no `enc:` prefix)
- Admin endpoint `POST /api/admin/encrypt-existing-tokens` to migrate existing tokens

## Changes
- **`src/lib/integrations/token-encryption.ts`**: `encryptToken()`, `decryptToken()`, `isEncrypted()` using AES-256-GCM with random IV
- **Instagram callback**: encrypts `longToken` before DB save
- **Instagram post**: decrypts token before API call
- **Google Calendar callback**: encrypts `access_token` + `refresh_token` before DB save
- **Google Calendar lib**: decrypts on read, encrypts on token refresh
- **Admin endpoint**: one-time migration of existing plaintext tokens
- **17 unit tests** covering encrypt/decrypt cycle, format, backwards compat, tampering, source verification

## Deployment steps
1. Set `OAUTH_TOKEN_ENCRYPTION_KEY` env var in Vercel (generate: `openssl rand -hex 32`)
2. Deploy this PR
3. Call `POST /api/admin/encrypt-existing-tokens` with `{ "secret": "<SETUP_SECRET>" }` to encrypt existing tokens

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npx vitest run` — 17/17 new tests passing
- [x] Unit: encrypt produces `enc:` prefixed output != input
- [x] Unit: decrypt(encrypt(raw)) === raw (roundtrip)
- [x] Unit: plaintext passthrough for legacy tokens
- [x] Unit: tampered ciphertext throws
- [x] Unit: source verification — all callbacks encrypt, all readers decrypt
- [ ] CI green

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)