### PR TITLE
fix(ops): remove dead notification_queue — never processed

### DIFF
--- a/e2e/notifications/01-emails.spec.ts
+++ b/e2e/notifications/01-emails.spec.ts
@@ -1,9 +1,8 @@
 /**
- * Email & Notificações — Crons e Fila
+ * Email & Notificações — Crons e Webhook
  *
  * Testes de integração que verificam o pipeline de notificações:
  *  - Crons de lembrete agendados (send-reminders, send-maintenance-reminders)
- *  - Processamento da notification_queue pelo endpoint /notifications/send
  *  - Webhook Resend para tracking de entregas
  *
  * Estratégia:
@@ -111,119 +110,9 @@ test.describe('Cron — send-maintenance-reminders', () => {
   });
 });
 
-// ─── 3: Notification Queue Processing ────────────────────────────────────────
-
-test.describe('Notification Queue — /api/notifications/send', () => {
-  let testNotificationId: string | null = null;
-
-  test.afterEach(async () => {
-    // Cleanup: remover notificação de teste se criada
-    if (testNotificationId) {
-      await supabase.from('notification_queue').delete().eq('id', testNotificationId);
-      testNotificationId = null;
-    }
-  });
-
-  test('processa notificação pendente e muda status para sent', async ({ request }) => {
-    // Setup: inserir notificação de teste sem email (para não enviar email real)
-    const { data: inserted, error } = await supabase
-      .from('notification_queue')
-      .insert({
-        professional_id: TEST.PROFESSIONAL_ID,
-        type: 'reminder',
-        recipient_name: 'Teste E2E Notificação',
-        recipient_phone: TEST.PHONE,
-        recipient_email: null, // sem email → sem Resend chamado
-        message_template: 'reminder',
-        message_data: {
-          booking_id: null,
-          message: 'Teste de lembrete E2E — pode ignorar',
-        },
-        language: 'pt',
-        status: 'pending',
-      })
-      .select('id')
-      .single();
-
-    if (error || !inserted) {
-      console.log(`⏭️  Falha ao inserir notificação de teste: ${error?.message}`);
-      test.skip(true, 'Não foi possível inserir na notification_queue');
-      return;
-    }
-
-    testNotificationId = inserted.id;
-    console.log(`✅ Notificação de teste inserida: id=${testNotificationId}`);
-
-    // Chamar endpoint de processamento
-    const res = await request.post(`${TEST.BASE_URL}/api/notifications/send`, {
-      headers: { 'x-cron-secret': TEST.CRON_SECRET },
-    });
-
-    expect(res.status()).toBe(200);
-    const data = await res.json();
-    console.log('  ✅ /api/notifications/send response:', JSON.stringify(data));
-
-    // Response deve ser JSON válido com campo recognized
-    expect(data).toBeDefined();
-
-    // Aguardar processamento assíncrono (Vercel pode ter latência)
-    await new Promise<void>((r) => setTimeout(r, 2000));
-
-    // Verificar status da notificação
-    const { data: updated } = await supabase
-      .from('notification_queue')
-      .select('status, sent_at, error_message')
-      .eq('id', testNotificationId)
-      .maybeSingle();
-
-    if (updated) {
-      console.log(
-        `  ℹ️  Notificação: status=${updated.status}, sent_at=${updated.sent_at}`,
-      );
-      if (updated.status === 'pending') {
-        // O endpoint usa auth de sessão (sem cookies em contexto cron) →
-        // RLS pode impedir visibilidade da notificação. Resultado documentativo.
-        console.log('  ℹ️  Notificação ainda pending — endpoint pode não ter acesso via RLS sem sessão ativa');
-      } else if (updated.status === 'failed') {
-        console.log(`  ℹ️  Notificação falhou: ${updated.error_message}`);
-      } else {
-        console.log(`  ✅ Notificação processada com sucesso: status=${updated.status}`);
-      }
-      // Status pode ser 'pending', 'sent' ou 'failed' — todos são resultados válidos em E2E
-      expect(['pending', 'sent', 'failed']).toContain(updated.status);
-    } else {
-      console.log('  ℹ️  Notificação não encontrada após processamento (pode ter sido deletada)');
-    }
-  });
-
-  test('retorna estrutura correta quando não há notificações pendentes', async ({ request }) => {
-    // Chamar endpoint sem inserir nada — não garante fila vazia,
-    // mas verifica que o endpoint responde com estrutura correta
-
-    const res = await request.post(`${TEST.BASE_URL}/api/notifications/send`, {
-      headers: { 'x-cron-secret': TEST.CRON_SECRET },
-    });
-
-    expect(res.status()).toBe(200);
-    const data = await res.json();
-
-    // Resposta deve ser JSON válido com campo processed ou message
-    const hasExpectedField =
-      'processed' in data || 'message' in data || 'success' in data || 'results' in data;
-    expect(hasExpectedField).toBe(true);
-
-    console.log(`✅ /api/notifications/send: resposta válida ${JSON.stringify(data)}`);
-  });
-
-  test('retorna 401 sem x-cron-secret', async ({ request }) => {
-    const res = await request.post(`${TEST.BASE_URL}/api/notifications/send`, {
-      headers: { 'Content-Type': 'application/json' },
-    });
-
-    expect(res.status()).toBe(401);
-    console.log('✅ /api/notifications/send rejeita request sem auth (401)');
-  });
-});
+// ─── 3: Notification Queue — REMOVED (issue #18) ────────────────────────────
+// notification_queue was a dead queue (never processed by any cron).
+// Table dropped in migration 20260303000007. Tests removed.
 
 // ─── 4: Resend Webhook ───────────────────────────────────────────────────────
 
@@ -277,38 +166,9 @@ test.describe('Webhook Resend — /api/webhooks/resend', () => {
   });
 });
 
-// ─── 5: Integridade da notification_queue ────────────────────────────────────
+// ─── 5: notification_logs (notification_queue removed in issue #18) ──────────
 
-test.describe('Notification Queue — Integridade', () => {
-  test('não há notificações travadas em pending por mais de 1 hora', async () => {
-    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
-
-    const { data: stuckNotifications, count } = await supabase
-      .from('notification_queue')
-      .select('id, type, created_at, recipient_phone', { count: 'exact' })
-      .eq('status', 'pending')
-      .lt('created_at', oneHourAgo);
-
-    const stuckCount = count ?? 0;
-
-    if (stuckCount > 0) {
-      console.log(`⚠️  ${stuckCount} notificação(ões) travada(s) em pending por >1h:`);
-      (stuckNotifications ?? []).slice(0, 5).forEach((n) => {
-        console.log(`  - id=${n.id}, type=${n.type}, created_at=${n.created_at}`);
-      });
-      // Não falhamos o CI por notificações travadas — é informativo
-      // (pode ser que o processador ainda não rodou)
-      console.log(
-        '  ℹ️  Notificações travadas documentadas — verificar se /api/notifications/send está sendo chamado',
-      );
-    } else {
-      console.log('✅ Nenhuma notificação travada em pending por >1h');
-    }
-
-    // Este teste sempre passa — é puramente documentativo
-    expect(true).toBe(true);
-  });
-
+test.describe('Notification Logs — Integridade', () => {
   test('notification_logs registra notificações enviadas recentemente', async () => {
     const { data: recentLogs, count } = await supabase
       .from('notification_logs')

--- a/e2e/notifications/03-cancellation.spec.ts
+++ b/e2e/notifications/03-cancellation.spec.ts
@@ -2,7 +2,7 @@
  * Notificação de cancelamento — Prompt 1.1
  *
  * Verifica que quando um agendamento é cancelado via token (cliente cancela),
- * a notificação de email é disparada (notification_logs / notification_queue).
+ * a notificação de email é disparada (notification_logs).
  *
  * Estratégia:
  *  - Inserir booking com client_email via admin client
@@ -155,28 +155,12 @@ test.describe('Notificação de cancelamento — cliente cancela via token', () 
       // Email deve ter sido enviado (ou pelo menos tentado)
       expect(['sent', 'failed']).toContain(emailLogs[0].status);
     } else {
-      // Se não há logs, verificar notification_queue (pode estar pendente)
-      const { data: queueEntry } = await supabase
-        .from('notification_queue')
-        .select('id, type, message_template, status')
-        .eq('professional_id', TEST.PROFESSIONAL_ID)
-        .gte('created_at', logsBefore)
-        .order('created_at', { ascending: false })
-        .limit(5);
-
-      if (queueEntry && queueEntry.length > 0) {
-        console.log(`  ℹ️  notification_queue tem ${queueEntry.length} entrada(s) (ainda não processado)`);
-        queueEntry.forEach((q) => {
-          console.log(`    - id=${q.id}, type=${q.type}, template=${q.message_template}`);
-        });
-      } else {
-        console.log(
-          '  ⚠️  Nenhum log ou queue entry encontrado — email pode não ter sido disparado'
-        );
-        console.log(
-          '  ℹ️  Verificar: cliente tem RESEND_API_KEY configurada? sendCancellationEmail foi chamado?'
-        );
-      }
+      console.log(
+        '  ⚠️  Nenhum log encontrado — email pode não ter sido disparado'
+      );
+      console.log(
+        '  ℹ️  Verificar: cliente tem RESEND_API_KEY configurada? sendCancellationEmail foi chamado?'
+      );
       // Este teste é documentativo — não falha o CI se email não foi enviado em prod
       // (pode ser que RESEND_API_KEY não está configurada no ambiente de teste)
       expect(true).toBe(true);

--- a/e2e/notifications/04-maintenance-reminder.spec.ts
+++ b/e2e/notifications/04-maintenance-reminder.spec.ts
@@ -3,14 +3,14 @@
  *
  * Verifica que o cron /api/cron/send-maintenance-reminders:
  *  - Identifica bookings concluídos cujo prazo (completed_at + lifetime_days) é hoje
- *  - Insere entrada na notification_queue para o cliente
+ *  - Envia notificação diretamente ao cliente (fire-and-forget)
  *  - Marca maintenance_reminder_sent = true no booking
  *
  * Estratégia:
  *  1. Criar serviço de teste com lifetime_days = 3
  *  2. Criar booking concluído com completed_at = hoje − 3 dias, maintenance_reminder_sent = false
  *  3. Chamar o cron
- *  4. Verificar notification_queue tem entrada para o booking
+ *  4. Verificar booking.maintenance_reminder_sent = true
  *  5. Verificar booking.maintenance_reminder_sent = true
  *  6. Cleanup
  */
