### PR TITLE
fix(security): add signature validation to sales-bot and Resend webhooks

### DIFF
--- a/src/__tests__/security/webhook-signatures.test.ts
+++ b/src/__tests__/security/webhook-signatures.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHmac } from 'crypto';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #20: Webhook signature validation
+ *
+ * Fixes:
+ * 1. sales-bot webhook validates Evolution API `apikey` header
+ * 2. Resend webhook validates Svix signatures (HMAC-SHA256 + timestamp tolerance)
+ */
+
+// ─── Evolution API webhook validation ────────────────────────────────────────
+
+describe('validateEvolutionWebhook (issue #20)', () => {
+  it('returns true when apikey header matches secret', async () => {
+    const { validateEvolutionWebhook } = await import('@/lib/webhooks/signature');
+    expect(validateEvolutionWebhook('my-secret-key', 'my-secret-key')).toBe(true);
+  });
+
+  it('returns false when apikey header does not match', async () => {
+    const { validateEvolutionWebhook } = await import('@/lib/webhooks/signature');
+    expect(validateEvolutionWebhook('wrong-key', 'my-secret-key')).toBe(false);
+  });
+
+  it('returns false when apikey header is null', async () => {
+    const { validateEvolutionWebhook } = await import('@/lib/webhooks/signature');
+    expect(validateEvolutionWebhook(null, 'my-secret-key')).toBe(false);
+  });
+
+  it('returns false when secret is undefined', async () => {
+    const { validateEvolutionWebhook } = await import('@/lib/webhooks/signature');
+    expect(validateEvolutionWebhook('some-key', undefined)).toBe(false);
+  });
+
+  it('returns false when both are empty strings', async () => {
+    const { validateEvolutionWebhook } = await import('@/lib/webhooks/signature');
+    expect(validateEvolutionWebhook('', '')).toBe(false);
+  });
+
+  it('is case-sensitive', async () => {
+    const { validateEvolutionWebhook } = await import('@/lib/webhooks/signature');
+    expect(validateEvolutionWebhook('MySecret', 'mysecret')).toBe(false);
+  });
+});
+
+// ─── Resend / Svix webhook validation ────────────────────────────────────────
+
+describe('validateResendWebhook (issue #20)', () => {
+  const secret = 'whsec_' + Buffer.from('test-secret-key-32bytes!!').toString('base64');
+
+  function signPayload(svixId: string, timestamp: string, body: string) {
+    const rawSecret = secret.slice(6);
+    const secretBytes = Buffer.from(rawSecret, 'base64');
+    const signedContent = `${svixId}.${timestamp}.${body}`;
+    const sig = createHmac('sha256', secretBytes).update(signedContent).digest('base64');
+    return `v1,${sig}`;
+  }
+
+  it('returns true for valid signature', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    const body = '{"type":"email.delivered"}';
+    const svixId = 'msg_abc123';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = signPayload(svixId, timestamp, body);
+
+    expect(validateResendWebhook(body, {
+      'svix-id': svixId,
+      'svix-timestamp': timestamp,
+      'svix-signature': signature,
+    }, secret)).toBe(true);
+  });
+
+  it('returns true when valid signature is among multiple', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    const body = '{"type":"email.opened"}';
+    const svixId = 'msg_multi';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const validSig = signPayload(svixId, timestamp, body);
+    const signatures = `v1,invalidbase64garbage ${validSig}`;
+
+    expect(validateResendWebhook(body, {
+      'svix-id': svixId,
+      'svix-timestamp': timestamp,
+      'svix-signature': signatures,
+    }, secret)).toBe(true);
+  });
+
+  it('returns false for wrong signature', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    const body = '{"type":"email.delivered"}';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+
+    expect(validateResendWebhook(body, {
+      'svix-id': 'msg_wrong',
+      'svix-timestamp': timestamp,
+      'svix-signature': 'v1,dGhpc2lzaW52YWxpZA==',
+    }, secret)).toBe(false);
+  });
+
+  it('returns false when secret is undefined', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    expect(validateResendWebhook('{}', {
+      'svix-id': 'msg_1',
+      'svix-timestamp': '1234567890',
+      'svix-signature': 'v1,abc',
+    }, undefined)).toBe(false);
+  });
+
+  it('returns false when svix-id is missing', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    expect(validateResendWebhook('{}', {
+      'svix-id': null,
+      'svix-timestamp': '1234567890',
+      'svix-signature': 'v1,abc',
+    }, secret)).toBe(false);
+  });
+
+  it('returns false when svix-timestamp is missing', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    expect(validateResendWebhook('{}', {
+      'svix-id': 'msg_1',
+      'svix-timestamp': null,
+      'svix-signature': 'v1,abc',
+    }, secret)).toBe(false);
+  });
+
+  it('returns false when svix-signature is missing', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    expect(validateResendWebhook('{}', {
+      'svix-id': 'msg_1',
+      'svix-timestamp': '1234567890',
+      'svix-signature': null,
+    }, secret)).toBe(false);
+  });
+
+  it('returns false when timestamp is too old (replay attack)', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    const body = '{"type":"email.delivered"}';
+    const svixId = 'msg_old';
+    const oldTimestamp = (Math.floor(Date.now() / 1000) - 600).toString(); // 10 min ago
+    const signature = signPayload(svixId, oldTimestamp, body);
+
+    expect(validateResendWebhook(body, {
+      'svix-id': svixId,
+      'svix-timestamp': oldTimestamp,
+      'svix-signature': signature,
+    }, secret)).toBe(false);
+  });
+
+  it('returns false when timestamp is in the future', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    const body = '{"type":"email.delivered"}';
+    const svixId = 'msg_future';
+    const futureTimestamp = (Math.floor(Date.now() / 1000) + 600).toString();
+    const signature = signPayload(svixId, futureTimestamp, body);
+
+    expect(validateResendWebhook(body, {
+      'svix-id': svixId,
+      'svix-timestamp': futureTimestamp,
+      'svix-signature': signature,
+    }, secret)).toBe(false);
+  });
+
+  it('returns false when timestamp is not a number', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    expect(validateResendWebhook('{}', {
+      'svix-id': 'msg_1',
+      'svix-timestamp': 'not-a-number',
+      'svix-signature': 'v1,abc',
+    }, secret)).toBe(false);
+  });
+
+  it('returns false when body was tampered with', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    const originalBody = '{"type":"email.delivered"}';
+    const svixId = 'msg_tamper';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = signPayload(svixId, timestamp, originalBody);
+
+    // Tamper with the body
+    expect(validateResendWebhook('{"type":"email.bounced"}', {
+      'svix-id': svixId,
+      'svix-timestamp': timestamp,
+      'svix-signature': signature,
+    }, secret)).toBe(false);
+  });
+
+  it('handles secret without whsec_ prefix', async () => {
+    const { validateResendWebhook } = await import('@/lib/webhooks/signature');
+    const rawSecret = Buffer.from('test-secret-key-32bytes!!').toString('base64');
+    const body = '{"type":"email.delivered"}';
+    const svixId = 'msg_noprefix';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+
+    const secretBytes = Buffer.from(rawSecret, 'base64');
+    const signedContent = `${svixId}.${timestamp}.${body}`;
+    const sig = createHmac('sha256', secretBytes).update(signedContent).digest('base64');
+
+    expect(validateResendWebhook(body, {
+      'svix-id': svixId,
+      'svix-timestamp': timestamp,
+      'svix-signature': `v1,${sig}`,
+    }, rawSecret)).toBe(true);
+  });
+});
+
+// ─── Code verification ───────────────────────────────────────────────────────
+
+describe('Webhook route code verification (issue #20)', () => {
+  it('sales-bot webhook validates apikey header', () => {
+    const source = readFileSync(
+      resolve('src/app/api/sales-bot/webhook/route.ts'),
+      'utf-8'
+    );
+    expect(source).toContain('validateEvolutionWebhook');
+    expect(source).toContain('SALES_WEBHOOK_SECRET');
+    expect(source).toContain('401');
+  });
+
+  it('Resend webhook validates Svix signature', () => {
+    const source = readFileSync(
+      resolve('src/app/api/webhooks/resend/route.ts'),
+      'utf-8'
+    );
+    expect(source).toContain('validateResendWebhook');
+    expect(source).toContain('svix-id');
+    expect(source).toContain('svix-timestamp');
+    expect(source).toContain('svix-signature');
+    expect(source).toContain('RESEND_WEBHOOK_SECRET');
+    expect(source).toContain('401');
+  });
+
+  it('Resend webhook reads raw body (not parsed JSON) for signature verification', () => {
+    const source = readFileSync(
+      resolve('src/app/api/webhooks/resend/route.ts'),
+      'utf-8'
+    );
+    expect(source).toContain('request.text()');
+    expect(source).toContain('JSON.parse(rawBody)');
+  });
+});

