### PR TITLE
fix(security): sanitize error messages in 38 API routes (#106)

### DIFF
--- a/src/__tests__/security/no-error-message-leak.test.ts
+++ b/src/__tests__/security/no-error-message-leak.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+const API_DIR = join(__dirname, '..', '..', 'app', 'api');
+
+/**
+ * Recursively collect all .ts files in a directory.
+ */
+function collectTsFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...collectTsFiles(full));
+    } else if (full.endsWith('.ts') || full.endsWith('.tsx')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe('API routes do not leak error.message to clients (#106)', () => {
+  const allFiles = collectTsFiles(API_DIR);
+  // Exclude test files
+  const apiFiles = allFiles.filter((f) => !f.includes('__tests__'));
+
+  it('found API route files to check', () => {
+    expect(apiFiles.length).toBeGreaterThan(20);
+  });
+
+  it('no route returns { error: error.message } in NextResponse.json', () => {
+    const violations: string[] = [];
+
+    for (const file of apiFiles) {
+      const content = readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        // Skip cron_logs server-side logging (error_message: is OK)
+        if (line.includes('error_message:')) continue;
+        // Skip metadata inserts (server-side)
+        if (line.includes('metadata:')) continue;
+        // Skip internal arrays (errors.push)
+        if (line.includes('errors.push')) continue;
+
+        // Check for { error: error.message } pattern in response
+        if (
+          line.includes('error: error.message') &&
+          !line.includes('error_message')
+        ) {
+          const relPath = file.replace(API_DIR, 'api');
+          violations.push(`${relPath}:${i + 1}: ${line.trim()}`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('no route returns message: error.message in NextResponse.json response', () => {
+    const violations: string[] = [];
+
+    for (const file of apiFiles) {
+      const content = readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        // Skip cron_logs inserts (error_message: is server-side)
+        if (line.includes('error_message:')) continue;
+        // Skip metadata inserts
+        if (line.includes('metadata:')) continue;
+
+        // message: error.message in response body
+        if (line.match(/\bmessage: error\.message\b/)) {
+          const relPath = file.replace(API_DIR, 'api');
+          violations.push(`${relPath}:${i + 1}: ${line.trim()}`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/src/app/api/admin/control-center/[id]/resolve/route.ts
+++ b/src/app/api/admin/control-center/[id]/resolve/route.ts
@@ -23,7 +23,7 @@ export async function PATCH(
     .single();
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 
   if (!data) {

--- a/src/app/api/admin/control-center/route.ts
+++ b/src/app/api/admin/control-center/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
     .order('created_at', { ascending: false });
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 
   return NextResponse.json(data);
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
     .single();
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 
   return NextResponse.json(data, { status: 201 });

--- a/src/app/api/admin/restore-account/route.ts
+++ b/src/app/api/admin/restore-account/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
     .not('deleted_at', 'is', null);
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 
   return NextResponse.json({ success: true });

--- a/src/app/api/admin/support/tickets/[id]/route.ts
+++ b/src/app/api/admin/support/tickets/[id]/route.ts
@@ -34,7 +34,7 @@ export async function PATCH(
     .update(updates)
     .eq('id', id);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
 
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -33,7 +33,7 @@ export async function POST() {
 
     if (error) {
       logger.error('[resend-verification] error:', error);
-      return NextResponse.json({ error: error.message }, { status: 429 });
+      return NextResponse.json({ error: 'Internal server error' }, { status: 429 });
     }
 
     return NextResponse.json({ success: true });

--- a/src/app/api/bookings/cancel-notification/route.ts
+++ b/src/app/api/bookings/cancel-notification/route.ts
@@ -135,6 +135,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: true, whatsappSent, emailSent });
   } catch (error: any) {
     logger.error('[cancel-notification] Erro:', error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/bookings/check/route.ts
+++ b/src/app/api/bookings/check/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: Request) {
     .order('created_at', { ascending: false });
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 
   // Mapear campos para o formato esperado pelos testes

--- a/src/app/api/contacts/import-whatsapp/route.ts
+++ b/src/app/api/contacts/import-whatsapp/route.ts
@@ -210,7 +210,7 @@ export async function POST(_request: NextRequest) {
   } catch (error: any) {
     logger.error('[import-whatsapp] Unexpected error:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/cron/birthdays/route.ts
+++ b/src/app/api/cron/birthdays/route.ts
@@ -164,7 +164,7 @@ export async function POST(request: NextRequest) {
   } catch (error: any) {
     logger.error('Fatal error in birthdays cron:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/cron/cleanup-tokens/route.ts
+++ b/src/app/api/cron/cleanup-tokens/route.ts
@@ -57,7 +57,7 @@ export async function POST(request: NextRequest) {
     });
 
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/cron/expire-pending-payments/route.ts
+++ b/src/app/api/cron/expire-pending-payments/route.ts
@@ -67,7 +67,7 @@ export async function POST(request: NextRequest) {
     } catch { /* non-fatal */ }
 
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/cron/expire-waitlist/route.ts
+++ b/src/app/api/cron/expire-waitlist/route.ts
@@ -57,7 +57,7 @@ export async function POST(request: NextRequest) {
     });
 
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/cron/process-deletions/route.ts
+++ b/src/app/api/cron/process-deletions/route.ts
@@ -117,7 +117,7 @@ export async function POST(request: NextRequest) {
     });
 
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/cron/refresh-analytics/route.ts
+++ b/src/app/api/cron/refresh-analytics/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
     });
 
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -112,7 +112,7 @@ export async function POST(request: NextRequest) {
   } catch (error: any) {
     logger.error('Fatal error in reminders cron:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/cron/send-campaign-messages/route.ts
+++ b/src/app/api/cron/send-campaign-messages/route.ts
@@ -150,7 +150,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ sent, failed });
   } catch (error: any) {
     logger.error('[campaign-cron] Erro fatal:', error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
 

--- a/src/app/api/cron/send-maintenance-reminders/route.ts
+++ b/src/app/api/cron/send-maintenance-reminders/route.ts
@@ -273,7 +273,7 @@ export async function POST(request: NextRequest) {
         });
       } catch (error: any) {
         logger.error(`Error processing booking ${booking.id}:`, error);
-        errors.push({ booking_id: booking.id, error: error.message });
+        errors.push({ booking_id: booking.id, error: 'Processing failed' });
       }
     }
 
@@ -308,7 +308,7 @@ export async function POST(request: NextRequest) {
     });
 
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -238,7 +238,7 @@ export async function POST(request: NextRequest) {
         logger.error(`Error processing booking ${booking.id}:`, error);
         errors.push({
           booking_id: booking.id,
-          error: error.message,
+          error: 'Processing failed',
         });
       }
     }
@@ -279,7 +279,7 @@ export async function POST(request: NextRequest) {
     });
 
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/cron/send-retention-emails/route.ts
+++ b/src/app/api/cron/send-retention-emails/route.ts
@@ -149,7 +149,7 @@ export async function POST(request: NextRequest) {
       } as never);
     } catch { /* non-fatal */ }
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/cron/send-trial-expiration-notifications/route.ts
+++ b/src/app/api/cron/send-trial-expiration-notifications/route.ts
@@ -150,7 +150,7 @@ export async function POST(request: NextRequest) {
 
   if (error) {
     logger.error('[send-trial-expiration-notifications] query error:', error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 
   if (!professionals || professionals.length === 0) {

--- a/src/app/api/email-campaigns/[id]/send/route.ts
+++ b/src/app/api/email-campaigns/[id]/send/route.ts
@@ -160,7 +160,7 @@ export async function POST(
       .eq('id', id)
 
     return NextResponse.json(
-      { error: error.message || 'Failed to send campaign' },
+      { error: 'Internal server error' },
       { status: 500 }
     )
   }

--- a/src/app/api/email-campaigns/route.ts
+++ b/src/app/api/email-campaigns/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: NextRequest) {
 
   if (error) {
     logger.error('Error fetching campaigns:', error)
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 
   return NextResponse.json({ campaigns })
@@ -133,7 +133,7 @@ export async function POST(request: NextRequest) {
 
   if (error) {
     logger.error('Error creating campaign:', error)
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 
   return NextResponse.json({ campaign }, { status: 201 })

--- a/src/app/api/integrations/google-calendar/disconnect/route.ts
+++ b/src/app/api/integrations/google-calendar/disconnect/route.ts
@@ -58,7 +58,6 @@ export async function POST() {
     return NextResponse.json(
       {
         error: 'Failed to disconnect Google Calendar',
-        message: error.message,
       },
       { status: 500 }
     );

--- a/src/app/api/integrations/google-calendar/sync/route.ts
+++ b/src/app/api/integrations/google-calendar/sync/route.ts
@@ -62,7 +62,6 @@ export async function POST() {
     return NextResponse.json(
       {
         error: 'Synchronization failed',
-        message: error.message,
       },
       { status: 500 }
     );

--- a/src/app/api/integrations/instagram/post/route.ts
+++ b/src/app/api/integrations/instagram/post/route.ts
@@ -119,7 +119,7 @@ export async function POST(request: NextRequest) {
       })
 
     return NextResponse.json(
-      { error: error.message || 'Failed to post to Instagram' },
+      { error: 'Internal server error' },
       { status: 500 }
     )
   }

--- a/src/app/api/integrations/route.ts
+++ b/src/app/api/integrations/route.ts
@@ -58,7 +58,6 @@ export async function GET() {
     return NextResponse.json(
       {
         error: 'Failed to fetch integrations',
-        message: error.message,
       },
       { status: 500 }
     );

--- a/src/app/api/loyalty/card/[token]/route.ts
+++ b/src/app/api/loyalty/card/[token]/route.ts
@@ -57,7 +57,7 @@ export async function GET(
   } catch (error: any) {
     logger.error('Error fetching loyalty card:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/loyalty/cards/route.ts
+++ b/src/app/api/loyalty/cards/route.ts
@@ -37,7 +37,7 @@ export async function GET() {
   } catch (error: any) {
     logger.error('Error fetching loyalty cards:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/notifications/send/route.ts
+++ b/src/app/api/notifications/send/route.ts
@@ -109,7 +109,7 @@ export async function POST(request: Request) {
           })
           .eq('id', notification.id);
 
-        results.push({ id: notification.id, status: 'failed', error: error.message });
+        results.push({ id: notification.id, status: 'failed', error: 'Send failed' });
       }
     }
 
@@ -121,7 +121,7 @@ export async function POST(request: Request) {
   } catch (error: any) {
     logger.error('Error in notification sender:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/packages/route.ts
+++ b/src/app/api/packages/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
   } catch (error: any) {
     logger.error('Error fetching packages:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }
@@ -102,7 +102,7 @@ export async function POST(request: NextRequest) {
   } catch (error: any) {
     logger.error('Error creating package:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/payments/revolut/create/route.ts
+++ b/src/app/api/payments/revolut/create/route.ts
@@ -82,7 +82,7 @@ export async function POST(request: NextRequest) {
   } catch (error: any) {
     logger.error('Revolut API error:', error)
     return NextResponse.json(
-      { error: error.message || 'Failed to create Revolut order' },
+      { error: 'Internal server error' },
       { status: 500 }
     )
   }

--- a/src/app/api/reschedule/[token]/cancel/route.ts
+++ b/src/app/api/reschedule/[token]/cancel/route.ts
@@ -105,7 +105,7 @@ export async function POST(
   } catch (error: any) {
     logger.error('Error cancelling booking:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/reschedule/[token]/change/route.ts
+++ b/src/app/api/reschedule/[token]/change/route.ts
@@ -85,7 +85,7 @@ export async function POST(
   } catch (error: any) {
     logger.error('Error rescheduling booking:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/reschedule/[token]/route.ts
+++ b/src/app/api/reschedule/[token]/route.ts
@@ -63,7 +63,7 @@ export async function GET(
   } catch (error: any) {
     logger.error('Error validating token:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/support/tickets/[id]/reply/route.ts
+++ b/src/app/api/support/tickets/[id]/reply/route.ts
@@ -37,7 +37,7 @@ export async function POST(
     message: message.trim(),
   });
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
 
   // Update status to in_progress if was still open
   if (ticket.status === 'open') {

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: NextRequest) {
   } catch (error: any) {
     logger.error('Error fetching waitlist:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }
@@ -101,7 +101,7 @@ export async function POST(request: NextRequest) {
   } catch (error: any) {
     logger.error('Error adding to waitlist:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }
@@ -149,7 +149,7 @@ export async function DELETE(request: NextRequest) {
   } catch (error: any) {
     logger.error('Error removing from waitlist:', error);
     return NextResponse.json(
-      { error: 'Internal server error', message: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -112,7 +112,7 @@ export async function POST(request: NextRequest) {
   } catch (error: any) {
     logger.error('Error processing Resend webhook:', error)
     return NextResponse.json(
-      { error: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     )
   }

--- a/src/app/api/webhooks/revolut/route.ts
+++ b/src/app/api/webhooks/revolut/route.ts
@@ -120,7 +120,7 @@ export async function POST(request: NextRequest) {
   } catch (error: any) {
     logger.error('Error processing Revolut webhook:', error)
     return NextResponse.json(
-      { error: error.message },
+      { error: 'Internal server error' },
       { status: 500 }
     )
   }


### PR DESCRIPTION
## Summary
- Replaces all `error.message` leaks in client-facing JSON responses across 38 API routes with generic messages (`'Internal server error'`, `'Processing failed'`, `'Send failed'`)
- Server-side logging (`cron_logs.error_message`, `logger.error`) is preserved for debugging
- Adds regression test (`no-error-message-leak.test.ts`) that scans all API files to prevent future leaks

## Test plan
- [x] `npx vitest run src/__tests__/security/no-error-message-leak.test.ts` — 3 tests pass
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] `npm run test:fast` — 49/50 pass (1 unrelated failure from unstaged email work)
- [ ] CI green

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)