### PR TITLE
fix(security): add file size validation to gallery upload (#107)

### DIFF
--- a/src/__tests__/security/gallery-upload-size.test.ts
+++ b/src/__tests__/security/gallery-upload-size.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROUTE_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  'app',
+  'api',
+  'gallery',
+  'upload',
+  'route.ts'
+);
+
+describe('Gallery upload file size validation (#107)', () => {
+  const source = readFileSync(ROUTE_PATH, 'utf-8');
+
+  it('validates content-length header before parsing FormData', () => {
+    // Must check content-length BEFORE request.formData()
+    const contentLengthIndex = source.indexOf('content-length');
+    const formDataIndex = source.indexOf('request.formData()');
+
+    expect(contentLengthIndex).toBeGreaterThan(-1);
+    expect(formDataIndex).toBeGreaterThan(-1);
+    expect(contentLengthIndex).toBeLessThan(formDataIndex);
+  });
+
+  it('returns 413 for oversized requests', () => {
+    expect(source).toContain('status: 413');
+  });
+
+  it('defines MAX_REQUEST_SIZE constant', () => {
+    expect(source).toMatch(/MAX_REQUEST_SIZE\s*=\s*50\s*\*\s*1024\s*\*\s*1024/);
+  });
+
+  it('defines MAX_FILE_SIZE constant (5MB)', () => {
+    expect(source).toMatch(/MAX_FILE_SIZE\s*=\s*5\s*\*\s*1024\s*\*\s*1024/);
+  });
+
+  it('validates individual file sizes after parsing', () => {
+    expect(source).toContain('f.size > MAX_FILE_SIZE');
+  });
+
+  it('checks all upload files (file, beforeFile, afterFile)', () => {
+    expect(source).toContain('[file, beforeFile, afterFile]');
+  });
+});

--- a/src/app/api/gallery/upload/route.ts
+++ b/src/app/api/gallery/upload/route.ts
@@ -2,7 +2,16 @@ import { logger } from '@/lib/logger';
 import { createClient } from '@/lib/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
 
+const MAX_REQUEST_SIZE = 50 * 1024 * 1024; // 50 MB total
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB per file
+
 export async function POST(request: NextRequest) {
+  // Validate content-length before parsing body
+  const contentLength = request.headers.get('content-length');
+  if (contentLength && parseInt(contentLength, 10) > MAX_REQUEST_SIZE) {
+    return NextResponse.json({ error: 'Request too large' }, { status: 413 });
+  }
+
   const supabase = await createClient();
 
   // Auth check
@@ -37,6 +46,17 @@ export async function POST(request: NextRequest) {
 
     if (!file && (!isBeforeAfter || !beforeFile || !afterFile)) {
       return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+    }
+
+    // Validate individual file sizes
+    const filesToCheck = [file, beforeFile, afterFile].filter(Boolean) as File[];
+    for (const f of filesToCheck) {
+      if (f.size > MAX_FILE_SIZE) {
+        return NextResponse.json(
+          { error: 'File too large. Maximum size is 5MB per file.' },
+          { status: 413 }
+        );
+      }
     }
 
     // Sanitize file extension to prevent path traversal


### PR DESCRIPTION
## Summary
- Validates `content-length` header (50MB max) **before** parsing FormData to prevent memory exhaustion
- Validates individual file sizes (5MB max per file, aligned with Supabase bucket limit)
- Checks all upload files: `file`, `beforeFile`, `afterFile`
- Returns 413 (Payload Too Large) for oversized requests

## Test plan
- [x] `npx vitest run src/__tests__/security/gallery-upload-size.test.ts` — 6 tests pass
- [x] `npx tsc --noEmit` — no errors
- [ ] CI green

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)