### PR TITLE
fix(ci): fail GDPR job on deploy timeout instead of silent fallback (#57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -662,9 +662,11 @@ jobs:
                 echo "url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
                 exit 0
               fi
-              echo "⚠️ Preview URL não respondeu — usando produção como fallback"
+              echo "❌ Preview URL não respondeu — deploy não ficou pronto"
+              exit 1
             else
-              echo "⚠️ Preview URL não encontrada — usando produção como fallback"
+              echo "❌ Preview URL não encontrada após 3min — deploy não ficou pronto"
+              exit 1
             fi
           fi
           echo "url=$PROD_URL" >> "$GITHUB_OUTPUT"

--- a/src/__tests__/ci/deploy-wait-timeout.test.ts
+++ b/src/__tests__/ci/deploy-wait-timeout.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(__dirname, '..', '..', '..');
+const ciPath = join(ROOT, '.github/workflows/ci.yml');
+
+describe('CI deploy wait timeout — must fail on timeout (#57)', () => {
+  const content = readFileSync(ciPath, 'utf-8');
+
+  it('does NOT silently continue when preview URL is not found', () => {
+    // Must not contain fallback warnings that allow silent continuation
+    expect(content).not.toContain('usando produção como fallback');
+  });
+
+  it('exits with error code 1 when preview URL not found', () => {
+    // After "Preview URL não encontrada" it must exit 1
+    expect(content).toContain('Preview URL não encontrada');
+    // The line after should be exit 1
+    const lines = content.split('\n');
+    const notFoundLine = lines.findIndex(l => l.includes('Preview URL não encontrada'));
+    expect(notFoundLine).toBeGreaterThan(-1);
+    const nextLine = lines[notFoundLine + 1]?.trim();
+    expect(nextLine).toBe('exit 1');
+  });
+
+  it('exits with error code 1 when preview URL does not respond', () => {
+    expect(content).toContain('Preview URL não respondeu');
+    const lines = content.split('\n');
+    const notRespondedLine = lines.findIndex(l => l.includes('Preview URL não respondeu'));
+    expect(notRespondedLine).toBeGreaterThan(-1);
+    const nextLine = lines[notRespondedLine + 1]?.trim();
+    expect(nextLine).toBe('exit 1');
+  });
+
+  it('still falls back to prod URL on push events (non-PR)', () => {
+    // The prod URL fallback should still exist for push events (line after the if block)
+    expect(content).toContain('echo "url=$PROD_URL" >> "$GITHUB_OUTPUT"');
+  });
+});

--- a/src/__tests__/ci/gdpr-preview-url.test.ts
+++ b/src/__tests__/ci/gdpr-preview-url.test.ts
@@ -31,9 +31,12 @@ describe('GDPR job uses Vercel preview URL (issue #54)', () => {
     expect(ciYml).toContain('environment_url');
   });
 
-  it('falls back to production URL when preview is unavailable', () => {
+  it('fails the job when preview is unavailable instead of falling back (#57)', () => {
     expect(ciYml).toContain('https://booking.circlehood-tech.com');
-    expect(ciYml).toContain('usando produção como fallback');
+    // Must NOT silently fall back to production — must exit 1
+    expect(ciYml).not.toContain('usando produção como fallback');
+    expect(ciYml).toContain('deploy não ficou pronto');
+    expect(ciYml).toContain('exit 1');
   });
 
   it('verifies preview URL responds before using it', () => {


### PR DESCRIPTION
## Summary
- Replace silent production fallback (`⚠️ usando produção como fallback`) with `exit 1` when Vercel preview deploy is not ready
- Two failure paths now exit explicitly: preview URL not found after 3min polling, or preview URL found but not responding
- Push events (non-PR) still fall back to production URL as before
- Updated existing `gdpr-preview-url.test.ts` to expect the new behavior
- Added new `deploy-wait-timeout.test.ts` with 4 assertions

Closes #57

## Test plan
- [x] 4 new unit tests pass: no silent fallback, exit 1 on both failure paths, prod fallback on push
- [x] 8 existing GDPR preview URL tests pass (1 updated)
- [ ] CI green on all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)