--- a/src/app/api/sales-bot/webhook/route.ts
+++ b/src/app/api/sales-bot/webhook/route.ts
@@ -234,6 +234,14 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
+    // ─── Signature validation (Evolution API apikey header) ─────────────
+    const { validateEvolutionWebhook } = await import('@/lib/webhooks/signature');
+    const apikeyHeader = request.headers.get('apikey');
+    if (!validateEvolutionWebhook(apikeyHeader, process.env.SALES_WEBHOOK_SECRET)) {
+      logger.warn('[sales-bot/webhook] Invalid or missing apikey header');
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     const body = await request.json();
 
     // Verificar formato Evolution API

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -1,11 +1,29 @@
 import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { validateResendWebhook } from '@/lib/webhooks/signature'
 
 export async function POST(request: NextRequest) {
-  const supabase = await createClient()
+  // ─── Signature validation (Svix / Resend) ──────────────────────────
+  const rawBody = await request.text()
 
-  const body = await request.json()
+  const isValid = validateResendWebhook(
+    rawBody,
+    {
+      'svix-id': request.headers.get('svix-id'),
+      'svix-timestamp': request.headers.get('svix-timestamp'),
+      'svix-signature': request.headers.get('svix-signature'),
+    },
+    process.env.RESEND_WEBHOOK_SECRET,
+  )
+
+  if (!isValid) {
+    logger.warn('[resend/webhook] Invalid signature — rejecting request')
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = JSON.parse(rawBody)
+  const supabase = await createClient()
 
   logger.info('Resend webhook event:', body.type)
 

--- a/src/lib/webhooks/signature.ts
+++ b/src/lib/webhooks/signature.ts
@@ -1,0 +1,100 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+/**
+ * Validates Evolution API webhook requests.
+ * Checks that the `apikey` header matches the expected secret.
+ */
+export function validateEvolutionWebhook(
+  apikeyHeader: string | null,
+  secret: string | undefined
+): boolean {
+  if (!secret) return false; // secret not configured → reject
+  if (!apikeyHeader) return false;
+
+  // Timing-safe comparison
+  try {
+    const a = Buffer.from(apikeyHeader);
+    const b = Buffer.from(secret);
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates Resend webhook requests using Svix signature verification.
+ *
+ * Resend uses Svix for webhook delivery. Headers:
+ * - `svix-id`: unique message ID
+ * - `svix-timestamp`: Unix timestamp (seconds)
+ * - `svix-signature`: comma-separated signatures (format: `v1,<base64>`)
+ *
+ * @param rawBody - The raw request body as string
+ * @param headers - Object with svix-id, svix-timestamp, svix-signature
+ * @param secret - The webhook signing secret (starts with `whsec_`)
+ * @param toleranceSeconds - Max age of timestamp (default 5 minutes)
+ */
+export function validateResendWebhook(
+  rawBody: string,
+  headers: {
+    'svix-id': string | null;
+    'svix-timestamp': string | null;
+    'svix-signature': string | null;
+  },
+  secret: string | undefined,
+  toleranceSeconds = 300
+): boolean {
+  if (!secret) return false;
+
+  const svixId = headers['svix-id'];
+  const svixTimestamp = headers['svix-timestamp'];
+  const svixSignature = headers['svix-signature'];
+
+  if (!svixId || !svixTimestamp || !svixSignature) return false;
+
+  // Check timestamp tolerance (prevent replay attacks)
+  const ts = parseInt(svixTimestamp, 10);
+  if (isNaN(ts)) return false;
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - ts) > toleranceSeconds) return false;
+
+  // Decode secret (strip `whsec_` prefix, base64 decode)
+  let secretBytes: Buffer;
+  try {
+    const rawSecret = secret.startsWith('whsec_') ? secret.slice(6) : secret;
+    secretBytes = Buffer.from(rawSecret, 'base64');
+  } catch {
+    return false;
+  }
+
+  // Build signed content
+  const signedContent = `${svixId}.${svixTimestamp}.${rawBody}`;
+
+  // Compute expected signature
+  const expectedSignature = createHmac('sha256', secretBytes)
+    .update(signedContent)
+    .digest('base64');
+
+  // Parse received signatures (format: "v1,<base64> v1,<base64>")
+  const receivedSignatures = svixSignature.split(' ');
+
+  // Check if any signature matches
+  for (const sig of receivedSignatures) {
+    const parts = sig.split(',');
+    if (parts.length !== 2 || parts[0] !== 'v1') continue;
+
+    const receivedBase64 = parts[1];
+    try {
+      const a = Buffer.from(expectedSignature);
+      const b = Buffer.from(receivedBase64);
+      if (a.length === b.length && timingSafeEqual(a, b)) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- **sales-bot webhook**: validates Evolution API `apikey` header against `SALES_WEBHOOK_SECRET` env var (timing-safe comparison)
- **Resend webhook**: validates Svix signatures (`svix-id`, `svix-timestamp`, `svix-signature` headers) with HMAC-SHA256 against `RESEND_WEBHOOK_SECRET` env var, including timestamp tolerance (5min) for replay attack protection
- Shared signature validation module at `src/lib/webhooks/signature.ts`

## Changes
- `src/lib/webhooks/signature.ts` — new module with `validateEvolutionWebhook()` and `validateResendWebhook()`
- `src/app/api/sales-bot/webhook/route.ts` — reject requests without valid `apikey` header (401)
- `src/app/api/webhooks/resend/route.ts` — read raw body, validate Svix signature before parsing JSON (401)
- `src/__tests__/security/webhook-signatures.test.ts` — 21 tests

## Test plan
- [x] Valid signature accepted (both Evolution and Resend)
- [x] Invalid/missing signature rejected with 401
- [x] Replay attack protection (expired timestamp)
- [x] Body tampering detection
- [x] Multiple signatures support (Svix format)
- [x] Code verification tests (routes contain expected patterns)

## Env vars needed in Vercel
- `SALES_WEBHOOK_SECRET` — the apikey configured in Evolution API webhook settings
- `RESEND_WEBHOOK_SECRET` — the webhook signing secret from Resend dashboard (starts with `whsec_`)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)