### PR TITLE
fix(security): fix email_campaigns RLS tenant isolation

### DIFF
--- a/src/__tests__/security/email-campaigns-rls.test.ts
+++ b/src/__tests__/security/email-campaigns-rls.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(__dirname, '..', '..', '..');
+
+describe('Email campaigns RLS uses professionals subquery (#102)', () => {
+  describe('Migration fix exists', () => {
+    const migration = readFileSync(
+      join(ROOT, 'supabase/migrations/20260304000002_fix_email_campaigns_rls.sql'),
+      'utf-8'
+    );
+
+    it('drops all 5 old policies', () => {
+      const drops = migration.match(/DROP POLICY IF EXISTS/g) || [];
+      expect(drops.length).toBe(5);
+    });
+
+    it('creates 5 new policies with professionals subquery', () => {
+      const creates = migration.match(/CREATE POLICY/g) || [];
+      expect(creates.length).toBe(5);
+    });
+
+    it('all policies use professionals WHERE user_id = auth.uid()', () => {
+      const subqueries = migration.match(
+        /SELECT id FROM professionals WHERE user_id = auth\.uid\(\)/g
+      ) || [];
+      // 4 for email_campaigns + 1 nested for email_campaign_recipients
+      expect(subqueries.length).toBe(5);
+    });
+
+    it('no policy uses direct professional_id = auth.uid()', () => {
+      // Should NOT have the old broken pattern
+      expect(migration).not.toMatch(/professional_id\s*=\s*auth\.uid\(\)/);
+    });
+
+    it('covers SELECT, INSERT, UPDATE, DELETE for email_campaigns', () => {
+      expect(migration).toContain('FOR SELECT');
+      expect(migration).toContain('FOR INSERT');
+      expect(migration).toContain('FOR UPDATE');
+      expect(migration).toContain('FOR DELETE');
+    });
+
+    it('covers email_campaign_recipients SELECT', () => {
+      expect(migration).toContain('email_campaign_recipients FOR SELECT');
+    });
+  });
+
+  describe('API routes use professional.id instead of user.id', () => {
+    it('email-campaigns/route.ts queries by professional.id', () => {
+      const content = readFileSync(
+        join(ROOT, 'src/app/api/email-campaigns/route.ts'),
+        'utf-8'
+      );
+      // Should lookup professional first
+      expect(content).toContain(".eq('user_id', user.id)");
+      expect(content).toContain(".eq('professional_id', professional.id)");
+      // Should NOT use user.id as professional_id directly
+      expect(content).not.toContain("professional_id: user.id");
+      expect(content).not.toContain(".eq('professional_id', user.id)");
+    });
+
+    it('email-campaigns/[id]/send/route.ts uses professional.id', () => {
+      const content = readFileSync(
+        join(ROOT, 'src/app/api/email-campaigns/[id]/send/route.ts'),
+        'utf-8'
+      );
+      // Should lookup professional first
+      expect(content).toContain(".eq('user_id', user.id)");
+      expect(content).toContain(".eq('professional_id', professional.id)");
+      // Should NOT use user.id as professional_id
+      expect(content).not.toContain("p_professional_id: user.id");
+      expect(content).not.toContain(".eq('professional_id', user.id)");
+    });
+
+    it('RPC get_contacts_by_segment receives professional.id', () => {
+      const content = readFileSync(
+        join(ROOT, 'src/app/api/email-campaigns/[id]/send/route.ts'),
+        'utf-8'
+      );
+      expect(content).toContain('p_professional_id: professional.id');
+    });
+  });
+});

