### PR TITLE
test(compliance): add cross-link tests for EN-US and ES-ES legal pages (#59)

### DIFF
--- a/e2e/legal-pages.spec.ts
+++ b/e2e/legal-pages.spec.ts
@@ -45,6 +45,12 @@ test.describe('Privacy Policy — EN-US', () => {
     await expect(page.locator('h1').first()).toContainText('Privacy Policy', { timeout: 15_000 });
     await expect(page.locator('body')).not.toContainText(/500|internal server error/i);
   });
+
+  test('link para Terms of Use visível', async ({ page }) => {
+    await page.goto(`${BASE}/en-US/privacy`);
+    const termsLink = page.locator('a[href*="/terms"]').first();
+    await expect(termsLink).toBeVisible({ timeout: 10_000 });
+  });
 });
 
 test.describe('Política de Privacidad — ES-ES', () => {
@@ -52,6 +58,12 @@ test.describe('Política de Privacidad — ES-ES', () => {
     await page.goto(`${BASE}/es-ES/privacy`);
     await expect(page.locator('h1').first()).toContainText('Política de Privacidad', { timeout: 15_000 });
     await expect(page.locator('body')).not.toContainText(/500|error interno/i);
+  });
+
+  test('link para Términos de Uso visível', async ({ page }) => {
+    await page.goto(`${BASE}/es-ES/privacy`);
+    const termsLink = page.locator('a[href*="/terms"]').first();
+    await expect(termsLink).toBeVisible({ timeout: 10_000 });
   });
 });
 
@@ -82,6 +94,12 @@ test.describe('Terms of Use — EN-US', () => {
     await expect(page.locator('h1').first()).toContainText('Terms of Use', { timeout: 15_000 });
     await expect(page.locator('body')).not.toContainText(/500|internal server error/i);
   });
+
+  test('link para Privacy Policy visível', async ({ page }) => {
+    await page.goto(`${BASE}/en-US/terms`);
+    const privacyLink = page.locator('a[href*="/privacy"]').first();
+    await expect(privacyLink).toBeVisible({ timeout: 10_000 });
+  });
 });
 
 test.describe('Términos de Uso — ES-ES', () => {
@@ -89,6 +107,12 @@ test.describe('Términos de Uso — ES-ES', () => {
     await page.goto(`${BASE}/es-ES/terms`);
     await expect(page.locator('h1').first()).toContainText('Términos de Uso', { timeout: 15_000 });
     await expect(page.locator('body')).not.toContainText(/500|error interno/i);
+  });
+
+  test('link para Política de Privacidad visível', async ({ page }) => {
+    await page.goto(`${BASE}/es-ES/terms`);
+    const privacyLink = page.locator('a[href*="/privacy"]').first();
+    await expect(privacyLink).toBeVisible({ timeout: 10_000 });
   });
 });
 

--- a/src/__tests__/ci/legal-cross-links-coverage.test.ts
+++ b/src/__tests__/ci/legal-cross-links-coverage.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(__dirname, '..', '..', '..');
+const content = readFileSync(join(ROOT, 'e2e/legal-pages.spec.ts'), 'utf-8');
+
+describe('Legal pages E2E has cross-link tests for all locales (#59)', () => {
+  it('EN-US privacy has cross-link test to terms', () => {
+    expect(content).toContain('/en-US/privacy');
+    expect(content).toMatch(/en-US\/privacy[\s\S]*?a\[href\*="\/terms"\]/);
+  });
+
+  it('ES-ES privacy has cross-link test to terms', () => {
+    expect(content).toContain('/es-ES/privacy');
+    expect(content).toMatch(/es-ES\/privacy[\s\S]*?a\[href\*="\/terms"\]/);
+  });
+
+  it('EN-US terms has cross-link test to privacy', () => {
+    expect(content).toContain('/en-US/terms');
+    expect(content).toMatch(/en-US\/terms[\s\S]*?a\[href\*="\/privacy"\]/);
+  });
+
+  it('ES-ES terms has cross-link test to privacy', () => {
+    expect(content).toContain('/es-ES/terms');
+    expect(content).toMatch(/es-ES\/terms[\s\S]*?a\[href\*="\/privacy"\]/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 4 E2E cross-link tests: privacy→terms and terms→privacy for EN-US and ES-ES
- Matches existing PT-BR coverage pattern
- Add unit test verifying all 4 cross-link tests exist in the spec file

| Locale | Título | Botão Voltar | privacy→terms | terms→privacy |
|--------|:--:|:--:|:--:|:--:|
| PT-BR | ✅ | ✅ | ✅ | ✅ |
| EN-US | ✅ | ❌ | ✅ **new** | ✅ **new** |
| ES-ES | ✅ | ❌ | ✅ **new** | ✅ **new** |

Closes #59

## Test plan
- [x] 4 unit tests pass (cross-links coverage verification)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)