### PR TITLE
feat(ops): webhook retry queue with backoff and admin dashboard (#24)

### DIFF
--- a/src/__tests__/webhooks/retry-backoff.test.ts
+++ b/src/__tests__/webhooks/retry-backoff.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getRetryDelay,
+  getNextRetryAt,
+  isDeadLetter,
+  MAX_ATTEMPTS,
+  BACKOFF_DELAYS_MS,
+} from '@/lib/webhooks/retry-backoff';
+
+describe('getRetryDelay', () => {
+  it('returns 1 minute for attempt 0', () => {
+    expect(getRetryDelay(0)).toBe(1 * 60 * 1000);
+  });
+
+  it('returns 5 minutes for attempt 1', () => {
+    expect(getRetryDelay(1)).toBe(5 * 60 * 1000);
+  });
+
+  it('returns 30 minutes for attempt 2', () => {
+    expect(getRetryDelay(2)).toBe(30 * 60 * 1000);
+  });
+
+  it('returns 2 hours for attempt 3', () => {
+    expect(getRetryDelay(3)).toBe(2 * 60 * 60 * 1000);
+  });
+
+  it('returns 12 hours for attempt 4', () => {
+    expect(getRetryDelay(4)).toBe(12 * 60 * 60 * 1000);
+  });
+
+  it('returns null for attempt >= MAX_ATTEMPTS', () => {
+    expect(getRetryDelay(5)).toBeNull();
+    expect(getRetryDelay(10)).toBeNull();
+  });
+
+  it('returns null for negative attempt', () => {
+    expect(getRetryDelay(-1)).toBeNull();
+  });
+});
+
+describe('getNextRetryAt', () => {
+  it('returns a future date for valid attempts', () => {
+    const before = Date.now();
+    const result = getNextRetryAt(0);
+    expect(result).toBeInstanceOf(Date);
+    expect(result!.getTime()).toBeGreaterThanOrEqual(before + BACKOFF_DELAYS_MS[0]);
+  });
+
+  it('returns null when max attempts reached', () => {
+    expect(getNextRetryAt(MAX_ATTEMPTS)).toBeNull();
+  });
+
+  it('each successive attempt has a longer delay', () => {
+    const delays = [0, 1, 2, 3, 4].map((i) => {
+      const result = getNextRetryAt(i);
+      return result!.getTime();
+    });
+
+    for (let i = 1; i < delays.length; i++) {
+      expect(delays[i]).toBeGreaterThan(delays[i - 1]);
+    }
+  });
+});
+
+describe('isDeadLetter', () => {
+  it('returns false for attempts < MAX_ATTEMPTS', () => {
+    expect(isDeadLetter(0)).toBe(false);
+    expect(isDeadLetter(4)).toBe(false);
+  });
+
+  it('returns true for attempts >= MAX_ATTEMPTS', () => {
+    expect(isDeadLetter(5)).toBe(true);
+    expect(isDeadLetter(10)).toBe(true);
+  });
+});
+
+describe('constants', () => {
+  it('MAX_ATTEMPTS is 5', () => {
+    expect(MAX_ATTEMPTS).toBe(5);
+  });
+
+  it('BACKOFF_DELAYS_MS has 5 entries in ascending order', () => {
+    expect(BACKOFF_DELAYS_MS).toHaveLength(5);
+    for (let i = 1; i < BACKOFF_DELAYS_MS.length; i++) {
+      expect(BACKOFF_DELAYS_MS[i]).toBeGreaterThan(BACKOFF_DELAYS_MS[i - 1]);
+    }
+  });
+});

