### PR TITLE
fix(bot): suppress duplicate greeting + fix retention language and E2E data leak

### DIFF
--- a/src/__tests__/bot/duplicate-greeting-retention.test.ts
+++ b/src/__tests__/bot/duplicate-greeting-retention.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #46: Bot duplicate messages + retention in English with E2E data
+ *
+ * Three bugs fixed:
+ * 1. Greeting lock failure falls through to Claude → duplicate greeting
+ * 2. Maintenance reminder language based on phone prefix only → English for PT-BR professionals
+ * 3. E2E test bookings not filtered → cron sends retention for "[E2E] Teste vida útil"
+ */
+
+// ─── Bug 1: Duplicate greeting suppression ──────────────────────────────────
+
+describe('Bug 1: Greeting lock failure returns empty (no duplicate)', () => {
+  it('chatbot.ts returns empty string when greeting lock fails', () => {
+    const source = readFileSync(resolve('src/lib/ai/chatbot.ts'), 'utf-8');
+
+    // When lock is NOT acquired, should return '' instead of continuing to Claude
+    expect(source).toContain("return '';");
+    // Old behavior should NOT exist: falling through to Claude on lock failure
+    expect(source).not.toContain('processando como mensagem normal');
+  });
+
+  it('processor.ts guards against empty responses', () => {
+    const source = readFileSync(resolve('src/lib/whatsapp/processor.ts'), 'utf-8');
+
+    // Processor should check for empty response before sending
+    expect(source).toContain('if (!response)');
+    expect(source).toContain('duplicata suprimida');
+  });
+});
+
+// ─── Bug 2: Maintenance reminder language resolution ──────────────────────────
+
+describe('Bug 2: Maintenance reminder uses professional locale for language', () => {
+  it('send-maintenance-reminders includes resolveLanguage function', () => {
+    const source = readFileSync(
+      resolve('src/app/api/cron/send-maintenance-reminders/route.ts'),
+      'utf-8'
+    );
+
+    // Should have resolveLanguage that uses professional locale
+    expect(source).toContain('function resolveLanguage');
+    expect(source).toContain('professionalLocale');
+  });
+
+  it('queries professionals with locale field', () => {
+    const source = readFileSync(
+      resolve('src/app/api/cron/send-maintenance-reminders/route.ts'),
+      'utf-8'
+    );
+
+    // Should select locale from professionals
+    expect(source).toContain("'id, user_id, locale'");
+  });
+
+  it('uses resolveLanguage instead of detectLanguage for message generation', () => {
+    const source = readFileSync(
+      resolve('src/app/api/cron/send-maintenance-reminders/route.ts'),
+      'utf-8'
+    );
+
+    // Should call resolveLanguage with professional locale and phone
+    expect(source).toContain('resolveLanguage(profInfo?.locale, phone)');
+    // Old detectLanguage(phone) should NOT be used in the loop
+    expect(source).not.toMatch(/const lang = detectLanguage\(phone\)/);
+  });
+
+  it('resolveLanguage: pt-BR locale returns pt', () => {
+    const source = readFileSync(
+      resolve('src/app/api/cron/send-maintenance-reminders/route.ts'),
+      'utf-8'
+    );
+    // The function checks if locale starts with 'pt'
+    expect(source).toContain("professionalLocale.startsWith('pt')");
+  });
+
+  it('resolveLanguage: falls back to phone prefix when no locale', () => {
+    const source = readFileSync(
+      resolve('src/app/api/cron/send-maintenance-reminders/route.ts'),
+      'utf-8'
+    );
+    // When locale is null/undefined, should fall back to phone detection
+    expect(source).toContain('detectLanguageFromPhone(phone)');
+  });
+});
+
+// ─── Bug 3: E2E data filtered from maintenance reminders ────────────────────
+
+describe('Bug 3: E2E test data filtered from maintenance reminders cron', () => {
+  it('filters out [E2E] prefixed client names', () => {
+    const source = readFileSync(
+      resolve('src/app/api/cron/send-maintenance-reminders/route.ts'),
+      'utf-8'
+    );
+
+    // Should exclude bookings with E2E test client names
+    expect(source).toContain(".not('client_name', 'ilike', '[E2E]%')");
+  });
+
+  it('filters out E2E space-prefixed client names', () => {
+    const source = readFileSync(
+      resolve('src/app/api/cron/send-maintenance-reminders/route.ts'),
+      'utf-8'
+    );
+
+    // Also filters "E2E " prefix (without brackets)
+    expect(source).toContain(".not('client_name', 'ilike', 'E2E %')");
+  });
+
+  it('filters are applied BEFORE the date check (in DB query)', () => {
+    const source = readFileSync(
+      resolve('src/app/api/cron/send-maintenance-reminders/route.ts'),
+      'utf-8'
+    );
+
+    // The E2E filters should be in the same query chain as the other filters
+    const queryBlock = source.slice(
+      source.indexOf(".eq('status', 'completed')"),
+      source.indexOf('if (bookingsError)')
+    );
+    expect(queryBlock).toContain("not('client_name', 'ilike', '[E2E]%')");
+    expect(queryBlock).toContain("not('client_name', 'ilike', 'E2E %')");
+  });
+});
+
+// ─── resolveLanguage unit tests ──────────────────────────────────────────────
+
+describe('resolveLanguage logic (extracted from source)', () => {
+  // Re-implement the function here for unit testing
+  function detectLanguageFromPhone(phone: string): 'pt' | 'en' {
+    const clean = phone.replace(/\D/g, '');
+    if (
+      phone.startsWith('+55') || phone.startsWith('+351') ||
+      clean.startsWith('55') || clean.startsWith('351')
+    ) return 'pt';
+    return 'en';
+  }
+
+  function resolveLanguage(
+    professionalLocale: string | null | undefined,
+    phone: string
+  ): 'pt' | 'en' {
+    if (professionalLocale) {
+      if (professionalLocale.startsWith('pt')) return 'pt';
+      if (professionalLocale.startsWith('en')) return 'en';
+      if (professionalLocale.startsWith('es')) return 'pt';
+    }
+    return detectLanguageFromPhone(phone);
+  }
+
+  it('returns pt for pt-BR locale regardless of phone', () => {
+    expect(resolveLanguage('pt-BR', '+353851234567')).toBe('pt');
+    expect(resolveLanguage('pt-BR', '+441234567890')).toBe('pt');
+  });
+
+  it('returns en for en-US locale regardless of phone', () => {
+    expect(resolveLanguage('en-US', '+5511999999999')).toBe('en');
+  });
+
+  it('returns pt for es-ES locale (closest template)', () => {
+    expect(resolveLanguage('es-ES', '+34612345678')).toBe('pt');
+  });
+
+  it('falls back to phone prefix when locale is null', () => {
+    expect(resolveLanguage(null, '+5511999999999')).toBe('pt');
+    expect(resolveLanguage(null, '+353851234567')).toBe('en');
+  });
+
+  it('falls back to phone prefix when locale is undefined', () => {
+    expect(resolveLanguage(undefined, '+351912345678')).toBe('pt');
+    expect(resolveLanguage(undefined, '+442071234567')).toBe('en');
+  });
+
+  it('handles Brazilian phone without + prefix', () => {
+    expect(resolveLanguage(null, '5511999999999')).toBe('pt');
+  });
+
+  it('handles Portuguese phone without + prefix', () => {
+    expect(resolveLanguage(null, '351912345678')).toBe('pt');
+  });
+});

