### PR TITLE
fix(ci): use Vercel preview URL instead of production in GDPR job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,47 +628,46 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npx playwright install chromium --with-deps
-      - name: Obter URL do Vercel preview deploy
+      - name: Obter URL do Vercel deploy
         id: vercel-url
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           PROD_URL="https://booking.circlehood-tech.com"
-          # On PRs, poll GitHub Deployments API for preview URL
+          # On PRs, try to use the Vercel preview URL for this commit
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             SHA="${{ github.event.pull_request.head.sha }}"
             echo "Buscando preview URL para SHA $SHA..."
-            for i in $(seq 1 30); do
-              DEPLOY_URL=$(gh api "repos/${{ github.repository }}/deployments?sha=$SHA&environment=Preview&per_page=5" \
+            PREVIEW_URL=""
+            for i in $(seq 1 18); do
+              DEPLOY_ID=$(gh api "repos/${{ github.repository }}/deployments?sha=$SHA&environment=Preview&per_page=5" \
                 --jq '.[0].id // empty' 2>/dev/null)
-              if [ -n "$DEPLOY_URL" ]; then
-                STATUS_URL=$(gh api "repos/${{ github.repository }}/deployments/$DEPLOY_URL/statuses" \
+              if [ -n "$DEPLOY_ID" ]; then
+                CANDIDATE=$(gh api "repos/${{ github.repository }}/deployments/$DEPLOY_ID/statuses" \
                   --jq '[.[] | select(.state == "success")][0].environment_url // empty' 2>/dev/null)
-                if [ -n "$STATUS_URL" ]; then
-                  echo "✅ Preview URL encontrada: $STATUS_URL (tentativa $i)"
-                  echo "url=$STATUS_URL" >> "$GITHUB_OUTPUT"
-                  exit 0
+                if [ -n "$CANDIDATE" ]; then
+                  PREVIEW_URL="$CANDIDATE"
+                  echo "✅ Preview URL encontrada: $PREVIEW_URL (tentativa $i)"
+                  break
                 fi
               fi
-              echo "⏳ Tentativa $i/30: preview deploy não pronto, aguardando 10s..."
+              echo "⏳ Tentativa $i/18: preview deploy não pronto, aguardando 10s..."
               sleep 10
             done
-            echo "⚠️ Timeout — usando URL de produção como fallback"
+            # Verify the preview URL actually serves the page
+            if [ -n "$PREVIEW_URL" ]; then
+              echo "Verificando se preview responde..."
+              if curl -sfL --max-time 20 "$PREVIEW_URL/register" 2>/dev/null | grep -q 'noopener'; then
+                echo "✅ Preview responde — usando $PREVIEW_URL"
+                echo "url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "⚠️ Preview URL não respondeu — usando produção como fallback"
+            else
+              echo "⚠️ Preview URL não encontrada — usando produção como fallback"
+            fi
           fi
           echo "url=$PROD_URL" >> "$GITHUB_OUTPUT"
-      - name: Aguardar preview responder
-        run: |
-          TARGET="${{ steps.vercel-url.outputs.url }}"
-          echo "Aguardando $TARGET responder..."
-          for i in $(seq 1 12); do
-            if curl -sfL --max-time 15 "$TARGET/register" 2>/dev/null | grep -q 'noopener'; then
-              echo "✅ Deploy pronto (tentativa $i)"
-              exit 0
-            fi
-            echo "⏳ Tentativa $i/12: aguardando 10s..."
-            sleep 10
-          done
-          echo "⚠️ Timeout — continuando mesmo assim"
       - name: Run GDPR and legal pages tests
         run: npx playwright test --project=auth-setup --project=legal --project=gdpr
         env:

--- a/src/__tests__/ci/gdpr-preview-url.test.ts
+++ b/src/__tests__/ci/gdpr-preview-url.test.ts
@@ -13,16 +13,16 @@ import { resolve } from 'path';
 describe('GDPR job uses Vercel preview URL (issue #54)', () => {
   const ciYml = readFileSync(resolve('.github/workflows/ci.yml'), 'utf-8');
 
-  it('does not hardcode production URL in the polling step', () => {
-    // The old pattern: curl directly against production URL
+  it('does not hardcode production URL in a curl polling loop', () => {
+    // The old pattern: curl directly against production URL in a loop
     expect(ciYml).not.toContain(
       'curl -sfL --max-time 15 https://booking.circlehood-tech.com/register'
     );
   });
 
-  it('has a step to obtain the Vercel preview URL', () => {
+  it('has a step to obtain the Vercel deploy URL', () => {
     expect(ciYml).toContain('id: vercel-url');
-    expect(ciYml).toContain('Obter URL do Vercel preview deploy');
+    expect(ciYml).toContain('Obter URL do Vercel deploy');
   });
 
   it('uses GitHub Deployments API to find preview URL on PRs', () => {
@@ -31,9 +31,14 @@ describe('GDPR job uses Vercel preview URL (issue #54)', () => {
     expect(ciYml).toContain('environment_url');
   });
 
-  it('falls back to production URL on push to main', () => {
+  it('falls back to production URL when preview is unavailable', () => {
     expect(ciYml).toContain('https://booking.circlehood-tech.com');
-    expect(ciYml).toContain('usando URL de produção como fallback');
+    expect(ciYml).toContain('usando produção como fallback');
+  });
+
+  it('verifies preview URL responds before using it', () => {
+    expect(ciYml).toContain('Verificando se preview responde');
+    expect(ciYml).toContain('Preview responde');
   });
 
   it('passes the dynamic URL as TEST_BASE_URL to the GDPR tests', () => {
@@ -41,7 +46,7 @@ describe('GDPR job uses Vercel preview URL (issue #54)', () => {
   });
 
   it('does not hardcode TEST_BASE_URL to production in the GDPR job', () => {
-    // Extract the GDPR job section (between gdpr-legal-e2e: and the next job)
+    // Extract the GDPR job section
     const gdprMatch = ciYml.match(/gdpr-legal-e2e:[\s\S]*?(?=\n  \w[\w-]*:|$)/);
     expect(gdprMatch).toBeTruthy();
     const gdprSection = gdprMatch![0];
@@ -51,5 +56,12 @@ describe('GDPR job uses Vercel preview URL (issue #54)', () => {
     for (const line of testBaseUrlLines) {
       expect(line).not.toContain('https://booking.circlehood-tech.com');
     }
+  });
+
+  it('polls at most 18 times (3 min) instead of 30 times (5 min)', () => {
+    // The old code did 30 attempts × 10s = 5 min polling against production
+    expect(ciYml).not.toContain('seq 1 30');
+    // New code polls max 18 attempts for preview URL
+    expect(ciYml).toContain('seq 1 18');
   });
 });


### PR DESCRIPTION
## Summary
- GDPR E2E job was polling `booking.circlehood-tech.com` (production) to check deploy readiness — this never updates on PRs, wasting 5 minutes per run
- Now uses GitHub Deployments API to find the Vercel preview URL for the PR's HEAD SHA
- Passes the preview URL as `TEST_BASE_URL` so tests run against the actual PR code
- Falls back to production URL on push-to-main (where there's no preview)

## Test plan
- [x] 6 unit tests verifying: no hardcoded production URL in polling, preview URL step exists, Deployments API usage, fallback logic, dynamic TEST_BASE_URL
- [x] YAML lint passes
- [x] `npm run test:fast` passes (589/591 — 2 pre-existing email/unsubscribe failures)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)