### PR TITLE
fix(security): sanitize gallery upload filename to prevent path traversal

### DIFF
--- a/src/__tests__/security/gallery-path-traversal.test.ts
+++ b/src/__tests__/security/gallery-path-traversal.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const source = readFileSync(
+  resolve('src/app/api/gallery/upload/route.ts'),
+  'utf-8',
+);
+
+describe('Gallery upload path traversal prevention (issue #37)', () => {
+  it('has a safeExt sanitizer function', () => {
+    expect(source).toContain('const safeExt');
+    // Must strip non-alphanumeric chars from extension
+    expect(source).toContain("replace(/[^a-zA-Z0-9]/g, '')");
+  });
+
+  it('uses safeExt for main file extension', () => {
+    expect(source).toContain('safeExt(file.name)');
+  });
+
+  it('uses safeExt for before/after file extensions', () => {
+    expect(source).toContain('safeExt(beforeFile.name)');
+    expect(source).toContain('safeExt(afterFile.name)');
+  });
+
+  it('does NOT use raw file.name.split for extension extraction', () => {
+    expect(source).not.toContain("file.name.split('.').pop()");
+    expect(source).not.toContain("beforeFile.name.split('.').pop()");
+    expect(source).not.toContain("afterFile.name.split('.').pop()");
+  });
+
+  it('safeExt correctly sanitizes malicious filenames', () => {
+    // Replicate the safeExt logic from the route
+    const safeExt = (name: string) =>
+      (name.split('.').pop() || 'bin').replace(/[^a-zA-Z0-9]/g, '');
+
+    // Normal extensions pass through
+    expect(safeExt('photo.jpg')).toBe('jpg');
+    expect(safeExt('image.png')).toBe('png');
+
+    // Path traversal: slashes and dots stripped from extension
+    expect(safeExt('../../etc/passwd')).toBe('etcpasswd');
+    expect(safeExt('photo.jpg/../../secret')).toBe('secret');
+    expect(safeExt('file.jpg%00.sh')).toBe('sh');
+
+    // All results are safe for path construction (no slashes, no dots)
+    const dangerous = ['../../etc/passwd', 'file.jpg/../../../etc/shadow', 'a.b%00.c/d'];
+    for (const name of dangerous) {
+      const ext = safeExt(name);
+      expect(ext).not.toContain('/');
+      expect(ext).not.toContain('\\');
+      expect(ext).not.toContain('..');
+      expect(ext).not.toContain('%');
+    }
+
+    // No extension → returns filename itself (sanitized)
+    expect(safeExt('noextension')).toBe('noextension');
+
+    // Special chars stripped
+    expect(safeExt('file.j/p/g')).toBe('jpg');
+  });
+});

--- a/src/app/api/gallery/upload/route.ts
+++ b/src/app/api/gallery/upload/route.ts
@@ -38,13 +38,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'No file provided' }, { status: 400 });
     }
 
+    // Sanitize file extension to prevent path traversal
+    const safeExt = (name: string) =>
+      (name.split('.').pop() || 'bin').replace(/[^a-zA-Z0-9]/g, '');
+
     let imageUrl = '';
     let beforeImageUrl = '';
     let afterImageUrl = '';
 
     // Upload imagem normal
     if (file) {
-      const fileExt = file.name.split('.').pop();
+      const fileExt = safeExt(file.name);
       const fileName = `${user.id}/${Date.now()}.${fileExt}`;
 
       const { data: uploadData, error: uploadError } = await supabase.storage
@@ -65,8 +69,8 @@ export async function POST(request: NextRequest) {
 
     // Upload before/after images
     if (isBeforeAfter && beforeFile && afterFile) {
-      const beforeExt = beforeFile.name.split('.').pop();
-      const afterExt = afterFile.name.split('.').pop();
+      const beforeExt = safeExt(beforeFile.name);
+      const afterExt = safeExt(afterFile.name);
       const beforeFileName = `${user.id}/before_${Date.now()}.${beforeExt}`;
       const afterFileName = `${user.id}/after_${Date.now()}.${afterExt}`;
 


### PR DESCRIPTION
## Summary
- `file.name` was used unsanitized to extract the file extension in gallery upload, allowing crafted filenames like `../../etc/passwd` to construct malicious storage paths
- Now strips all non-alphanumeric characters from file extensions via `safeExt()` helper
- Applied to all 3 upload paths: main file, before file, after file

## Changes
- **`src/app/api/gallery/upload/route.ts`**: added `safeExt()` sanitizer, replaced raw `.split('.').pop()` calls
- **`src/__tests__/security/gallery-path-traversal.test.ts`**: 5 tests verifying sanitization

## Test plan
- [x] `npx vitest run` — 5/5 new tests passing
- [x] Normal extensions pass through (jpg, png)
- [x] Path traversal attempts neutralized (no `/`, `\`, `..`, `%`)
- [x] All 3 file inputs use sanitized extension
- [ ] CI green

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)