@@ -81,12 +81,8 @@ test.describe('Cron — send-maintenance-reminders — com dados reais', () => {
   });
 
   test.afterAll(async () => {
-    // Cleanup: deletar notification_queue entries, booking e serviço
+    // Cleanup: deletar booking e serviço
     if (bookingId) {
-      await supabase
-        .from('notification_queue')
-        .delete()
-        .contains('message_data', { booking_id: bookingId });
       await supabase.from('bookings').delete().eq('id', bookingId);
     }
     if (serviceId) {
@@ -94,15 +90,13 @@ test.describe('Cron — send-maintenance-reminders — com dados reais', () => {
     }
   });
 
-  test('cron identifica booking vencido e insere na notification_queue', async ({
+  test('cron identifica booking vencido e envia notificação', async ({
     request,
   }) => {
     if (!bookingId || !serviceId) {
       test.skip(true, 'Setup falhou — pulando teste');
       return;
     }
-
-    const before = new Date().toISOString();
 
     // 3. Chamar o cron
     const res = await request.post(
@@ -117,36 +111,8 @@ test.describe('Cron — send-maintenance-reminders — com dados reais', () => {
     expect(data).toHaveProperty('success', true);
     expect(typeof data.remindersSent).toBe('number');
 
-    // 4. Verificar notification_queue tem entrada para o booking
-    // Aguardar brevemente para escrita no DB
+    // 4. Verificar booking.maintenance_reminder_sent = true
     await new Promise<void>((r) => setTimeout(r, 1000));
-
-    const { data: queueEntry } = await supabase
-      .from('notification_queue')
-      .select('id, type, recipient_phone, status, message_data')
-      .eq('professional_id', TEST.PROFESSIONAL_ID)
-      .eq('type', 'maintenance_reminder')
-      .gte('created_at', before)
-      .order('created_at', { ascending: false })
-      .limit(5);
-
-    if (queueEntry && queueEntry.length > 0) {
-      const entry = queueEntry.find(
-        (q) => (q.message_data as any)?.booking_id === bookingId
-      );
-      if (entry) {
-        console.log(`  ✅ notification_queue entry criada: id=${entry.id}, phone=${entry.recipient_phone}`);
-        expect(entry.recipient_phone).toBe(TEST.PHONE);
-      } else {
-        console.log(`  ℹ️  ${queueEntry.length} entrie(s) maintenance_reminder, mas não para este booking_id`);
-        console.log('  ℹ️  O cron pode ter encontrado outro booking elegível e processado antes');
-      }
-    } else {
-      console.log('  ℹ️  Nenhuma entrada maintenance_reminder na fila após o cron');
-      console.log('  ℹ️  Possíveis razões: booking já teve reminder enviado, ou cron_logs indica erro');
-    }
-
-    // 5. Verificar booking.maintenance_reminder_sent = true
     const { data: updatedBooking } = await supabase
       .from('bookings')
       .select('maintenance_reminder_sent, maintenance_reminder_sent_at')

--- a/src/__tests__/ops/notification-queue-removed.test.ts
+++ b/src/__tests__/ops/notification-queue-removed.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { resolve, join } from 'path';
+
+/**
+ * Tests that notification_queue (dead queue) has been fully removed.
+ *
+ * Bug: notification_queue received inserts via triggers and route handlers,
+ * but was never processed (no cron in vercel.json). Records accumulated
+ * indefinitely, creating confusion and risk of duplicate notifications
+ * if someone accidentally added a cron.
+ *
+ * Fix: Remove all inserts into notification_queue, drop trigger that used it,
+ * and drop the table itself.
+ */
+
+describe('notification_queue removal (issue #18)', () => {
+  // Files that previously inserted into notification_queue
+  const changeRoute = readFileSync(
+    resolve('src/app/api/reschedule/[token]/change/route.ts'),
+    'utf-8',
+  );
+
+  const cancelRoute = readFileSync(
+    resolve('src/app/api/reschedule/[token]/cancel/route.ts'),
+    'utf-8',
+  );
+
+  const automationsPage = readFileSync(
+    resolve('src/app/[locale]/(dashboard)/automations/page.tsx'),
+    'utf-8',
+  );
+
+  const migration = readFileSync(
+    resolve(
+      'supabase/migrations/20260303000007_drop_notification_queue.sql',
+    ),
+    'utf-8',
+  );
+
+  describe('app code no longer references notification_queue', () => {
+    it('reschedule change route does not insert into notification_queue', () => {
+      expect(changeRoute).not.toContain('notification_queue');
+    });
+
+    it('reschedule cancel route does not insert into notification_queue', () => {
+      expect(cancelRoute).not.toContain('notification_queue');
+    });
+
+    it('automations page does not query notification_queue', () => {
+      expect(automationsPage).not.toContain('notification_queue');
+    });
+  });
+
+  describe('cleanup migration drops dead queue', () => {
+    it('drops the booking_notify_waitlist trigger', () => {
+      expect(migration).toContain(
+        'DROP TRIGGER IF EXISTS booking_notify_waitlist ON bookings',
+      );
+    });
+
+    it('recreates notify_waitlist_on_cancellation WITHOUT notification_queue insert', () => {
+      // The function body after CREATE OR REPLACE should NOT contain notification_queue
+      const funcStart = migration.indexOf(
+        'CREATE OR REPLACE FUNCTION notify_waitlist_on_cancellation()',
+      );
+      const funcEnd = migration.indexOf('$$ LANGUAGE plpgsql;');
+      const funcBody = migration.slice(funcStart, funcEnd);
+      expect(funcBody).not.toContain('notification_queue');
+    });
+
+    it('preserves waitlist notification logic (marks as notified)', () => {
+      expect(migration).toContain('UPDATE waitlist');
+      expect(migration).toContain("notified = true");
+      expect(migration).toContain("status = 'notified'");
+    });
+
+    it('drops notification_queue table', () => {
+      expect(migration).toContain(
+        'DROP TABLE IF EXISTS notification_queue CASCADE',
+      );
+    });
+
+    it('recreates the trigger with updated function', () => {
+      expect(migration).toContain(
+        'CREATE TRIGGER booking_notify_waitlist',
+      );
+      expect(migration).toContain(
+        'EXECUTE FUNCTION notify_waitlist_on_cancellation()',
+      );
+    });
+  });
+
+  describe('vercel.json has no notification_queue cron', () => {
+    const vercelConfig = readFileSync(resolve('vercel.json'), 'utf-8');
+
+    it('does not reference notification_queue or notifications/send cron', () => {
+      expect(vercelConfig).not.toContain('notification_queue');
+      expect(vercelConfig).not.toContain('notifications/send');
+    });
+  });
+});

--- a/src/app/[locale]/(dashboard)/automations/page.tsx
+++ b/src/app/[locale]/(dashboard)/automations/page.tsx
@@ -36,12 +36,6 @@ export default async function AutomationsPage() {
     .select('*', { count: 'exact', head: true })
     .eq('professional_id', professional.id);
 
-  const { count: pendingQueue } = await supabase
-    .from('notification_queue')
-    .select('*', { count: 'exact', head: true })
-    .eq('professional_id', professional.id)
-    .eq('status', 'pending');
-
   return (
     <AutomationsManager
       professional={professional}
@@ -49,7 +43,7 @@ export default async function AutomationsPage() {
       notificationLogs={notificationLogs || []}
       stats={{
         totalNotifications: totalNotifications || 0,
-        pendingQueue: pendingQueue || 0,
+        pendingQueue: 0,
       }}
     />
   );

--- a/src/app/api/reschedule/[token]/cancel/route.ts
+++ b/src/app/api/reschedule/[token]/cancel/route.ts
@@ -69,20 +69,6 @@ export async function POST(
       (err) => console.error('notifyWaitlist error:', err)
     );
 
-    // Notificar profissional (log na fila)
-    await supabase.from('notification_queue').insert({
-      professional_id: tokenData.bookings.professional_id,
-      type: 'booking_confirmation',
-      recipient_name: 'Profissional',
-      recipient_phone: '',
-      message_template: 'booking_cancelled_by_client',
-      message_data: {
-        booking_id: tokenData.bookings.id,
-        reason: reason || 'Cancelado pelo cliente',
-      },
-      language: 'pt',
-    });
-
     // Notificar cliente via email (fire-and-forget)
     const booking = tokenData.bookings as any;
     if (booking.client_email) {

--- a/src/app/api/reschedule/[token]/change/route.ts
+++ b/src/app/api/reschedule/[token]/change/route.ts
@@ -76,21 +76,6 @@ export async function POST(
       booking_id: tokenData.bookings.id,
     });
 
-    // Notificar profissional
-    await supabase.from('notification_queue').insert({
-      professional_id: tokenData.bookings.professional_id,
-      type: 'booking_confirmation',
-      recipient_name: 'Profissional',
-      recipient_phone: '',
-      message_template: 'booking_rescheduled',
-      message_data: {
-        booking_id: tokenData.bookings.id,
-        new_date,
-        new_time,
-      },
-      language: 'pt',
-    });
-
     return NextResponse.json({
       success: true,
       message: 'Agendamento reagendado com sucesso',

--- a/supabase/migrations/20260303000007_drop_notification_queue.sql
+++ b/supabase/migrations/20260303000007_drop_notification_queue.sql
@@ -1,0 +1,57 @@
+-- Fix: notification_queue é uma fila morta — nunca processada por nenhum cron.
+-- Notificações reais são enviadas via fire-and-forget (Evolution API + Resend).
+-- Trigger notify_waitlist_on_cancellation inseria na fila sem efeito.
+--
+-- Esta migration:
+-- 1. Remove o trigger que insere na fila
+-- 2. Recria a função SEM o insert na notification_queue (mantém a lógica de waitlist)
+-- 3. Dropa a tabela notification_queue e seus índices
+
+-- 1. Dropar trigger (se existir)
+DROP TRIGGER IF EXISTS booking_notify_waitlist ON bookings;
+
+-- 2. Recriar função sem insert na notification_queue
+-- Mantém apenas a lógica de marcar waitlist como notificado
+CREATE OR REPLACE FUNCTION notify_waitlist_on_cancellation()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_waitlist_record RECORD;
+BEGIN
+  -- Só processa se mudou de confirmado para cancelado
+  IF OLD.status = 'confirmed' AND NEW.status = 'cancelled' THEN
+
+    -- Busca primeiro da waitlist para este serviço e data
+    SELECT * INTO v_waitlist_record
+    FROM waitlist
+    WHERE professional_id = NEW.professional_id
+      AND service_id = NEW.service_id
+      AND NEW.booking_date = ANY(preferred_dates)
+      AND status = 'active'
+      AND notified = false
+    ORDER BY created_at ASC
+    LIMIT 1;
+
+    -- Se encontrou alguém na waitlist, marca como notificado
+    IF v_waitlist_record.id IS NOT NULL THEN
+      UPDATE waitlist
+      SET
+        notified = true,
+        notified_at = now(),
+        notification_expires_at = now() + interval '24 hours',
+        status = 'notified'
+      WHERE id = v_waitlist_record.id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Recriar trigger com a função atualizada
+CREATE TRIGGER booking_notify_waitlist
+  AFTER UPDATE ON bookings
+  FOR EACH ROW
+  EXECUTE FUNCTION notify_waitlist_on_cancellation();
+
+-- 3. Dropar tabela notification_queue (fila morta)
+DROP TABLE IF EXISTS notification_queue CASCADE;


### PR DESCRIPTION
## Summary
- `notification_queue` table received inserts via triggers and route handlers but was **never processed** — no cron in `vercel.json`, no consumer
- Records accumulated indefinitely, creating confusion and risk of accidental duplicate notifications
- Follows **Option A** from issue: remove all references and drop the table

## Changes
- **Migration** `20260303000007_drop_notification_queue.sql`:
  - Drops `booking_notify_waitlist` trigger
  - Recreates `notify_waitlist_on_cancellation()` WITHOUT `notification_queue` insert (keeps waitlist marking logic)
  - Drops `notification_queue` table
- **`reschedule/[token]/change/route.ts`**: removed dead insert into notification_queue
- **`reschedule/[token]/cancel/route.ts`**: removed dead insert into notification_queue
- **`automations/page.tsx`**: removed query to notification_queue (hardcoded pendingQueue=0)
- **E2E tests**: removed/updated tests referencing notification_queue (01-emails, 03-cancellation, 04-maintenance)
- **Unit tests**: 9 tests verifying all references removed

## Test plan
- [x] `npx vitest run` — 9/9 new tests passing
- [x] No `notification_queue` references in reschedule routes or automations page
- [x] Migration drops trigger, function rebuilt without queue insert, table dropped
- [x] E2E tests updated to not reference dropped table
- [ ] CI green

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)