### PR TITLE
fix(security): add security headers to prevent clickjacking and MIME sniffing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,13 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n.ts');
 
+const securityHeaders = [
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'geolocation=(), microphone=()' },
+];
+
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
@@ -18,6 +25,14 @@ const nextConfig: NextConfig = {
         hostname: '*.supabase.co',
       },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 

--- a/src/__tests__/security/security-headers.test.ts
+++ b/src/__tests__/security/security-headers.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const configSource = readFileSync(resolve('next.config.ts'), 'utf-8');
+
+describe('Security headers (issue #14)', () => {
+  it('sets X-Frame-Options: DENY to prevent clickjacking', () => {
+    expect(configSource).toContain("key: 'X-Frame-Options', value: 'DENY'");
+  });
+
+  it('sets X-Content-Type-Options: nosniff to prevent MIME sniffing', () => {
+    expect(configSource).toContain(
+      "key: 'X-Content-Type-Options', value: 'nosniff'",
+    );
+  });
+
+  it('sets Referrer-Policy to prevent token leakage via Referer header', () => {
+    expect(configSource).toContain(
+      "key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin'",
+    );
+  });
+
+  it('sets Permissions-Policy to restrict sensitive APIs', () => {
+    expect(configSource).toContain(
+      "key: 'Permissions-Policy', value: 'geolocation=(), microphone=()'",
+    );
+  });
+
+  it('applies headers to all routes via catch-all source', () => {
+    expect(configSource).toContain("source: '/(.*)'");
+  });
+
+  it('exports async headers() function in nextConfig', () => {
+    expect(configSource).toContain('async headers()');
+  });
+});


### PR DESCRIPTION
## Summary
- Zero security headers were configured — no X-Frame-Options, no X-Content-Type-Options, no Referrer-Policy, no Permissions-Policy
- Adds all 4 headers to every response via `next.config.ts` `headers()`:
  - `X-Frame-Options: DENY` — prevents clickjacking (iframe embedding)
  - `X-Content-Type-Options: nosniff` — prevents MIME sniffing attacks
  - `Referrer-Policy: strict-origin-when-cross-origin` — prevents token leakage via Referer
  - `Permissions-Policy: geolocation=(), microphone=()` — restricts sensitive browser APIs

## Changes
- **`next.config.ts`**: added `async headers()` with security headers for all routes `/(.*)`
- **`src/__tests__/security/security-headers.test.ts`**: 6 tests verifying all headers are present

## Verify after deploy
```bash
curl -I https://booking.circlehood-tech.com/dashboard | grep -iE "x-frame|x-content-type|referrer|permissions"
```

## Test plan
- [x] `npx vitest run` — 6/6 new tests passing
- [x] All 4 headers configured with correct values
- [x] Applied to all routes via catch-all source
- [ ] CI green

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)