### PR TITLE
fix(booking): replace booking_time with start_time in reschedule

### DIFF
--- a/src/__tests__/security/reschedule-column-fix.test.ts
+++ b/src/__tests__/security/reschedule-column-fix.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(__dirname, '..', '..', '..');
+
+describe('Reschedule routes use start_time instead of booking_time (#103)', () => {
+  it('change/route.ts uses start_time for availability check', () => {
+    const content = readFileSync(
+      join(ROOT, 'src/app/api/reschedule/[token]/change/route.ts'),
+      'utf-8'
+    );
+    expect(content).toContain("'start_time'");
+    expect(content).not.toContain("'booking_time'");
+    expect(content).not.toContain('booking_time:');
+  });
+
+  it('change/route.ts uses start_time for update', () => {
+    const content = readFileSync(
+      join(ROOT, 'src/app/api/reschedule/[token]/change/route.ts'),
+      'utf-8'
+    );
+    expect(content).toContain('start_time: new_time');
+  });
+
+  it('[token]/route.ts selects start_time from bookings', () => {
+    const content = readFileSync(
+      join(ROOT, 'src/app/api/reschedule/[token]/route.ts'),
+      'utf-8'
+    );
+    expect(content).toContain('start_time');
+    expect(content).not.toContain('booking_time');
+  });
+
+  it('reschedule page.tsx renders start_time', () => {
+    const content = readFileSync(
+      join(ROOT, 'src/app/[locale]/(public)/reschedule/[token]/page.tsx'),
+      'utf-8'
+    );
+    expect(content).toContain('start_time');
+    expect(content).not.toContain('booking_time');
+  });
+});

--- a/src/app/[locale]/(public)/reschedule/[token]/page.tsx
+++ b/src/app/[locale]/(public)/reschedule/[token]/page.tsx
@@ -164,7 +164,7 @@ export default function ReschedulePage() {
                   </div>
                   <div>
                     <span className="text-sm text-gray-600">Horário:</span>
-                    <p className="font-semibold">{booking.booking_time.substring(0, 5)}</p>
+                    <p className="font-semibold">{booking.start_time.substring(0, 5)}</p>
                   </div>
                   <div>
                     <span className="text-sm text-gray-600">Local:</span>

--- a/src/app/api/reschedule/[token]/change/route.ts
+++ b/src/app/api/reschedule/[token]/change/route.ts
@@ -42,7 +42,7 @@ export async function POST(
       .select('id')
       .eq('professional_id', tokenData.bookings.professional_id)
       .eq('booking_date', new_date)
-      .eq('booking_time', new_time)
+      .eq('start_time', new_time)
       .eq('status', 'confirmed')
       .single();
 
@@ -55,7 +55,7 @@ export async function POST(
       .from('bookings')
       .update({
         booking_date: new_date,
-        booking_time: new_time,
+        start_time: new_time,
       })
       .eq('id', tokenData.bookings.id)
       .select('*, services(name, price), professionals(business_name)')

--- a/src/app/api/reschedule/[token]/route.ts
+++ b/src/app/api/reschedule/[token]/route.ts
@@ -19,7 +19,7 @@ export async function GET(
         bookings (
           id,
           booking_date,
-          booking_time,
+          start_time,
           contact_name,
           contact_phone,
           status,


### PR DESCRIPTION
## Summary
- Replace nonexistent column `booking_time` with correct `start_time` in 3 files:
  - `src/app/api/reschedule/[token]/change/route.ts` — availability check + update query
  - `src/app/api/reschedule/[token]/route.ts` — select query
  - `src/app/[locale]/(public)/reschedule/[token]/page.tsx` — UI rendering

## Test plan
- [x] 4 unit tests verify no `booking_time` references remain in reschedule routes
- [x] `next build` passes
- [ ] CI green

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)