### PR TITLE
fix(bot): use positive status filter for conflict checks (pending_payment)

### DIFF
--- a/src/__tests__/bookings/double-booking-pending-payment.test.ts
+++ b/src/__tests__/bookings/double-booking-pending-payment.test.ts
@@ -206,15 +206,15 @@ describe('Double-booking — code verification (#3)', () => {
     expect(source).toContain(".in('status', ['confirmed', 'pending_payment'])");
   });
 
-  it('chatbot conflict check excludes cancelled/completed (catches pending_payment)', async () => {
+  it('chatbot conflict check uses positive status filter (catches pending_payment)', async () => {
     const { readFileSync } = await import('fs');
     const { join } = await import('path');
     const chatbotPath = join(process.cwd(), 'src/lib/ai/chatbot.ts');
     const source = readFileSync(chatbotPath, 'utf-8');
 
-    // Chatbot uses .neq('status', 'cancelled').neq('status', 'completed')
-    // which naturally includes pending_payment
-    expect(source).toContain(".neq('status', 'cancelled')");
-    expect(source).toContain(".neq('status', 'completed')");
+    // Chatbot uses .in('status', ['confirmed', 'pending_payment'])
+    // which explicitly treats pending_payment as occupied
+    expect(source).toContain(".in('status', ['confirmed', 'pending_payment'])");
+    expect(source).not.toContain(".neq('status', 'cancelled')");
   });
 });

--- a/src/__tests__/bot/pending-payment-conflict.test.ts
+++ b/src/__tests__/bot/pending-payment-conflict.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #8: Bot ignores pending_payment as occupied slot
+ *
+ * All conflict checks in chatbot.ts must use positive filter
+ * .in('status', ['confirmed', 'pending_payment']) instead of
+ * negative filter .neq('status', 'cancelled').neq('status', 'completed')
+ */
+
+const chatbotPath = resolve('src/lib/ai/chatbot.ts');
+
+describe('Bot: pending_payment treated as occupied slot (issue #8)', () => {
+  const source = readFileSync(chatbotPath, 'utf-8');
+
+  it('uses positive status filter for check_availability conflict query', () => {
+    // check_availability: "Verificar conflitos reais com agendamentos existentes"
+    expect(source).toContain(".in('status', ['confirmed', 'pending_payment'])");
+  });
+
+  it('uses positive status filter for createAppointment conflict query', () => {
+    // createAppointment: "5. Verificar conflitos de horário"
+    const createSection = source.slice(source.indexOf('5. Verificar conflitos de horário'));
+    expect(createSection).toContain(".in('status', ['confirmed', 'pending_payment'])");
+  });
+
+  it('uses positive status filter for future bookings duplicate check', () => {
+    // createAppointment: "3. Verificar agendamentos futuros do mesmo cliente"
+    const futureSection = source.slice(source.indexOf('agendamentos futuros do mesmo cliente'));
+    expect(futureSection).toContain(".in('status', ['confirmed', 'pending_payment'])");
+  });
+
+  it('uses positive status filter for tomorrow availability check', () => {
+    // suggestAlternative: tomorrow bookings query
+    const tomorrowSection = source.slice(source.indexOf("eq('booking_date', tomorrowStr)"));
+    expect(tomorrowSection).toContain(".in('status', ['confirmed', 'pending_payment'])");
+  });
+
+  it('does NOT use negative .neq status filters for conflict queries', () => {
+    // Ensure no .neq('status', 'cancelled') remains
+    expect(source).not.toContain(".neq('status', 'cancelled')");
+    expect(source).not.toContain(".neq('status', 'completed')");
+  });
+
+  it('has at least 4 positive status filters (one per query)', () => {
+    const matches = source.match(/\.in\('status', \['confirmed', 'pending_payment'\]\)/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('bookings/route.ts also uses positive filter (consistency check)', () => {
+    const bookingsSource = readFileSync(
+      resolve('src/app/api/bookings/route.ts'),
+      'utf-8'
+    );
+    expect(bookingsSource).toContain(".in('status', ['confirmed', 'pending_payment'])");
+  });
+});

--- a/src/lib/ai/chatbot.ts
+++ b/src/lib/ai/chatbot.ts
@@ -523,8 +523,7 @@ NUNCA chame cancel_appointment + create_appointment separadamente para reagendar
         .select('start_time, end_time')
         .eq('professional_id', professionalId)
         .eq('booking_date', normalizedDate)
-        .neq('status', 'cancelled')
-        .neq('status', 'completed');
+        .in('status', ['confirmed', 'pending_payment']);
 
       if (existingBookings && existingBookings.length > 0) {
         const BUFFER = 15;
@@ -693,8 +692,7 @@ NUNCA chame cancel_appointment + create_appointment separadamente para reagendar
         .eq('professional_id', professionalId)
         .eq('client_phone', clientPhone)
         .gte('booking_date', todayISO)
-        .neq('status', 'cancelled')
-        .neq('status', 'completed')
+        .in('status', ['confirmed', 'pending_payment'])
         .order('booking_date', { ascending: true });
 
       if (futureBookings && futureBookings.length > 0) {
@@ -749,8 +747,7 @@ NUNCA chame cancel_appointment + create_appointment separadamente para reagendar
         .select('start_time, end_time')
         .eq('professional_id', professionalId)
         .eq('booking_date', bookingDate)
-        .neq('status', 'cancelled')
-        .neq('status', 'completed');
+        .in('status', ['confirmed', 'pending_payment']);
 
       if (existingBookings && existingBookings.length > 0) {
         const reqStart = timeToMinutes(bookingTime);
@@ -808,8 +805,7 @@ NUNCA chame cancel_appointment + create_appointment separadamente para reagendar
                 .select('start_time, end_time')
                 .eq('professional_id', professionalId)
                 .eq('booking_date', tomorrowStr)
-                .neq('status', 'cancelled')
-                .neq('status', 'completed'),
+                .in('status', ['confirmed', 'pending_payment']),
             ]);
 
             logger.info(`🗓️ Working hours amanhã (day_int=${tomorrowDayInt}, data=${tomorrowStr}):`, tomorrowWH ? `${tomorrowWH.start_time}–${tomorrowWH.end_time}` : 'não atende');


### PR DESCRIPTION
## Summary

- Replace `.neq('status', 'cancelled').neq('status', 'completed')` with `.in('status', ['confirmed', 'pending_payment'])` in all 4 conflict queries in `chatbot.ts`
- `check_availability`, `createAppointment`, future bookings duplicate check, and tomorrow availability all now explicitly treat `pending_payment` as occupied
- Positive filter is safer: new statuses (like `expired`) won't accidentally block slots
- Updated existing `double-booking-pending-payment.test.ts` to match new pattern

## Test plan

- [x] 7 new unit tests verifying positive filter in all queries
- [x] Existing double-booking test updated
- [x] `tsc --noEmit` clean
- [x] `npm run test:fast` — 319 passed (2 pre-existing failures in unsubscribe.test.ts)
- [ ] CI green

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)