### PR TITLE
fix(security): add professional_id to WhatsApp tables (#109)

### DIFF
--- a/src/__tests__/security/whatsapp-professional-id.test.ts
+++ b/src/__tests__/security/whatsapp-professional-id.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'supabase',
+  'migrations',
+  '20260304000005_add_professional_id_whatsapp_tables.sql'
+);
+
+const SEND_ROUTE_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  'app',
+  'api',
+  'whatsapp',
+  'send',
+  'route.ts'
+);
+
+describe('WhatsApp tables multi-tenant isolation (#109)', () => {
+  it('migration file exists', () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true);
+  });
+
+  describe('migration adds professional_id to all 3 tables', () => {
+    const migration = readFileSync(MIGRATION_PATH, 'utf-8');
+
+    it('adds professional_id to whatsapp_conversations', () => {
+      expect(migration).toContain('ALTER TABLE whatsapp_conversations');
+      expect(migration).toContain(
+        'professional_id UUID REFERENCES professionals(id) ON DELETE CASCADE'
+      );
+    });
+
+    it('adds professional_id to ai_instructions', () => {
+      expect(migration).toContain('ALTER TABLE ai_instructions');
+    });
+
+    it('adds professional_id to whatsapp_templates', () => {
+      expect(migration).toContain('ALTER TABLE whatsapp_templates');
+    });
+
+    it('back-fills professional_id from professionals.user_id', () => {
+      // All 3 tables must have back-fill UPDATE statements
+      const backfillCount = (migration.match(/UPDATE [\s\S]*?SET professional_id = p\.id/g) || [])
+        .length;
+      expect(backfillCount).toBe(3);
+    });
+
+    it('creates indexes on professional_id', () => {
+      expect(migration).toContain('idx_whatsapp_conversations_professional');
+      expect(migration).toContain('idx_ai_instructions_professional');
+      expect(migration).toContain('idx_whatsapp_templates_professional');
+    });
+
+    it('updates RLS policies to use professional_id subquery', () => {
+      expect(migration).toContain(
+        'SELECT id FROM professionals WHERE user_id = auth.uid()'
+      );
+      // Must drop old policies before creating new ones
+      const dropCount = (migration.match(/DROP POLICY IF EXISTS/g) || []).length;
+      expect(dropCount).toBeGreaterThanOrEqual(3);
+    });
+
+    it('preserves user_id fallback in RLS for backwards compatibility', () => {
+      // New policies should still allow user_id = auth.uid() as fallback
+      // for rows not yet back-filled
+      expect(migration).toContain('OR user_id = auth.uid()');
+    });
+  });
+
+  describe('whatsapp/send/route.ts uses correct column', () => {
+    const sendRoute = readFileSync(SEND_ROUTE_PATH, 'utf-8');
+
+    it('does not filter whatsapp_config by professional_id (column does not exist)', () => {
+      // whatsapp_config does NOT have professional_id — must use user_id
+      expect(sendRoute).not.toContain("eq('professional_id'");
+    });
+
+    it('filters whatsapp_config by user_id', () => {
+      expect(sendRoute).toContain("eq('user_id', user.id)");
+    });
+  });
+});

--- a/src/app/api/whatsapp/send/route.ts
+++ b/src/app/api/whatsapp/send/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest) {
     const { data: config } = await supabase
       .from('whatsapp_config')
       .select('evolution_api_url, evolution_api_key, evolution_instance, is_active')
-      .eq('professional_id', professional.id)
+      .eq('user_id', user.id)
       .eq('is_active', true)
       .single();
 

--- a/supabase/migrations/20260304000005_add_professional_id_whatsapp_tables.sql
+++ b/supabase/migrations/20260304000005_add_professional_id_whatsapp_tables.sql
@@ -1,0 +1,91 @@
+-- Add professional_id to whatsapp_conversations, ai_instructions, whatsapp_templates
+-- for consistent multi-tenant isolation (#109)
+
+-- 1. whatsapp_conversations
+ALTER TABLE whatsapp_conversations
+  ADD COLUMN IF NOT EXISTS professional_id UUID REFERENCES professionals(id) ON DELETE CASCADE;
+
+-- Back-fill from professionals.user_id
+UPDATE whatsapp_conversations wc
+SET professional_id = p.id
+FROM professionals p
+WHERE wc.user_id = p.user_id
+  AND wc.professional_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_whatsapp_conversations_professional
+  ON whatsapp_conversations(professional_id);
+
+-- 2. ai_instructions
+ALTER TABLE ai_instructions
+  ADD COLUMN IF NOT EXISTS professional_id UUID REFERENCES professionals(id) ON DELETE CASCADE;
+
+UPDATE ai_instructions ai
+SET professional_id = p.id
+FROM professionals p
+WHERE ai.user_id = p.user_id
+  AND ai.professional_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ai_instructions_professional
+  ON ai_instructions(professional_id);
+
+-- 3. whatsapp_templates
+ALTER TABLE whatsapp_templates
+  ADD COLUMN IF NOT EXISTS professional_id UUID REFERENCES professionals(id) ON DELETE CASCADE;
+
+UPDATE whatsapp_templates wt
+SET professional_id = p.id
+FROM professionals p
+WHERE wt.user_id = p.user_id
+  AND wt.professional_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_whatsapp_templates_professional
+  ON whatsapp_templates(professional_id);
+
+-- 4. Update RLS policies to use professional_id subquery pattern
+-- (consistent with bookings, services, etc.)
+
+-- whatsapp_conversations
+DROP POLICY IF EXISTS "Users can view own conversations" ON whatsapp_conversations;
+DROP POLICY IF EXISTS "Users can manage own conversations" ON whatsapp_conversations;
+
+CREATE POLICY "Users can view own conversations"
+  ON whatsapp_conversations FOR SELECT
+  USING (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+    OR user_id = auth.uid()
+  );
+
+CREATE POLICY "Users can manage own conversations"
+  ON whatsapp_conversations FOR ALL
+  USING (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+    OR user_id = auth.uid()
+  );
+
+-- ai_instructions
+DROP POLICY IF EXISTS "Users can manage own AI instructions" ON ai_instructions;
+
+CREATE POLICY "Users can manage own AI instructions"
+  ON ai_instructions FOR ALL
+  USING (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+    OR user_id = auth.uid()
+  );
+
+-- whatsapp_templates
+DROP POLICY IF EXISTS "Users can manage own templates" ON whatsapp_templates;
+
+CREATE POLICY "Users can manage own templates"
+  ON whatsapp_templates FOR ALL
+  USING (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+    OR user_id = auth.uid()
+  );


### PR DESCRIPTION
## Summary
- Adds `professional_id` column (FK → professionals) to `whatsapp_conversations`, `ai_instructions`, `whatsapp_templates`
- Back-fills existing rows from `professionals.user_id` lookup
- Updates RLS policies to use `professional_id IN (SELECT id FROM professionals WHERE user_id = auth.uid())` pattern (consistent with bookings, services, etc.)
- Preserves `OR user_id = auth.uid()` fallback for backwards compatibility
- Fixes bug in `whatsapp/send/route.ts:43` filtering `whatsapp_config` by nonexistent `professional_id` column → now uses `user_id`

## Test plan
- [x] `npx vitest run src/__tests__/security/whatsapp-professional-id.test.ts` — 10 tests pass
- [x] `npx tsc --noEmit` — no errors
- [ ] CI green
- [ ] Run migration on Supabase after merge

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)