### PR TITLE
fix(ci): remove unused CRON_SECRET from gdpr-legal-e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -676,7 +676,6 @@ jobs:
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          CRON_SECRET: ${{ secrets.CRON_SECRET }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/src/__tests__/ci/gdpr-no-cron-secret.test.ts
+++ b/src/__tests__/ci/gdpr-no-cron-secret.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #60: Remove CRON_SECRET from gdpr-legal-e2e job env
+ *
+ * CRON_SECRET was exposed unnecessarily in the GDPR job — none of the
+ * tests it runs use it. Follows the principle of least privilege.
+ */
+
+describe('gdpr-legal-e2e job does not expose CRON_SECRET (issue #60)', () => {
+  const ciYml = readFileSync(resolve('.github/workflows/ci.yml'), 'utf-8');
+
+  // Extract the GDPR job section
+  const gdprMatch = ciYml.match(/gdpr-legal-e2e:[\s\S]*?(?=\n  \w[\w-]*:|$)/);
+
+  it('GDPR job section exists in ci.yml', () => {
+    expect(gdprMatch).toBeTruthy();
+  });
+
+  it('does not include CRON_SECRET in the GDPR job env', () => {
+    const gdprSection = gdprMatch![0];
+    expect(gdprSection).not.toContain('CRON_SECRET');
+  });
+
+  it('still includes required secrets for GDPR tests', () => {
+    const gdprSection = gdprMatch![0];
+    expect(gdprSection).toContain('TEST_USER_EMAIL');
+    expect(gdprSection).toContain('TEST_USER_PASSWORD');
+    expect(gdprSection).toContain('NEXT_PUBLIC_SUPABASE_URL');
+    expect(gdprSection).toContain('SUPABASE_SERVICE_ROLE_KEY');
+  });
+});


### PR DESCRIPTION
## Summary
- Removed `CRON_SECRET` from the `gdpr-legal-e2e` job env block — none of the GDPR tests use it
- Follows the principle of least privilege: don't expose secrets to jobs that don't need them

## Test plan
- [x] 3 unit tests: GDPR section has no CRON_SECRET, required secrets still present
- [x] YAML lint passes
- [x] Zero risk of breakage — variable was unused

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)