--- a/src/app/api/email-campaigns/[id]/send/route.ts
+++ b/src/app/api/email-campaigns/[id]/send/route.ts
@@ -16,6 +16,17 @@ export async function POST(
 
   const { id } = await params
 
+  // Lookup professional_id from auth user
+  const { data: professional } = await supabase
+    .from('professionals')
+    .select('id')
+    .eq('user_id', user.id)
+    .single()
+
+  if (!professional) {
+    return NextResponse.json({ error: 'Professional not found' }, { status: 404 })
+  }
+
   // Buscar campanha
   const { data: campaign, error: campaignError } = await supabase
     .from('email_campaigns')
@@ -27,7 +38,7 @@ export async function POST(
       )
     `)
     .eq('id', id)
-    .eq('professional_id', user.id)
+    .eq('professional_id', professional.id)
     .single()
 
   if (campaignError || !campaign) {
@@ -49,7 +60,7 @@ export async function POST(
   const { data: contacts, error: contactsError } = await supabase.rpc(
     'get_contacts_by_segment',
     {
-      p_professional_id: user.id,
+      p_professional_id: professional.id,
       p_segment: campaign.target_segment,
       p_custom_filters: campaign.custom_filters || {}
     }
@@ -99,7 +110,7 @@ export async function POST(
       recipients,
       tags: [
         { name: 'campaign_id', value: campaign.id },
-        { name: 'professional_id', value: user.id }
+        { name: 'professional_id', value: professional.id }
       ]
     })
 

--- a/src/app/api/email-campaigns/route.ts
+++ b/src/app/api/email-campaigns/route.ts
@@ -11,13 +11,24 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  // Lookup professional_id from auth user
+  const { data: professional } = await supabase
+    .from('professionals')
+    .select('id')
+    .eq('user_id', user.id)
+    .single()
+
+  if (!professional) {
+    return NextResponse.json({ error: 'Professional not found' }, { status: 404 })
+  }
+
   const { searchParams } = new URL(request.url)
   const status = searchParams.get('status')
 
   let query = supabase
     .from('email_campaigns')
     .select('*')
-    .eq('professional_id', user.id)
+    .eq('professional_id', professional.id)
     .order('created_at', { ascending: false })
 
   if (status && status !== 'all') {
@@ -75,11 +86,22 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  // Calcular total de destinatários (simulado)
+  // Lookup professional_id from auth user
+  const { data: professional } = await supabase
+    .from('professionals')
+    .select('id')
+    .eq('user_id', user.id)
+    .single()
+
+  if (!professional) {
+    return NextResponse.json({ error: 'Professional not found' }, { status: 404 })
+  }
+
+  // Calcular total de destinatários
   const { data: contactsCount } = await supabase.rpc(
     'get_contacts_by_segment',
     {
-      p_professional_id: user.id,
+      p_professional_id: professional.id,
       p_segment: targetSegment || 'all',
       p_custom_filters: customFilters || {}
     }
@@ -91,7 +113,7 @@ export async function POST(request: NextRequest) {
   const { data: campaign, error } = await supabase
     .from('email_campaigns')
     .insert({
-      professional_id: user.id,
+      professional_id: professional.id,
       name,
       subject,
       from_name: fromName,

--- a/supabase/migrations/20260304000002_fix_email_campaigns_rls.sql
+++ b/supabase/migrations/20260304000002_fix_email_campaigns_rls.sql
@@ -1,0 +1,36 @@
+-- Fix #102: email_campaigns RLS policies usam auth.uid() diretamente,
+-- mas professional_id referencia professionals.id (não auth.users.id).
+-- Corrige para usar subquery que resolve o user_id → professional_id.
+
+-- email_campaigns: SELECT
+DROP POLICY IF EXISTS "Profissional pode ver suas campanhas" ON email_campaigns;
+CREATE POLICY "Profissional pode ver suas campanhas"
+  ON email_campaigns FOR SELECT
+  USING (professional_id IN (SELECT id FROM professionals WHERE user_id = auth.uid()));
+
+-- email_campaigns: INSERT
+DROP POLICY IF EXISTS "Profissional pode criar campanhas" ON email_campaigns;
+CREATE POLICY "Profissional pode criar campanhas"
+  ON email_campaigns FOR INSERT
+  WITH CHECK (professional_id IN (SELECT id FROM professionals WHERE user_id = auth.uid()));
+
+-- email_campaigns: UPDATE
+DROP POLICY IF EXISTS "Profissional pode atualizar suas campanhas" ON email_campaigns;
+CREATE POLICY "Profissional pode atualizar suas campanhas"
+  ON email_campaigns FOR UPDATE
+  USING (professional_id IN (SELECT id FROM professionals WHERE user_id = auth.uid()));
+
+-- email_campaigns: DELETE
+DROP POLICY IF EXISTS "Profissional pode deletar suas campanhas" ON email_campaigns;
+CREATE POLICY "Profissional pode deletar suas campanhas"
+  ON email_campaigns FOR DELETE
+  USING (professional_id IN (SELECT id FROM professionals WHERE user_id = auth.uid()));
+
+-- email_campaign_recipients: SELECT (via campaign ownership)
+DROP POLICY IF EXISTS "Profissional pode ver destinatários" ON email_campaign_recipients;
+CREATE POLICY "Profissional pode ver destinatários"
+  ON email_campaign_recipients FOR SELECT
+  USING (campaign_id IN (
+    SELECT id FROM email_campaigns
+    WHERE professional_id IN (SELECT id FROM professionals WHERE user_id = auth.uid())
+  ));


### PR DESCRIPTION
## Summary
- Fix RLS policies on `email_campaigns` and `email_campaign_recipients` that used `professional_id = auth.uid()` directly — `professional_id` references `professionals.id`, not `auth.users.id`
- Fix API routes (`/api/email-campaigns` GET/POST and `/api/email-campaigns/[id]/send`) that stored `user.id` as `professional_id`, breaking FK integrity
- Migration recreates all 5 RLS policies with correct subquery: `professional_id IN (SELECT id FROM professionals WHERE user_id = auth.uid())`

## Test plan
- [x] 9 unit tests verify migration structure and API code patterns
- [x] `test:fast` passes (666/668, 2 pre-existing failures in email/unsubscribe)
- [x] `next build` passes
- [ ] CI green

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)