### PR TITLE
fix(ci): replace fixed waitForTimeout with polling in E2E tests (#58)

### DIFF
--- a/e2e/import-whatsapp.spec.ts
+++ b/e2e/import-whatsapp.spec.ts
@@ -78,7 +78,8 @@ test.describe('Botão "Importar do WhatsApp"', () => {
     });
 
     // Aguardar que o useEffect termine de buscar a config (pode demorar até 3s)
-    await page.waitForTimeout(3000);
+    // Wait for useEffect init to complete (fetches professional + whatsapp_config + contacts)
+    await page.waitForLoadState('networkidle', { timeout: 15_000 });
 
     const whatsappBtn = page.getByRole('button', { name: /importar do whatsapp/i });
 
@@ -113,7 +114,8 @@ test.describe('Botão "Importar do WhatsApp"', () => {
     await expect(page.getByRole('heading', { name: /importar contatos/i }).first()).toBeVisible({
       timeout: 15_000,
     });
-    await page.waitForTimeout(3000);
+    // Wait for useEffect init to complete (fetches professional + whatsapp_config + contacts)
+    await page.waitForLoadState('networkidle', { timeout: 15_000 });
 
     // Botão NÃO deve existir na página
     const count = await page.getByRole('button', { name: /importar do whatsapp/i }).count();

--- a/e2e/register-terms.spec.ts
+++ b/e2e/register-terms.spec.ts
@@ -70,12 +70,19 @@ test.describe('Checkbox de Termos — Validação', () => {
 
     // Preencher campos obrigatórios do step 2
     await page.fill('#businessName', 'Salão Teste Terms');
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(300);
 
     // Preencher slug com valor único (pode ter verificação async)
     const slug = `test-terms-${Date.now()}`;
     await page.fill('#slug', slug);
-    await page.waitForTimeout(1500);
+    // Poll for slug validation to complete (spinner disappears, check/error icon appears)
+    try {
+      await page.locator('.animate-spin').waitFor({ state: 'visible', timeout: 3000 });
+    } catch { /* spinner may have already gone */ }
+    await page.waitForFunction(
+      () => !document.querySelector('.animate-spin'),
+      { timeout: 25_000 }
+    );
 
     await page.fill('#city', 'Dublin');
 
@@ -98,10 +105,17 @@ test.describe('Checkbox de Termos — Validação', () => {
 
     // Preencher campos
     await page.fill('#businessName', 'Salão Terms OK');
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(300);
     const slug = `test-terms-ok-${Date.now()}`;
     await page.fill('#slug', slug);
-    await page.waitForTimeout(1500);
+    // Poll for slug validation to complete (spinner disappears, check/error icon appears)
+    try {
+      await page.locator('.animate-spin').waitFor({ state: 'visible', timeout: 3000 });
+    } catch { /* spinner may have already gone */ }
+    await page.waitForFunction(
+      () => !document.querySelector('.animate-spin'),
+      { timeout: 25_000 }
+    );
     await page.fill('#city', 'Lisboa');
 
     // Submeter SEM checkbox → erro aparece

--- a/src/__tests__/ci/no-fixed-waits.test.ts
+++ b/src/__tests__/ci/no-fixed-waits.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(__dirname, '..', '..', '..');
+
+describe('E2E tests use polling instead of fixed waits (#58)', () => {
+  it('register-terms.spec.ts does not use waitForTimeout(1500) for slug check', () => {
+    const content = readFileSync(join(ROOT, 'e2e/register-terms.spec.ts'), 'utf-8');
+    expect(content).not.toContain('waitForTimeout(1500)');
+    // Should use animate-spin polling pattern instead
+    expect(content).toContain('animate-spin');
+    expect(content).toContain('waitForFunction');
+  });
+
+  it('import-whatsapp.spec.ts does not use waitForTimeout(3000) for useEffect', () => {
+    const content = readFileSync(join(ROOT, 'e2e/import-whatsapp.spec.ts'), 'utf-8');
+    expect(content).not.toContain('waitForTimeout(3000)');
+    // Should use networkidle or semantic wait instead
+    expect(content).toContain('waitForLoadState');
+  });
+
+  it('register-terms.spec.ts has no waitForTimeout > 500ms', () => {
+    const content = readFileSync(join(ROOT, 'e2e/register-terms.spec.ts'), 'utf-8');
+    const matches = content.match(/waitForTimeout\((\d+)\)/g) || [];
+    for (const match of matches) {
+      const ms = Number(match.match(/\d+/)![0]);
+      expect(ms).toBeLessThanOrEqual(500);
+    }
+  });
+
+  it('import-whatsapp.spec.ts has no waitForTimeout calls at all', () => {
+    const content = readFileSync(join(ROOT, 'e2e/import-whatsapp.spec.ts'), 'utf-8');
+    expect(content).not.toMatch(/waitForTimeout\(\d+\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- **register-terms.spec.ts**: Replace `waitForTimeout(1500)` with animate-spin polling pattern — waits for slug validation spinner to appear then disappear, up to 25s
- **import-whatsapp.spec.ts**: Replace `waitForTimeout(3000)` with `waitForLoadState('networkidle')` — waits for useEffect API calls to complete instead of guessing
- **Unit test**: Verifies no `waitForTimeout` > 500ms remains in either file

Closes #58

## Test plan
- [x] 4 unit tests pass (no fixed waits verification)
- [x] Full Vitest suite passes (653/655, 2 pre-existing email failures)
- [ ] CI green — E2E tests should be more reliable with polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)