### PR TITLE
fix(ops): remove dead Meta Business API code from send-reminders cron

### DIFF
--- a/src/__tests__/cron/send-reminders-no-meta.test.ts
+++ b/src/__tests__/cron/send-reminders-no-meta.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #41: Dead code Meta Business API in cron send-reminders
+ *
+ * Meta Business API was fully removed from the project. The send-reminders
+ * cron still had a dead code block handling provider "meta" with
+ * graph.facebook.com calls. This test ensures it's been removed.
+ */
+
+describe('send-reminders — no Meta Business API dead code (issue #41)', () => {
+  const source = readFileSync(
+    resolve('src/app/api/cron/send-reminders/route.ts'),
+    'utf-8'
+  );
+
+  it('does not reference graph.facebook.com', () => {
+    expect(source).not.toContain('graph.facebook.com');
+  });
+
+  it('does not reference Meta provider', () => {
+    expect(source).not.toContain("provider === 'meta'");
+    expect(source).not.toContain('provider === "meta"');
+  });
+
+  it('does not reference phone_number_id (Meta-only field)', () => {
+    expect(source).not.toContain('phone_number_id');
+  });
+
+  it('does not reference access_token (Meta-only field)', () => {
+    expect(source).not.toContain('access_token');
+  });
+
+  it('does not reference messaging_product (Meta API field)', () => {
+    expect(source).not.toContain('messaging_product');
+  });
+
+  it('still uses Evolution API for sending', () => {
+    expect(source).toContain('evolution_api_url');
+    expect(source).toContain('evolution_instance');
+    expect(source).toContain('/message/sendText/');
+  });
+});

--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -142,7 +142,7 @@ export async function POST(request: NextRequest) {
     const userIds = (professionals ?? []).map((p) => p.user_id).filter(Boolean);
     const { data: whatsappConfigs } = await supabase
       .from('whatsapp_config')
-      .select('user_id, provider, evolution_api_url, evolution_api_key, evolution_instance, phone_number_id, access_token, is_active')
+      .select('user_id, evolution_api_url, evolution_api_key, evolution_instance, is_active')
       .in('user_id', userIds)
       .eq('is_active', true);
 
@@ -187,50 +187,23 @@ export async function POST(request: NextRequest) {
 
         let sent = false;
 
-        if (booking.client_phone && wc) {
-          if (wc.provider === 'evolution' && wc.evolution_api_url && wc.evolution_instance) {
-            const normalized = normalizePhoneForWhatsApp(booking.client_phone);
-            try {
-              const res = await fetch(
-                `${wc.evolution_api_url}/message/sendText/${wc.evolution_instance}`,
-                {
-                  method: 'POST',
-                  headers: { apikey: wc.evolution_api_key, 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ number: normalized, text: message }),
-                }
-              );
-              sent = res.ok;
-              if (!sent) {
-                logger.error('[send-reminders] Evolution error:', res.status, await res.text());
+        if (booking.client_phone && wc && wc.evolution_api_url && wc.evolution_instance) {
+          const normalized = normalizePhoneForWhatsApp(booking.client_phone);
+          try {
+            const res = await fetch(
+              `${wc.evolution_api_url}/message/sendText/${wc.evolution_instance}`,
+              {
+                method: 'POST',
+                headers: { apikey: wc.evolution_api_key, 'Content-Type': 'application/json' },
+                body: JSON.stringify({ number: normalized, text: message }),
               }
-            } catch (sendErr: any) {
-              logger.error('[send-reminders] Evolution fetch error:', sendErr.message);
+            );
+            sent = res.ok;
+            if (!sent) {
+              logger.error('[send-reminders] Evolution error:', res.status, await res.text());
             }
-          } else if (wc.provider === 'meta' && wc.phone_number_id) {
-            try {
-              const res = await fetch(
-                `https://graph.facebook.com/v18.0/${wc.phone_number_id}/messages`,
-                {
-                  method: 'POST',
-                  headers: {
-                    Authorization: `Bearer ${wc.access_token}`,
-                    'Content-Type': 'application/json',
-                  },
-                  body: JSON.stringify({
-                    messaging_product: 'whatsapp',
-                    to: booking.client_phone,
-                    type: 'text',
-                    text: { body: message },
-                  }),
-                }
-              );
-              sent = res.ok;
-              if (!sent) {
-                logger.error('[send-reminders] Meta error:', res.status, await res.text());
-              }
-            } catch (sendErr: any) {
-              logger.error('[send-reminders] Meta fetch error:', sendErr.message);
-            }
+          } catch (sendErr: any) {
+            logger.error('[send-reminders] Evolution fetch error:', sendErr.message);
           }
         }
 


### PR DESCRIPTION
## Summary
- Removed dead Meta Business API code block (lines 209-234) from `send-reminders` cron
- Cleaned up `whatsapp_config` select to no longer fetch Meta-only fields (`phone_number_id`, `access_token`)
- Simplified the send logic (no more provider branching — only Evolution API)

## Test plan
- [x] No `graph.facebook.com` references remain
- [x] No `provider === 'meta'` checks remain
- [x] No Meta-only fields (`phone_number_id`, `access_token`, `messaging_product`) remain
- [x] Evolution API sending still works (code preserved)
- [x] 6 unit tests

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)