### PR TITLE
fix(security): replace static admin cookie with HMAC-signed token + rate limiting

### DIFF
--- a/src/__tests__/security/admin-session.test.ts
+++ b/src/__tests__/security/admin-session.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #19: Admin auth uses static cookie without rate limiting
+ *
+ * Fixes:
+ * 1. Token is unique per session (crypto.randomUUID + HMAC signature)
+ * 2. Token is validated via HMAC (not compared to static '1')
+ * 3. Rate limiting: 5 attempts per IP per 15 minutes
+ * 4. Expiration reduced from 24h to 8h
+ */
+
+// ─── Token generation and validation ─────────────────────────────────────────
+
+describe('Admin session token (issue #19)', () => {
+  beforeEach(() => {
+    vi.stubEnv('ADMIN_PASSWORD', 'test-secret-password-123');
+  });
+
+  it('generates unique tokens on each call', async () => {
+    const { generateAdminToken } = await import('@/lib/admin/session');
+    const t1 = generateAdminToken();
+    const t2 = generateAdminToken();
+    expect(t1.token).not.toBe(t2.token);
+  });
+
+  it('generated token has 3 parts (sessionId.timestamp.signature)', async () => {
+    const { generateAdminToken } = await import('@/lib/admin/session');
+    const { token } = generateAdminToken();
+    const parts = token.split('.');
+    expect(parts).toHaveLength(3);
+    // sessionId is a UUID
+    expect(parts[0]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
+    // timestamp is numeric
+    expect(parseInt(parts[1])).toBeGreaterThan(0);
+    // signature is hex
+    expect(parts[2]).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('validates a freshly generated token', async () => {
+    const { generateAdminToken, validateAdminToken } = await import('@/lib/admin/session');
+    const { token } = generateAdminToken();
+    expect(validateAdminToken(token)).toBe(true);
+  });
+
+  it('rejects undefined/empty tokens', async () => {
+    const { validateAdminToken } = await import('@/lib/admin/session');
+    expect(validateAdminToken(undefined)).toBe(false);
+    expect(validateAdminToken('')).toBe(false);
+  });
+
+  it('rejects the old static value "1"', async () => {
+    const { validateAdminToken } = await import('@/lib/admin/session');
+    expect(validateAdminToken('1')).toBe(false);
+  });
+
+  it('rejects a forged token with wrong signature', async () => {
+    const { generateAdminToken, validateAdminToken } = await import('@/lib/admin/session');
+    const { token } = generateAdminToken();
+    const parts = token.split('.');
+    parts[2] = 'a'.repeat(64); // forged signature
+    expect(validateAdminToken(parts.join('.'))).toBe(false);
+  });
+
+  it('rejects a token with tampered sessionId', async () => {
+    const { generateAdminToken, validateAdminToken } = await import('@/lib/admin/session');
+    const { token } = generateAdminToken();
+    const parts = token.split('.');
+    parts[0] = '00000000-0000-4000-a000-000000000099'; // different UUID
+    expect(validateAdminToken(parts.join('.'))).toBe(false);
+  });
+
+  it('sets expiration to 8 hours', async () => {
+    const { generateAdminToken } = await import('@/lib/admin/session');
+    const before = Date.now();
+    const { expires } = generateAdminToken();
+    const after = Date.now();
+    const eightHoursMs = 8 * 60 * 60 * 1000;
+    expect(expires.getTime()).toBeGreaterThanOrEqual(before + eightHoursMs - 100);
+    expect(expires.getTime()).toBeLessThanOrEqual(after + eightHoursMs + 100);
+  });
+});
+
+// ─── Rate limiting ───────────────────────────────────────────────────────────
+
+describe('Admin rate limiting (issue #19)', () => {
+  it('allows first 5 attempts from same IP', async () => {
+    // Use fresh import to reset state
+    vi.resetModules();
+    const { isRateLimited } = await import('@/lib/admin/session');
+    const testIp = `rate-test-${Date.now()}`;
+    for (let i = 0; i < 5; i++) {
+      expect(isRateLimited(testIp)).toBe(false);
+    }
+  });
+
+  it('blocks 6th attempt from same IP', async () => {
+    vi.resetModules();
+    const { isRateLimited } = await import('@/lib/admin/session');
+    const testIp = `rate-block-${Date.now()}`;
+    for (let i = 0; i < 5; i++) {
+      isRateLimited(testIp);
+    }
+    expect(isRateLimited(testIp)).toBe(true);
+  });
+
+  it('allows attempts from different IPs', async () => {
+    vi.resetModules();
+    const { isRateLimited } = await import('@/lib/admin/session');
+    const ts = Date.now();
+    expect(isRateLimited(`ip-a-${ts}`)).toBe(false);
+    expect(isRateLimited(`ip-b-${ts}`)).toBe(false);
+    expect(isRateLimited(`ip-c-${ts}`)).toBe(false);
+  });
+});
+
+// ─── Code verification ───────────────────────────────────────────────────────
+
+describe('Admin auth code verification (issue #19)', () => {
+  it('auth route uses generateAdminToken (not static "1")', () => {
+    const source = readFileSync(
+      resolve('src/app/api/admin/auth/route.ts'),
+      'utf-8'
+    );
+    expect(source).toContain('generateAdminToken');
+    expect(source).not.toContain("'1'");
+  });
+
+  it('auth route has rate limiting', () => {
+    const source = readFileSync(
+      resolve('src/app/api/admin/auth/route.ts'),
+      'utf-8'
+    );
+    expect(source).toContain('isRateLimited');
+    expect(source).toContain('429');
+  });
+
+  it('auth route sets secure cookie flag', () => {
+    const source = readFileSync(
+      resolve('src/app/api/admin/auth/route.ts'),
+      'utf-8'
+    );
+    expect(source).toContain('secure: true');
+  });
+
+  it('admin layout uses validateAdminToken', () => {
+    const source = readFileSync(
+      resolve('src/app/[locale]/(admin)/layout.tsx'),
+      'utf-8'
+    );
+    expect(source).toContain('validateAdminToken');
+    expect(source).not.toContain("!== '1'");
+  });
+
+  const adminRoutes = [
+    'src/app/api/admin/control-center/route.ts',
+    'src/app/api/admin/control-center/[id]/resolve/route.ts',
+    'src/app/api/admin/bot-e2e-toggle/route.ts',
+    'src/app/api/admin/leads/[id]/toggle-bot/route.ts',
+    'src/app/api/admin/leads/[id]/message/route.ts',
+    'src/app/api/admin/evolution/check-connection/route.ts',
+    'src/app/api/admin/evolution/create-instance/route.ts',
+    'src/app/api/admin/restore-account/route.ts',
+  ];
+
+  for (const route of adminRoutes) {
+    it(`${route} uses validateAdminToken`, () => {
+      const source = readFileSync(resolve(route), 'utf-8');
+      expect(source).toContain('validateAdminToken');
+      expect(source).not.toContain("!== '1'");
+    });
+  }
+});

--- a/src/app/[locale]/(admin)/layout.tsx
+++ b/src/app/[locale]/(admin)/layout.tsx
@@ -11,9 +11,10 @@ export default async function AdminLayout({
   children: React.ReactNode;
 }) {
   const cookieStore = await cookies();
+  const { validateAdminToken } = await import('@/lib/admin/session');
   const adminSession = cookieStore.get('admin_session');
 
-  if (adminSession?.value !== '1') {
+  if (!validateAdminToken(adminSession?.value)) {
     redirect('/admin-login');
   }
 

--- a/src/app/api/admin/auth/route.ts
+++ b/src/app/api/admin/auth/route.ts
@@ -1,16 +1,27 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { generateAdminToken, isRateLimited } from '@/lib/admin/session';
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
+  // Rate limiting by IP
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  if (isRateLimited(ip)) {
+    return NextResponse.json(
+      { error: 'Muitas tentativas. Tente novamente em 15 minutos.' },
+      { status: 429 }
+    );
+  }
+
   const { password } = await request.json();
 
   if (!process.env.ADMIN_PASSWORD || password !== process.env.ADMIN_PASSWORD) {
     return NextResponse.json({ error: 'Senha incorreta' }, { status: 401 });
   }
 
-  const expires = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  const { token, expires } = generateAdminToken();
   const response = NextResponse.json({ ok: true });
-  response.cookies.set('admin_session', '1', {
+  response.cookies.set('admin_session', token, {
     httpOnly: true,
+    secure: true,
     sameSite: 'lax',
     path: '/',
     expires,

--- a/src/app/api/admin/bot-e2e-toggle/route.ts
+++ b/src/app/api/admin/bot-e2e-toggle/route.ts
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { validateAdminToken } from '@/lib/admin/session';
 
 const REPO = 'Gabiribpin/circlehood-booking';
 const VAR_NAME = 'BOT_E2E_ENABLED';
@@ -18,7 +19,7 @@ function ghHeaders(token: string) {
 
 export async function GET() {
   const cookieStore = await cookies();
-  if (cookieStore.get('admin_session')?.value !== '1') {
+  if (!validateAdminToken(cookieStore.get('admin_session')?.value)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
@@ -50,7 +51,7 @@ export async function GET() {
 
 export async function PATCH(request: Request) {
   const cookieStore = await cookies();
-  if (cookieStore.get('admin_session')?.value !== '1') {
+  if (!validateAdminToken(cookieStore.get('admin_session')?.value)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/admin/control-center/[id]/resolve/route.ts
+++ b/src/app/api/admin/control-center/[id]/resolve/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { validateAdminToken } from '@/lib/admin/session';
 
 export async function PATCH(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const cookieStore = await cookies();
-  if (cookieStore.get('admin_session')?.value !== '1') {
+  if (!validateAdminToken(cookieStore.get('admin_session')?.value)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/admin/control-center/route.ts
+++ b/src/app/api/admin/control-center/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { validateAdminToken } from '@/lib/admin/session';
 
 export async function GET() {
   const cookieStore = await cookies();
-  if (cookieStore.get('admin_session')?.value !== '1') {
+  if (!validateAdminToken(cookieStore.get('admin_session')?.value)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
@@ -23,7 +24,7 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   const cookieStore = await cookies();
-  if (cookieStore.get('admin_session')?.value !== '1') {
+  if (!validateAdminToken(cookieStore.get('admin_session')?.value)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/admin/evolution/check-connection/route.ts
+++ b/src/app/api/admin/evolution/check-connection/route.ts
@@ -3,13 +3,14 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { evolutionConfig } from '@/lib/evolution/config';
+import { validateAdminToken } from '@/lib/admin/session';
 
 const SALES_INSTANCE = process.env.EVOLUTION_INSTANCE_SALES ?? 'circlehood-sales';
 
 export async function GET() {
   try {
     const cookieStore = await cookies();
-    if (cookieStore.get('admin_session')?.value !== '1') {
+    if (!validateAdminToken(cookieStore.get('admin_session')?.value)) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 

--- a/src/app/api/admin/evolution/create-instance/route.ts
+++ b/src/app/api/admin/evolution/create-instance/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { evolutionConfig } from '@/lib/evolution/config';
+import { validateAdminToken } from '@/lib/admin/session';
 
 const SALES_INSTANCE = process.env.EVOLUTION_INSTANCE_SALES ?? 'circlehood-sales';
 const SYSTEM_USER_ID = '00000000-0000-4000-a000-000000000000';
@@ -10,7 +11,7 @@ const SYSTEM_USER_ID = '00000000-0000-4000-a000-000000000000';
 export async function POST(request: NextRequest) {
   try {
     const cookieStore = await cookies();
-    if (cookieStore.get('admin_session')?.value !== '1') {
+    if (!validateAdminToken(cookieStore.get('admin_session')?.value)) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 

--- a/src/app/api/admin/leads/[id]/message/route.ts
+++ b/src/app/api/admin/leads/[id]/message/route.ts
@@ -2,6 +2,7 @@ import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { validateAdminToken } from '@/lib/admin/session';
 
 export async function POST(
   request: NextRequest,
@@ -9,7 +10,7 @@ export async function POST(
 ) {
   // Auth: verificar cookie admin_session
   const cookieStore = await cookies();
-  if (cookieStore.get('admin_session')?.value !== '1') {
+  if (!validateAdminToken(cookieStore.get('admin_session')?.value)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/admin/leads/[id]/toggle-bot/route.ts
+++ b/src/app/api/admin/leads/[id]/toggle-bot/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { validateAdminToken } from '@/lib/admin/session';
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const cookieStore = await cookies();
-  if (cookieStore.get('admin_session')?.value !== '1') {
+  if (!validateAdminToken(cookieStore.get('admin_session')?.value)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/admin/restore-account/route.ts
+++ b/src/app/api/admin/restore-account/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { validateAdminToken } from '@/lib/admin/session';
 
 export async function POST(request: NextRequest) {
   const cookieStore = await cookies();
-  const adminSession = cookieStore.get('admin_session');
-  if (adminSession?.value !== '1') {
+  if (!validateAdminToken(cookieStore.get('admin_session')?.value)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/lib/admin/session.ts
+++ b/src/lib/admin/session.ts
@@ -1,0 +1,88 @@
+import { createHmac, randomUUID } from 'crypto';
+
+const SESSION_EXPIRY_HOURS = 8;
+
+/**
+ * Generates a signed admin session token.
+ * Format: `${sessionId}.${timestamp}.${signature}`
+ *
+ * Self-validating: no server-side storage needed.
+ * Each login generates a unique token (randomUUID).
+ */
+export function generateAdminToken(): { token: string; expires: Date } {
+  const secret = process.env.ADMIN_PASSWORD;
+  if (!secret) throw new Error('ADMIN_PASSWORD not configured');
+
+  const sessionId = randomUUID();
+  const timestamp = Date.now().toString();
+  const payload = `${sessionId}.${timestamp}`;
+  const signature = createHmac('sha256', secret).update(payload).digest('hex');
+  const token = `${payload}.${signature}`;
+
+  const expires = new Date(Date.now() + SESSION_EXPIRY_HOURS * 60 * 60 * 1000);
+  return { token, expires };
+}
+
+/**
+ * Validates an admin session token.
+ * Returns true if:
+ * 1. Token has correct format (3 parts)
+ * 2. HMAC signature matches
+ * 3. Token has not expired (based on embedded timestamp)
+ */
+export function validateAdminToken(token: string | undefined): boolean {
+  if (!token) return false;
+
+  const secret = process.env.ADMIN_PASSWORD;
+  if (!secret) return false;
+
+  const parts = token.split('.');
+  if (parts.length !== 3) return false;
+
+  const [sessionId, timestamp, signature] = parts;
+  if (!sessionId || !timestamp || !signature) return false;
+
+  // Verify signature
+  const payload = `${sessionId}.${timestamp}`;
+  const expected = createHmac('sha256', secret).update(payload).digest('hex');
+
+  // Timing-safe comparison
+  if (signature.length !== expected.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < signature.length; i++) {
+    mismatch |= signature.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  if (mismatch !== 0) return false;
+
+  // Check expiration
+  const ts = parseInt(timestamp, 10);
+  if (isNaN(ts)) return false;
+  const age = Date.now() - ts;
+  if (age > SESSION_EXPIRY_HOURS * 60 * 60 * 1000) return false;
+
+  return true;
+}
+
+// ─── Rate Limiting ────────────────────────────────────────────────────────────
+
+const MAX_ATTEMPTS = 5;
+const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+const attempts = new Map<string, { count: number; resetAt: number }>();
+
+/**
+ * Checks if an IP has exceeded the login rate limit.
+ * Returns true if the request should be BLOCKED.
+ */
+export function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = attempts.get(ip);
+
+  if (!entry || now > entry.resetAt) {
+    attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+    return false;
+  }
+
+  entry.count++;
+  return entry.count > MAX_ATTEMPTS;
+}


### PR DESCRIPTION
## Summary

- **HMAC-signed tokens**: Each login generates a unique token (`sessionId.timestamp.signature`) using `crypto.randomUUID()` + HMAC-SHA256. Self-validating — no server-side storage needed.
- **Rate limiting**: 5 login attempts per IP per 15 minutes. Returns 429 on excess.
- **Reduced expiration**: 24h → 8h
- **Secure cookie flag**: Added `secure: true`
- **All 9 verification points updated**: Layout + 8 API routes now use `validateAdminToken()` instead of comparing to static `'1'`
- Cookie value `'1'` is now rejected — forged cookies no longer work

## Test plan

- [x] 23 unit tests: token generation uniqueness, HMAC validation, forged/tampered/static token rejection, rate limiting (5 allowed, 6th blocked), code verification for all 9 files
- [x] `tsc --noEmit` clean
- [x] `npm run test:fast` — 342 passed (2 pre-existing failures in unsubscribe.test.ts)
- [ ] CI green

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)