### PR TITLE
fix(ops): add .env.example documenting all 41 env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,81 @@
+# ============================================================
+# CircleHood Booking — Environment Variables
+# Copy this file to .env.local and fill in the values
+# ============================================================
+
+# --- Supabase ---
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_PRODUCTION_REF=your-project-ref
+
+# --- App ---
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+
+# --- Admin ---
+ADMIN_PASSWORD=your-admin-password
+ADMIN_EMAIL=admin@example.com
+SETUP_SECRET=your-setup-secret
+
+# --- Cron Jobs ---
+CRON_SECRET=your-cron-secret
+
+# --- AI / Anthropic ---
+ANTHROPIC_API_KEY=sk-ant-...
+
+# --- Stripe (Subscriptions) ---
+STRIPE_SECRET_KEY=sk_test_...
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_PRICE_ID=price_...
+STRIPE_PRICE_ID_EUR=price_...
+STRIPE_PRICE_ID_GBP=price_...
+STRIPE_PRICE_ID_BRL=price_...
+STRIPE_PRICE_ID_USD=price_...
+
+# --- Stripe Connect (Deposits) ---
+STRIPE_CONNECT_WEBHOOK_SECRET=whsec_...
+STRIPE_DEPOSIT_WEBHOOK_SECRET=whsec_...
+
+# --- WhatsApp / Evolution API ---
+EVOLUTION_API_URL=https://your-evolution-api.com
+EVOLUTION_API_KEY=your-evolution-api-key
+EVOLUTION_INSTANCE_SALES=circlehood-sales
+WHATSAPP_SUPPORT_INSTANCE=your-support-instance
+WHATSAPP_VERIFY_TOKEN=your-verify-token
+SALES_WEBHOOK_SECRET=your-sales-webhook-secret
+
+# --- Redis (Conversation Cache) ---
+REDIS_URL=redis://localhost:6379
+STORAGE_URL=
+
+# --- Resend (Email) ---
+RESEND_API_KEY=re_...
+RESEND_FROM_EMAIL=noreply@your-domain.com
+RESEND_WEBHOOK_SECRET=whsec_...
+
+# --- Google Calendar Integration ---
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:3000/api/integrations/google-calendar/callback
+
+# --- Instagram Integration ---
+INSTAGRAM_CLIENT_ID=your-instagram-client-id
+INSTAGRAM_CLIENT_SECRET=your-instagram-client-secret
+
+# --- Revolut (Payments) ---
+REVOLUT_API_KEY=your-revolut-api-key
+REVOLUT_WEBHOOK_SECRET=your-revolut-webhook-secret
+
+# --- OAuth Token Encryption ---
+OAUTH_TOKEN_ENCRYPTION_KEY=32-byte-hex-string
+
+# --- GitHub (Issue Reporting) ---
+NEXT_PUBLIC_GH_ISSUES_PAT=ghp_...
+GH_ACTIONS_TOKEN=ghp_...
+
+# --- E2E Tests (CI only) ---
+# TEST_BASE_URL=https://booking.circlehood-tech.com
+# TEST_USER_EMAIL=test@example.com
+# TEST_USER_PASSWORD=your-test-password
+# STRIPE_TEST_ACCOUNT_ID=acct_...

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/src/__tests__/ops/env-example.test.ts
+++ b/src/__tests__/ops/env-example.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { execSync } from 'child_process';
+
+/**
+ * Tests for Issue #44: Missing .env.example — 27+ env vars sem documentação
+ */
+
+describe('.env.example documentation (issue #44)', () => {
+  const envExamplePath = resolve('.env.example');
+
+  it('.env.example file exists', () => {
+    expect(existsSync(envExamplePath)).toBe(true);
+  });
+
+  it('.env.example is not gitignored', () => {
+    const result = execSync('git check-ignore .env.example 2>&1; echo $?', {
+      encoding: 'utf-8',
+    }).trim();
+    // exit code 1 means NOT ignored
+    expect(result.endsWith('1')).toBe(true);
+  });
+
+  it('contains all critical Supabase vars', () => {
+    const content = readFileSync(envExamplePath, 'utf-8');
+    expect(content).toContain('NEXT_PUBLIC_SUPABASE_URL');
+    expect(content).toContain('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+    expect(content).toContain('SUPABASE_SERVICE_ROLE_KEY');
+  });
+
+  it('contains Stripe vars', () => {
+    const content = readFileSync(envExamplePath, 'utf-8');
+    expect(content).toContain('STRIPE_SECRET_KEY');
+    expect(content).toContain('NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY');
+    expect(content).toContain('STRIPE_WEBHOOK_SECRET');
+  });
+
+  it('contains AI/Anthropic vars', () => {
+    const content = readFileSync(envExamplePath, 'utf-8');
+    expect(content).toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('contains WhatsApp/Evolution API vars', () => {
+    const content = readFileSync(envExamplePath, 'utf-8');
+    expect(content).toContain('EVOLUTION_API_URL');
+    expect(content).toContain('EVOLUTION_API_KEY');
+  });
+
+  it('contains Redis vars', () => {
+    const content = readFileSync(envExamplePath, 'utf-8');
+    expect(content).toContain('REDIS_URL');
+  });
+
+  it('contains Resend vars', () => {
+    const content = readFileSync(envExamplePath, 'utf-8');
+    expect(content).toContain('RESEND_API_KEY');
+  });
+
+  it('contains admin/cron vars', () => {
+    const content = readFileSync(envExamplePath, 'utf-8');
+    expect(content).toContain('ADMIN_PASSWORD');
+    expect(content).toContain('CRON_SECRET');
+    expect(content).toContain('SETUP_SECRET');
+  });
+
+  it('does not contain actual secret values', () => {
+    const content = readFileSync(envExamplePath, 'utf-8');
+    // Should only have placeholder values, not real secrets
+    const lines = content.split('\n').filter((l) => l.includes('=') && !l.startsWith('#'));
+    for (const line of lines) {
+      const value = line.split('=').slice(1).join('=');
+      // Values should be placeholders (your-*, sk_test_*, etc.) not real secrets
+      expect(value.length).toBeLessThan(200);
+    }
+  });
+
+  it('covers at least 30 env vars', () => {
+    const content = readFileSync(envExamplePath, 'utf-8');
+    const vars = content
+      .split('\n')
+      .filter((l) => l.match(/^[A-Z_]+=/) && !l.startsWith('#'));
+    expect(vars.length).toBeGreaterThanOrEqual(30);
+  });
+});


### PR DESCRIPTION
## Summary
- Created `.env.example` with all 41 environment variables grouped by service
- Added `!.env.example` exception to `.gitignore` (was caught by `.env*` pattern)
- Variables grouped: Supabase, App, Admin, Cron, AI, Stripe, WhatsApp/Evolution, Redis, Resend, Google, Instagram, Revolut, OAuth, GitHub, E2E

## Test plan
- [x] 11 unit tests: file exists, not gitignored, critical vars present (Supabase, Stripe, AI, WhatsApp, Redis, Resend, admin/cron), no real secrets, covers 30+ vars
- [x] `npm run test:fast` passes

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)