--- a/src/app/api/cron/send-maintenance-reminders/route.ts
+++ b/src/app/api/cron/send-maintenance-reminders/route.ts
@@ -3,7 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { NextRequest, NextResponse } from 'next/server';
 import { normalizePhoneForWhatsApp } from '@/lib/whatsapp/evolution';
 
-function detectLanguage(phone: string): 'pt' | 'en' {
+function detectLanguageFromPhone(phone: string): 'pt' | 'en' {
   // Aceita com ou sem '+' (ex: '+5511...' e '5511...' são ambos Brasil)
   const clean = phone.replace(/\D/g, '');
   if (
@@ -11,6 +11,16 @@ function detectLanguage(phone: string): 'pt' | 'en' {
     clean.startsWith('55') || clean.startsWith('351')
   ) return 'pt';
   return 'en';
+}
+
+/** Determina idioma: locale do profissional > prefixo do telefone */
+function resolveLanguage(professionalLocale: string | null | undefined, phone: string): 'pt' | 'en' {
+  if (professionalLocale) {
+    if (professionalLocale.startsWith('pt')) return 'pt';
+    if (professionalLocale.startsWith('en')) return 'en';
+    if (professionalLocale.startsWith('es')) return 'pt'; // espanhol → template PT (mais próximo)
+  }
+  return detectLanguageFromPhone(phone);
 }
 
 const MESSAGE_TEMPLATES = {
@@ -58,7 +68,9 @@ export async function POST(request: NextRequest) {
       )
       .eq('status', 'completed')
       .eq('maintenance_reminder_sent', false)
-      .not('completed_at', 'is', null);
+      .not('completed_at', 'is', null)
+      .not('client_name', 'ilike', '[E2E]%')
+      .not('client_name', 'ilike', 'E2E %');
 
     if (bookingsError) {
       throw new Error(`Error fetching bookings: ${bookingsError.message}`);
@@ -120,12 +132,12 @@ export async function POST(request: NextRequest) {
 
     const { data: professionals } = await supabase
       .from('professionals')
-      .select('id, user_id')
+      .select('id, user_id, locale')
       .in('id', professionalIds);
 
-    const profMap = new Map((professionals ?? []).map((p) => [p.id, p.user_id]));
+    const profMap = new Map((professionals ?? []).map((p) => [p.id, { user_id: p.user_id, locale: p.locale }]));
 
-    const userIds = (professionals ?? []).map((p) => p.user_id).filter(Boolean);
+    const userIds = (professionals ?? []).map((p) => p.user_id).filter(Boolean) as string[];
     const { data: whatsappConfigs } = await supabase
       .from('whatsapp_config')
       .select('user_id, provider, evolution_api_url, evolution_api_key, evolution_instance, phone_number_id, access_token, is_active')
@@ -171,16 +183,17 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
-        const lang = detectLanguage(phone);
+        // Obter config do profissional
+        const profInfo = profMap.get(booking.professional_id);
+        const userId = profInfo?.user_id;
+        const wc = userId ? wcMap.get(userId) : undefined;
+
+        const lang = resolveLanguage(profInfo?.locale, phone);
         const message = MESSAGE_TEMPLATES[lang](
           booking.client_name,
           service.lifetime_days,
           service.name
         );
-
-        // Obter config WhatsApp do profissional
-        const userId = profMap.get(booking.professional_id);
-        const wc = userId ? wcMap.get(userId) : undefined;
 
         let sent = false;
 

--- a/src/lib/ai/chatbot.ts
+++ b/src/lib/ai/chatbot.ts
@@ -116,10 +116,10 @@ export class AIBot {
         // Lock distribuído: evita race condition quando mensagens chegam simultaneamente
         const lockAcquired = await ConversationCache.acquireGreetingLock(cacheKey);
         if (!lockAcquired) {
-          logger.info(`🔒 Greeting já enviado por outro processo — processando como mensagem normal`);
-          // Aguarda brevemente para o histórico ser salvo pelo processo que ganhou o lock
-          await new Promise(r => setTimeout(r, 500));
-          // Continua para processamento normal (Claude responde às perguntas)
+          logger.info(`🔒 Greeting já enviado por outro processo — ignorando duplicata`);
+          // Outro processo já está tratando esta saudação — retornar vazio
+          // para que o processor NÃO envie uma segunda mensagem.
+          return '';
         } else {
           logger.info(`👋 Saudação direta (bypass Claude): "${greeting}"`);
           const entry = memoryCache.get(cacheKey) || { conversationId: context.conversationId, messages: [] };

--- a/src/lib/whatsapp/processor.ts
+++ b/src/lib/whatsapp/processor.ts
@@ -74,6 +74,12 @@ export async function processWhatsAppMessage(
     const bot = new AIBot();
     const response = await bot.processMessage(from, text, config.user_id);
 
+    // Resposta vazia = duplicata suprimida pelo greeting lock — não enviar nada
+    if (!response) {
+      logger.info('⏭️ Resposta vazia (duplicata suprimida) — nada a enviar');
+      return;
+    }
+
     // Enviar resposta pelo provider correto
     if (provider === 'evolution') {
       await sendEvolutionMessage(from, response, {


### PR DESCRIPTION
## Summary

Fixes three bugs reported in #46:

- **Duplicate greeting**: When greeting lock fails (race condition), bot returned empty string instead of falling through to Claude (which generated a second greeting). Added guard in processor.ts to skip sending empty responses.
- **Retention in English**: Maintenance reminder cron used phone prefix only for language detection. Now uses professional's `locale` from DB, falling back to phone prefix when locale is not set.
- **E2E data leaking**: Maintenance reminder cron processed test bookings (`[E2E]` prefix). Added `.not('client_name', 'ilike', '[E2E]%')` filter to the DB query.

## Test plan

- [x] 17 unit tests covering all three fixes
- [x] `tsc --noEmit` clean
- [x] `npm run test:fast` — 299 passed (2 pre-existing failures in unsubscribe.test.ts)
- [ ] CI green

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)