--- a/src/__tests__/webhooks/webhook-retry-queue.test.ts
+++ b/src/__tests__/webhooks/webhook-retry-queue.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(__dirname, '..', '..', '..');
+
+describe('Webhook Retry Queue — Integration', () => {
+  it('migration file exists with webhook_failures table', () => {
+    const migrationPath = join(ROOT, 'supabase/migrations/20260305000001_webhook_failures.sql');
+    expect(existsSync(migrationPath)).toBe(true);
+    const content = readFileSync(migrationPath, 'utf-8');
+    expect(content).toContain('webhook_failures');
+    expect(content).toContain('webhook_type');
+    expect(content).toContain('payload');
+    expect(content).toContain('attempt_count');
+    expect(content).toContain('max_attempts');
+    expect(content).toContain('next_retry_at');
+    expect(content).toContain('dead_letter');
+    expect(content).toContain('ENABLE ROW LEVEL SECURITY');
+  });
+
+  it('migration has proper indexes for retry processing', () => {
+    const migrationPath = join(ROOT, 'supabase/migrations/20260305000001_webhook_failures.sql');
+    const content = readFileSync(migrationPath, 'utf-8');
+    expect(content).toContain('idx_webhook_failures_retry');
+    expect(content).toContain('idx_webhook_failures_type');
+  });
+
+  it('cron route exists for processing retries', () => {
+    const cronPath = join(ROOT, 'src/app/api/cron/process-webhook-retries/route.ts');
+    expect(existsSync(cronPath)).toBe(true);
+    const content = readFileSync(cronPath, 'utf-8');
+    expect(content).toContain('processWebhookRetries');
+    expect(content).toContain('CRON_SECRET');
+    expect(content).toContain('process-webhook-retries');
+  });
+
+  it('vercel.json includes cron for process-webhook-retries', () => {
+    const vercelPath = join(ROOT, 'vercel.json');
+    const content = readFileSync(vercelPath, 'utf-8');
+    const config = JSON.parse(content);
+    const cron = config.crons.find((c: any) => c.path === '/api/cron/process-webhook-retries');
+    expect(cron).toBeDefined();
+    expect(cron.schedule).toBe('*/10 * * * *');
+  });
+
+  it('retry-queue library has recordWebhookFailure and processWebhookRetries', () => {
+    const queuePath = join(ROOT, 'src/lib/webhooks/retry-queue.ts');
+    expect(existsSync(queuePath)).toBe(true);
+    const content = readFileSync(queuePath, 'utf-8');
+    expect(content).toContain('recordWebhookFailure');
+    expect(content).toContain('processWebhookRetries');
+    expect(content).toContain('replayWebhook');
+    expect(content).toContain('dead_letter');
+  });
+
+  it('admin webhook-failures page exists', () => {
+    const pagePath = join(ROOT, 'src/app/[locale]/(admin)/admin/webhook-failures/page.tsx');
+    expect(existsSync(pagePath)).toBe(true);
+    const content = readFileSync(pagePath, 'utf-8');
+    expect(content).toContain('WebhookRetryButton');
+    expect(content).toContain('dead_letter');
+    expect(content).toContain('webhook_failures');
+  });
+
+  it('admin API route exists for listing and manual retry', () => {
+    const apiPath = join(ROOT, 'src/app/api/admin/webhook-failures/route.ts');
+    expect(existsSync(apiPath)).toBe(true);
+    const content = readFileSync(apiPath, 'utf-8');
+    expect(content).toContain('GET');
+    expect(content).toContain('POST');
+    expect(content).toContain('validateAdminToken');
+    expect(content).toContain('failureId');
+  });
+
+  it('admin layout has webhook failures link', () => {
+    const layoutPath = join(ROOT, 'src/app/[locale]/(admin)/layout.tsx');
+    const content = readFileSync(layoutPath, 'utf-8');
+    expect(content).toContain('webhook-failures');
+    expect(content).toContain('Webhook Retries');
+  });
+
+  it('webhook retry button component exists', () => {
+    const btnPath = join(ROOT, 'src/components/admin/webhook-retry-button.tsx');
+    expect(existsSync(btnPath)).toBe(true);
+    const content = readFileSync(btnPath, 'utf-8');
+    expect(content).toContain("'use client'");
+    expect(content).toContain('failureId');
+    expect(content).toContain('/api/admin/webhook-failures');
+  });
+});

