### PR TITLE
fix(db): add missing index on professionals.user_id for RLS performance

### DIFF
--- a/src/__tests__/db/professionals-index.test.ts
+++ b/src/__tests__/db/professionals-index.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #40: Missing index on professionals.user_id
+ *
+ * Every RLS policy queries professionals WHERE user_id = auth.uid().
+ * Without an index this causes a full table scan on every authenticated request.
+ */
+
+describe('professionals.user_id index (issue #40)', () => {
+  const migrationsDir = resolve('supabase/migrations');
+
+  it('migration file exists for idx_professionals_user_id', () => {
+    const files = readdirSync(migrationsDir);
+    const indexMigration = files.find((f) => f.includes('idx_professionals_user_id'));
+    expect(indexMigration).toBeDefined();
+  });
+
+  it('migration creates the index on professionals(user_id)', () => {
+    const files = readdirSync(migrationsDir);
+    const indexMigration = files.find((f) => f.includes('idx_professionals_user_id'))!;
+    const sql = readFileSync(resolve(migrationsDir, indexMigration), 'utf-8');
+
+    expect(sql).toContain('CREATE INDEX');
+    expect(sql).toContain('idx_professionals_user_id');
+    expect(sql).toContain('professionals');
+    expect(sql).toContain('user_id');
+  });
+
+  it('migration uses IF NOT EXISTS for idempotency', () => {
+    const files = readdirSync(migrationsDir);
+    const indexMigration = files.find((f) => f.includes('idx_professionals_user_id'))!;
+    const sql = readFileSync(resolve(migrationsDir, indexMigration), 'utf-8');
+
+    expect(sql).toContain('IF NOT EXISTS');
+  });
+
+  it('RLS policies reference professionals.user_id (confirming the index is needed)', () => {
+    // Scan all migrations for RLS policies that reference user_id = auth.uid()
+    const files = readdirSync(migrationsDir);
+    let rlsPolicyCount = 0;
+
+    for (const file of files) {
+      const sql = readFileSync(resolve(migrationsDir, file), 'utf-8');
+      // Count policies that do subquery on professionals WHERE user_id = auth.uid()
+      const matches = sql.match(/professionals.*user_id\s*=\s*auth\.uid\(\)/gi);
+      if (matches) rlsPolicyCount += matches.length;
+    }
+
+    // There should be multiple RLS policies depending on this column
+    expect(rlsPolicyCount).toBeGreaterThan(0);
+  });
+});

--- a/supabase/migrations/20260303000008_idx_professionals_user_id.sql
+++ b/supabase/migrations/20260303000008_idx_professionals_user_id.sql
@@ -1,0 +1,4 @@
+-- Issue #40: Add missing index on professionals.user_id
+-- Every RLS policy does a subquery WHERE user_id = auth.uid() on this table.
+-- Without an index, every authenticated request triggers a full table scan.
+CREATE INDEX IF NOT EXISTS idx_professionals_user_id ON professionals(user_id);


### PR DESCRIPTION
## Summary
- Every RLS policy queries `professionals WHERE user_id = auth.uid()` — without an index this is a full table scan on **every authenticated request**
- Added `CREATE INDEX IF NOT EXISTS idx_professionals_user_id ON professionals(user_id)`

## Changes
- `supabase/migrations/20260303000008_idx_professionals_user_id.sql` — single-line migration
- `src/__tests__/db/professionals-index.test.ts` — 4 tests

## Test plan
- [x] Migration file exists and creates the correct index
- [x] Uses `IF NOT EXISTS` for idempotency
- [x] Confirmed RLS policies reference `professionals.user_id = auth.uid()` in migrations

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)