### PR TITLE
fix(security): fix revolut_payments RLS tenant isolation

### DIFF
--- a/src/__tests__/security/revolut-payments-rls.test.ts
+++ b/src/__tests__/security/revolut-payments-rls.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(__dirname, '..', '..', '..');
+
+describe('Revolut payments RLS uses professionals subquery (#104)', () => {
+  describe('Migration fix', () => {
+    const migration = readFileSync(
+      join(ROOT, 'supabase/migrations/20260304000003_fix_revolut_payments_rls.sql'),
+      'utf-8'
+    );
+
+    it('drops the old policy', () => {
+      expect(migration).toContain('DROP POLICY IF EXISTS');
+      expect(migration).toContain('revolut_payments');
+    });
+
+    it('creates new policy with professionals subquery', () => {
+      expect(migration).toContain('CREATE POLICY');
+      expect(migration).toContain(
+        'SELECT id FROM professionals WHERE user_id = auth.uid()'
+      );
+    });
+
+    it('does not use direct professional_id = auth.uid()', () => {
+      expect(migration).not.toMatch(/professional_id\s*=\s*auth\.uid\(\)/);
+    });
+  });
+
+  describe('API route uses professional.id', () => {
+    const content = readFileSync(
+      join(ROOT, 'src/app/api/payments/revolut/create/route.ts'),
+      'utf-8'
+    );
+
+    it('looks up professional by user_id', () => {
+      expect(content).toContain(".eq('user_id', user.id)");
+    });
+
+    it('does not query professionals by id = user.id', () => {
+      // The old broken pattern: .eq('id', user.id) on professionals table
+      expect(content).not.toMatch(/\.eq\('id', user\.id\)/);
+    });
+
+    it('stores professional.id as professional_id', () => {
+      expect(content).toContain('professional_id: professional.id');
+      expect(content).not.toContain('professional_id: user.id');
+    });
+
+    it('passes professional.id to createSubscriptionOrder', () => {
+      expect(content).toContain('professional.id,');
+      expect(content).not.toMatch(/createSubscriptionOrder\(\s*user\.id/);
+    });
+  });
+});

--- a/src/app/api/payments/revolut/create/route.ts
+++ b/src/app/api/payments/revolut/create/route.ts
@@ -11,11 +11,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  // Buscar dados do profissional
+  // Buscar dados do profissional (by user_id, not by id)
   const { data: professional, error: profError } = await supabase
     .from('professionals')
-    .select('name, email')
-    .eq('id', user.id)
+    .select('id, name, email')
+    .eq('user_id', user.id)
     .single()
 
   if (profError || !professional) {
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
   try {
     // Criar ordem de assinatura
     const order = await createSubscriptionOrder(
-      user.id,
+      professional.id,
       professional.email,
       professional.name,
       apiKey
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest) {
     const { data: payment, error: paymentError } = await supabase
       .from('revolut_payments')
       .insert({
-        professional_id: user.id,
+        professional_id: professional.id,
         revolut_order_id: order.id,
         merchant_order_ref: order.merchantOrderExtRef,
         amount: 9.99,

--- a/supabase/migrations/20260304000003_fix_revolut_payments_rls.sql
+++ b/supabase/migrations/20260304000003_fix_revolut_payments_rls.sql
@@ -1,0 +1,7 @@
+-- Fix #104: revolut_payments RLS policy uses auth.uid() directly,
+-- but professional_id references professionals.id (not auth.users.id).
+
+DROP POLICY IF EXISTS "Profissional pode ver seus pagamentos Revolut" ON revolut_payments;
+CREATE POLICY "Profissional pode ver seus pagamentos Revolut"
+  ON revolut_payments FOR SELECT
+  USING (professional_id IN (SELECT id FROM professionals WHERE user_id = auth.uid()));


### PR DESCRIPTION
## Summary
- Fix RLS policy on `revolut_payments` that used `professional_id = auth.uid()` — should use professionals subquery
- Fix API route `payments/revolut/create` that queried professionals by `.eq('id', user.id)` instead of `.eq('user_id', user.id)`
- Fix API route storing `user.id` as `professional_id` instead of `professional.id`

## Test plan
- [x] 7 unit tests verify migration and API code
- [x] `next build` passes
- [ ] CI green

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)