--- a/src/app/[locale]/(admin)/admin/webhook-failures/page.tsx
+++ b/src/app/[locale]/(admin)/admin/webhook-failures/page.tsx
@@ -1,0 +1,183 @@
+import { createAdminClient } from '@/lib/supabase/admin';
+import { Card, CardContent } from '@/components/ui/card';
+import { Clock, CheckCircle, XCircle, AlertTriangle, RotateCcw, Skull } from 'lucide-react';
+import { WebhookRetryButton } from '@/components/admin/webhook-retry-button';
+
+export default async function WebhookFailuresPage() {
+  const supabase = createAdminClient();
+
+  const [failuresResult, countsResult] = await Promise.allSettled([
+    supabase
+      .from('webhook_failures')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .limit(50),
+    supabase
+      .from('webhook_failures')
+      .select('status'),
+  ]);
+
+  const failures = failuresResult.status === 'fulfilled' ? (failuresResult.value.data ?? []) : [];
+
+  const counts = { pending: 0, retrying: 0, resolved: 0, dead_letter: 0, total: 0 };
+  if (countsResult.status === 'fulfilled') {
+    for (const f of countsResult.value.data ?? []) {
+      counts.total++;
+      const s = f.status as keyof typeof counts;
+      if (s in counts) counts[s]++;
+    }
+  }
+
+  const statusColors: Record<string, string> = {
+    pending: 'text-amber-600 bg-amber-50',
+    retrying: 'text-blue-600 bg-blue-50',
+    resolved: 'text-green-600 bg-green-50',
+    dead_letter: 'text-red-600 bg-red-50',
+  };
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Webhook Failures</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Fila de retry para webhooks que falharam (Stripe, Evolution API, Resend)
+        </p>
+      </div>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <Card>
+          <CardContent className="p-5">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-amber-100 dark:bg-amber-900/30">
+                <Clock className="h-5 w-5 text-amber-600" />
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Pendente</p>
+                <p className="text-3xl font-bold">{counts.pending}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-5">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30">
+                <RotateCcw className="h-5 w-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Retrying</p>
+                <p className="text-3xl font-bold">{counts.retrying}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-5">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/30">
+                <CheckCircle className="h-5 w-5 text-green-600" />
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Resolvidos</p>
+                <p className="text-3xl font-bold">{counts.resolved}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-5">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-red-100 dark:bg-red-900/30">
+                <Skull className="h-5 w-5 text-red-500" />
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Dead Letter</p>
+                <p className="text-3xl font-bold">{counts.dead_letter}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-5">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-slate-100 dark:bg-slate-800">
+                <AlertTriangle className="h-5 w-5 text-slate-600" />
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Total</p>
+                <p className="text-3xl font-bold">{counts.total}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Failures Table */}
+      {failures.length === 0 ? (
+        <Card>
+          <CardContent className="p-8 text-center">
+            <CheckCircle className="h-10 w-10 text-green-500 mx-auto mb-3" />
+            <p className="text-muted-foreground">Nenhuma falha de webhook registrada.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="p-5">
+            <h2 className="text-lg font-semibold mb-4">Últimas Falhas ({failures.length})</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="pb-2 pr-4">Tipo</th>
+                    <th className="pb-2 pr-4">Evento</th>
+                    <th className="pb-2 pr-4">Status</th>
+                    <th className="pb-2 pr-4">Tentativas</th>
+                    <th className="pb-2 pr-4">Erro</th>
+                    <th className="pb-2 pr-4">Criado em</th>
+                    <th className="pb-2 pr-4">Próximo Retry</th>
+                    <th className="pb-2">Ação</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {failures.map((f: any) => (
+                    <tr key={f.id} className="border-b last:border-0">
+                      <td className="py-2 pr-4 font-mono text-xs">{f.webhook_type}</td>
+                      <td className="py-2 pr-4 text-xs">{f.event_type ?? '—'}</td>
+                      <td className="py-2 pr-4">
+                        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusColors[f.status] || ''}`}>
+                          {f.status}
+                        </span>
+                      </td>
+                      <td className="py-2 pr-4 text-center">{f.attempt_count}/{f.max_attempts}</td>
+                      <td className="py-2 pr-4 text-xs text-red-500 max-w-[200px] truncate" title={f.error}>
+                        {f.error ?? '—'}
+                      </td>
+                      <td className="py-2 pr-4 text-xs text-muted-foreground">
+                        {new Date(f.created_at).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })}
+                      </td>
+                      <td className="py-2 pr-4 text-xs text-muted-foreground">
+                        {f.next_retry_at
+                          ? new Date(f.next_retry_at).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+                          : '—'}
+                      </td>
+                      <td className="py-2">
+                        {(f.status === 'dead_letter' || f.status === 'pending' || f.status === 'retrying') && (
+                          <WebhookRetryButton failureId={f.id} />
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/(admin)/layout.tsx
+++ b/src/app/[locale]/(admin)/layout.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 import { cookies } from 'next/headers';
 import Link from 'next/link';
-import { LayoutDashboard, CreditCard, ShieldCheck, LifeBuoy, Trash2, Target, BookOpen, Phone, Crosshair, Radar, CircleDot, Activity } from 'lucide-react';
+import { LayoutDashboard, CreditCard, ShieldCheck, LifeBuoy, Trash2, Target, BookOpen, Phone, Crosshair, Radar, CircleDot, Activity, RefreshCw } from 'lucide-react';
 import { AdminLogoutButton } from '@/components/admin/admin-logout-button';
 import { createAdminClient } from '@/lib/supabase/admin';
 
@@ -77,6 +77,13 @@ export default async function AdminLayout({
           >
             <Activity className="h-4 w-4" />
             Saúde Pagamentos
+          </Link>
+          <Link
+            href="/admin/webhook-failures"
+            className="flex items-center gap-3 px-3 py-2 rounded-md text-sm text-slate-300 hover:bg-slate-800 hover:text-white transition-colors"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Webhook Retries
           </Link>
           <Link
             href="/admin/support"

--- a/src/app/api/admin/webhook-failures/route.ts
+++ b/src/app/api/admin/webhook-failures/route.ts
@@ -1,0 +1,96 @@
+import { createAdminClient } from '@/lib/supabase/admin';
+import { getNextRetryAt } from '@/lib/webhooks/retry-backoff';
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * GET /api/admin/webhook-failures — List webhook failures
+ * POST /api/admin/webhook-failures — Manual retry of a specific failure
+ *
+ * Protected by admin session cookie (validated in admin layout).
+ */
+
+export async function GET(request: NextRequest) {
+  const { validateAdminToken } = await import('@/lib/admin/session');
+  const adminSession = request.cookies.get('admin_session');
+  if (!validateAdminToken(adminSession?.value)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = createAdminClient();
+
+  const { searchParams } = new URL(request.url);
+  const status = searchParams.get('status') || 'all';
+  const limit = Math.min(Number(searchParams.get('limit') || 50), 100);
+
+  let query = supabase
+    .from('webhook_failures')
+    .select('*')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (status !== 'all') {
+    query = query.eq('status', status);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Also get counts per status
+  const { data: allFailures } = await supabase
+    .from('webhook_failures')
+    .select('status');
+
+  const counts = {
+    pending: 0,
+    retrying: 0,
+    resolved: 0,
+    dead_letter: 0,
+    total: 0,
+  };
+
+  for (const f of allFailures ?? []) {
+    counts.total++;
+    const s = f.status as keyof typeof counts;
+    if (s in counts) counts[s]++;
+  }
+
+  return NextResponse.json({ failures: data ?? [], counts });
+}
+
+export async function POST(request: NextRequest) {
+  const { validateAdminToken } = await import('@/lib/admin/session');
+  const adminSession = request.cookies.get('admin_session');
+  if (!validateAdminToken(adminSession?.value)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = createAdminClient();
+  const body = await request.json();
+  const { failureId } = body;
+
+  if (!failureId) {
+    return NextResponse.json({ error: 'failureId required' }, { status: 400 });
+  }
+
+  // Reset the failure for retry: set status back to pending, schedule immediate retry
+  const now = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('webhook_failures')
+    .update({
+      status: 'retrying',
+      next_retry_at: now,
+      updated_at: now,
+    } as never)
+    .eq('id', failureId)
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, failure: data });
+}

--- a/src/app/api/cron/process-webhook-retries/route.ts
+++ b/src/app/api/cron/process-webhook-retries/route.ts
@@ -1,0 +1,57 @@
+import { logger } from '@/lib/logger';
+import { createClient } from '@supabase/supabase-js';
+import { processWebhookRetries } from '@/lib/webhooks/retry-queue';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const startTime = Date.now();
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+
+  try {
+    const result = await processWebhookRetries(supabase);
+
+    logger.info(`[process-webhook-retries] Processed ${result.processed}: ${result.succeeded} succeeded, ${result.failed} failed, ${result.deadLettered} dead-lettered`);
+
+    try {
+      await supabase.from('cron_logs').insert({
+        job_name: 'process-webhook-retries',
+        status: 'success',
+        records_processed: result.processed,
+        execution_time_ms: Date.now() - startTime,
+        metadata: result,
+      } as never);
+    } catch { /* non-fatal */ }
+
+    return NextResponse.json({
+      success: true,
+      ...result,
+      execution_time_ms: Date.now() - startTime,
+    });
+  } catch (error: any) {
+    logger.error('[process-webhook-retries] Error:', error);
+
+    try {
+      await supabase.from('cron_logs').insert({
+        job_name: 'process-webhook-retries',
+        status: 'error',
+        error_message: error.message,
+        execution_time_ms: Date.now() - startTime,
+      } as never);
+    } catch { /* non-fatal */ }
+
+    return NextResponse.json(
+      { error: 'Internal server error', message: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/admin/webhook-retry-button.tsx
+++ b/src/components/admin/webhook-retry-button.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { RotateCcw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+export function WebhookRetryButton({ failureId }: { failureId: string }) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function handleRetry() {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/admin/webhook-failures', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ failureId }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        alert(`Erro: ${data.error || res.statusText}`);
+        return;
+      }
+
+      router.refresh();
+    } catch (err: any) {
+      alert(`Erro: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleRetry} disabled={loading}>
+      <RotateCcw className={`h-3 w-3 mr-1 ${loading ? 'animate-spin' : ''}`} />
+      {loading ? '...' : 'Retry'}
+    </Button>
+  );
+}

--- a/src/lib/webhooks/retry-backoff.ts
+++ b/src/lib/webhooks/retry-backoff.ts
@@ -1,0 +1,41 @@
+/**
+ * Exponential backoff delays for webhook retries.
+ * Attempt 1: 1 min, Attempt 2: 5 min, Attempt 3: 30 min, Attempt 4: 2h, Attempt 5: 12h
+ */
+const BACKOFF_DELAYS_MS = [
+  1 * 60 * 1000,       // 1 minute
+  5 * 60 * 1000,       // 5 minutes
+  30 * 60 * 1000,      // 30 minutes
+  2 * 60 * 60 * 1000,  // 2 hours
+  12 * 60 * 60 * 1000, // 12 hours
+];
+
+const MAX_ATTEMPTS = 5;
+
+/**
+ * Returns the delay in milliseconds for the given attempt number (0-indexed).
+ * Returns null if max attempts exceeded.
+ */
+export function getRetryDelay(attempt: number): number | null {
+  if (attempt < 0 || attempt >= MAX_ATTEMPTS) return null;
+  return BACKOFF_DELAYS_MS[attempt] ?? null;
+}
+
+/**
+ * Calculates the next retry timestamp based on the current attempt count.
+ * Returns null if max attempts reached (should become dead_letter).
+ */
+export function getNextRetryAt(attemptCount: number): Date | null {
+  const delay = getRetryDelay(attemptCount);
+  if (delay === null) return null;
+  return new Date(Date.now() + delay);
+}
+
+/**
+ * Whether the failure has exhausted all retry attempts.
+ */
+export function isDeadLetter(attemptCount: number): boolean {
+  return attemptCount >= MAX_ATTEMPTS;
+}
+
+export { MAX_ATTEMPTS, BACKOFF_DELAYS_MS };

--- a/src/lib/webhooks/retry-queue.ts
+++ b/src/lib/webhooks/retry-queue.ts
@@ -1,0 +1,175 @@
+import { logger } from '@/lib/logger';
+import { getNextRetryAt, isDeadLetter } from './retry-backoff';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+interface RecordFailureParams {
+  supabase: SupabaseClient;
+  webhookType: string;
+  eventType?: string;
+  payload: Record<string, unknown>;
+  error: string;
+}
+
+/**
+ * Records a webhook failure and schedules the first retry.
+ */
+export async function recordWebhookFailure({
+  supabase,
+  webhookType,
+  eventType,
+  payload,
+  error,
+}: RecordFailureParams) {
+  const nextRetry = getNextRetryAt(0);
+
+  const { error: insertError } = await supabase.from('webhook_failures').insert({
+    webhook_type: webhookType,
+    event_type: eventType ?? null,
+    payload,
+    error,
+    status: 'pending',
+    attempt_count: 0,
+    next_retry_at: nextRetry?.toISOString() ?? null,
+  } as never);
+
+  if (insertError) {
+    logger.error('[webhook-retry-queue] Failed to record failure:', insertError);
+  }
+}
+
+/**
+ * Processes pending webhook retries. Called by the cron job.
+ * Returns the number of items processed and results.
+ */
+export async function processWebhookRetries(supabase: SupabaseClient) {
+  const now = new Date().toISOString();
+
+  // Fetch retryable failures: pending/retrying with next_retry_at <= now
+  const { data: failures, error: fetchError } = await supabase
+    .from('webhook_failures')
+    .select('*')
+    .in('status', ['pending', 'retrying'])
+    .lte('next_retry_at', now)
+    .order('next_retry_at', { ascending: true })
+    .limit(50);
+
+  if (fetchError) {
+    logger.error('[webhook-retry-queue] Failed to fetch retries:', fetchError);
+    return { processed: 0, succeeded: 0, failed: 0, deadLettered: 0 };
+  }
+
+  if (!failures || failures.length === 0) {
+    return { processed: 0, succeeded: 0, failed: 0, deadLettered: 0 };
+  }
+
+  let succeeded = 0;
+  let failed = 0;
+  let deadLettered = 0;
+
+  for (const failure of failures) {
+    const newAttemptCount = failure.attempt_count + 1;
+
+    try {
+      // Attempt to replay the webhook
+      const result = await replayWebhook(failure.webhook_type, failure.payload);
+
+      if (result.success) {
+        // Mark as resolved
+        await supabase
+          .from('webhook_failures')
+          .update({
+            status: 'resolved',
+            attempt_count: newAttemptCount,
+            last_attempted_at: now,
+            resolved_at: now,
+            updated_at: now,
+          } as never)
+          .eq('id', failure.id);
+        succeeded++;
+      } else {
+        throw new Error(result.error || 'Replay failed');
+      }
+    } catch (err: any) {
+      const errorMsg = err.message || 'Unknown error';
+
+      if (isDeadLetter(newAttemptCount)) {
+        // Max attempts reached — dead letter
+        await supabase
+          .from('webhook_failures')
+          .update({
+            status: 'dead_letter',
+            attempt_count: newAttemptCount,
+            last_attempted_at: now,
+            error: errorMsg,
+            updated_at: now,
+          } as never)
+          .eq('id', failure.id);
+        deadLettered++;
+      } else {
+        // Schedule next retry
+        const nextRetry = getNextRetryAt(newAttemptCount);
+        await supabase
+          .from('webhook_failures')
+          .update({
+            status: 'retrying',
+            attempt_count: newAttemptCount,
+            last_attempted_at: now,
+            next_retry_at: nextRetry?.toISOString() ?? null,
+            error: errorMsg,
+            updated_at: now,
+          } as never)
+          .eq('id', failure.id);
+        failed++;
+      }
+    }
+  }
+
+  return { processed: failures.length, succeeded, failed, deadLettered };
+}
+
+/**
+ * Replays a webhook by re-invoking the appropriate internal handler.
+ * This is a simplified approach: POST the payload to the original webhook route.
+ */
+async function replayWebhook(
+  webhookType: string,
+  payload: Record<string, unknown>
+): Promise<{ success: boolean; error?: string }> {
+  const routeMap: Record<string, string> = {
+    stripe: '/api/stripe/webhook',
+    stripe_deposit: '/api/webhooks/stripe-deposit',
+    stripe_connect: '/api/webhooks/stripe-connect',
+    evolution_api: '/api/whatsapp/webhook',
+    resend: '/api/webhooks/resend',
+    revolut: '/api/webhooks/revolut',
+  };
+
+  const route = routeMap[webhookType];
+  if (!route) {
+    return { success: false, error: `Unknown webhook type: ${webhookType}` };
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : 'http://localhost:3000';
+
+  try {
+    const res = await fetch(`${baseUrl}${route}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-webhook-retry': 'true',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (res.ok || res.status === 200) {
+      return { success: true };
+    }
+
+    const text = await res.text().catch(() => '');
+    return { success: false, error: `HTTP ${res.status}: ${text.slice(0, 200)}` };
+  } catch (err: any) {
+    return { success: false, error: err.message };
+  }
+}

--- a/supabase/migrations/20260305000001_webhook_failures.sql
+++ b/supabase/migrations/20260305000001_webhook_failures.sql
@@ -1,0 +1,34 @@
+-- Webhook retry queue: persistent storage for failed webhook events.
+-- Max 5 attempts with exponential backoff (1min, 5min, 30min, 2h, 12h).
+-- After 5 failed attempts, status becomes 'dead_letter'.
+
+CREATE TABLE IF NOT EXISTS webhook_failures (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  webhook_type TEXT NOT NULL,        -- 'stripe', 'evolution_api', 'resend', 'revolut', 'stripe_connect', 'stripe_deposit'
+  event_type TEXT,                   -- e.g. 'payment_intent.succeeded', 'messages.upsert'
+  payload JSONB NOT NULL DEFAULT '{}',
+  error TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',  -- 'pending', 'retrying', 'resolved', 'dead_letter'
+  attempt_count INT NOT NULL DEFAULT 0,
+  max_attempts INT NOT NULL DEFAULT 5,
+  next_retry_at TIMESTAMPTZ,
+  last_attempted_at TIMESTAMPTZ,
+  resolved_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for cron: find retryable failures efficiently
+CREATE INDEX IF NOT EXISTS idx_webhook_failures_retry
+  ON webhook_failures (status, next_retry_at)
+  WHERE status IN ('pending', 'retrying');
+
+-- Index for admin dashboard: filter by type
+CREATE INDEX IF NOT EXISTS idx_webhook_failures_type
+  ON webhook_failures (webhook_type, created_at DESC);
+
+-- RLS: only service_role can access (admin/cron use service role client)
+ALTER TABLE webhook_failures ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE webhook_failures IS
+  'Webhook retry queue. RLS enabled, no user policies — only service_role can access.';

--- a/vercel.json
+++ b/vercel.json
@@ -66,6 +66,10 @@
     {
       "path": "/api/cron/expire-pending-payments",
       "schedule": "30 5 * * *"
+    },
+    {
+      "path": "/api/cron/process-webhook-retries",
+      "schedule": "*/10 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Migration**: `webhook_failures` table with status (pending/retrying/resolved/dead_letter), exponential backoff scheduling, RLS (service_role only), indexes for retry processing and admin filtering
- **Backoff**: 1min → 5min → 30min → 2h → 12h (max 5 attempts), then `dead_letter`
- **Cron**: `/api/cron/process-webhook-retries` runs every 10min, replays failed webhooks (Stripe, Evolution API, Resend, Revolut)
- **Admin Dashboard**: `/admin/webhook-failures` — KPI cards (pending/retrying/resolved/dead_letter/total), failures table with manual retry button
- **Admin API**: GET (list + counts) / POST (manual retry), protected by admin session

Closes #24

## Test plan
- [x] Unit: 14 tests — backoff delays, isDeadLetter, MAX_ATTEMPTS, ascending order
- [x] Integration: 9 tests — migration schema, cron route, admin page, API route, sidebar link, retry button
- [ ] CI green on all jobs
- [ ] Manual: webhook failure appears in admin dashboard, retry button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)