### PR TITLE
fix(admin): improve Bot E2E toggle error with setup instructions

### DIFF
--- a/src/__tests__/admin/bot-e2e-toggle.test.ts
+++ b/src/__tests__/admin/bot-e2e-toggle.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #84: Bot E2E toggle shows "GH_ACTIONS_TOKEN not configured"
+ *
+ * The bot-e2e-toggle API needs GH_ACTIONS_TOKEN to manage the BOT_E2E_ENABLED
+ * GitHub Actions variable. The error message should clearly explain what's needed.
+ */
+
+describe('bot-e2e-toggle route (issue #84)', () => {
+  const source = readFileSync(
+    resolve('src/app/api/admin/bot-e2e-toggle/route.ts'),
+    'utf-8'
+  );
+
+  it('checks for GH_ACTIONS_TOKEN env var', () => {
+    expect(source).toContain('process.env.GH_ACTIONS_TOKEN');
+  });
+
+  it('returns descriptive error when GH_ACTIONS_TOKEN is missing (GET)', () => {
+    // Should explain what token is needed and where to add it
+    expect(source).toContain('GitHub PAT');
+    expect(source).toContain('Vercel');
+  });
+
+  it('returns descriptive error when GH_ACTIONS_TOKEN is missing (PATCH)', () => {
+    // Both GET and PATCH should have helpful error messages
+    const patchSection = source.slice(source.indexOf('export async function PATCH'));
+    expect(patchSection).toContain('GH_ACTIONS_TOKEN');
+    expect(patchSection).toContain('GitHub PAT');
+  });
+
+  it('requires admin authentication on GET', () => {
+    expect(source).toContain('validateAdminToken');
+    expect(source).toContain("status: 401");
+  });
+
+  it('requires admin authentication on PATCH', () => {
+    const patchSection = source.slice(source.indexOf('export async function PATCH'));
+    expect(patchSection).toContain('validateAdminToken');
+    expect(patchSection).toContain("status: 401");
+  });
+
+  it('manages BOT_E2E_ENABLED GitHub Actions variable', () => {
+    expect(source).toContain("'BOT_E2E_ENABLED'");
+    expect(source).toContain('actions/variables');
+  });
+
+  it('handles variable creation when it does not exist (404)', () => {
+    expect(source).toContain('res.status === 404');
+    expect(source).toContain("method: 'POST'");
+  });
+});
+
+describe('execution-wheel page — Bot E2E section', () => {
+  const source = readFileSync(
+    resolve('src/app/[locale]/(admin)/admin/execution-wheel/page.tsx'),
+    'utf-8'
+  );
+
+  it('shows Bot E2E toggle in the UI', () => {
+    expect(source).toContain('Bot E2E (Anthropic)');
+  });
+
+  it('explains what the toggle does', () => {
+    expect(source).toContain('BOT_E2E_ENABLED');
+  });
+
+  it('shows error message from API when token is missing', () => {
+    expect(source).toContain('botE2eError');
+  });
+
+  it('disables toggle when there is an error', () => {
+    expect(source).toContain('disabled={botE2eLoading || !!botE2eError}');
+  });
+});

--- a/src/app/[locale]/(admin)/admin/execution-wheel/page.tsx
+++ b/src/app/[locale]/(admin)/admin/execution-wheel/page.tsx
@@ -500,7 +500,7 @@ export default function ExecutionWheelPage() {
               <p className="text-[11px] text-slate-400 dark:text-slate-500 mt-0.5">
                 {botE2eError
                   ? botE2eError
-                  : 'Deixe OFF no dia-a-dia. Ligue apenas antes de release.'}
+                  : 'Controla a variável BOT_E2E_ENABLED no GitHub Actions. Deixe OFF no dia-a-dia — ligue apenas antes de release.'}
               </p>
             </div>
           </div>

--- a/src/app/api/admin/bot-e2e-toggle/route.ts
+++ b/src/app/api/admin/bot-e2e-toggle/route.ts
@@ -25,7 +25,10 @@ export async function GET() {
 
   const token = process.env.GH_ACTIONS_TOKEN;
   if (!token) {
-    return NextResponse.json({ enabled: false, error: 'GH_ACTIONS_TOKEN not configured' });
+    return NextResponse.json({
+      enabled: false,
+      error: 'GH_ACTIONS_TOKEN não configurado. Adicione um GitHub PAT (Fine-grained, permissão Actions: Read/Write) nas env vars do Vercel.',
+    });
   }
 
   try {
@@ -57,7 +60,9 @@ export async function PATCH(request: Request) {
 
   const token = process.env.GH_ACTIONS_TOKEN;
   if (!token) {
-    return NextResponse.json({ error: 'GH_ACTIONS_TOKEN not configured' }, { status: 500 });
+    return NextResponse.json({
+      error: 'GH_ACTIONS_TOKEN não configurado. Adicione um GitHub PAT nas env vars do Vercel.',
+    }, { status: 500 });
   }
 
   const body = await request.json();


### PR DESCRIPTION
## Summary
- Improved error message from `GH_ACTIONS_TOKEN not configured` to explain what's needed: a GitHub Fine-grained PAT with Actions: Read/Write permission, added to Vercel env vars
- Updated UI description to clarify the toggle controls the `BOT_E2E_ENABLED` GitHub Actions variable
- Toggle remains disabled when the token is not configured (existing behavior)

## Setup instructions
To enable the Bot E2E toggle:
1. Create a GitHub Fine-grained PAT at https://github.com/settings/tokens?type=beta
2. Grant it **Actions: Read/Write** permission on `Gabiribpin/circlehood-booking`
3. Add it as `GH_ACTIONS_TOKEN` in Vercel Environment Variables
4. Redeploy

## Test plan
- [x] 11 unit tests: env var check, descriptive errors (GET/PATCH), admin auth, variable management, UI elements
- [x] `tsc --noEmit` passes

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)