### PR TITLE
fix(db): add professional_id to notifications table (#110)

### DIFF
--- a/src/__tests__/security/notifications-professional-id.test.ts
+++ b/src/__tests__/security/notifications-professional-id.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'supabase',
+  'migrations',
+  '20260304000006_add_professional_id_notifications.sql'
+);
+
+describe('Notifications table multi-tenant isolation (#110)', () => {
+  it('migration file exists', () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true);
+  });
+
+  describe('migration content', () => {
+    const migration = readFileSync(MIGRATION_PATH, 'utf-8');
+
+    it('adds professional_id column with FK to professionals', () => {
+      expect(migration).toContain('ALTER TABLE notifications');
+      expect(migration).toContain(
+        'professional_id UUID REFERENCES professionals(id) ON DELETE CASCADE'
+      );
+    });
+
+    it('back-fills professional_id from professionals.user_id', () => {
+      expect(migration).toMatch(/UPDATE notifications[\s\S]*?SET professional_id = p\.id/);
+    });
+
+    it('creates index on professional_id', () => {
+      expect(migration).toContain('idx_notifications_professional');
+    });
+
+    it('updates RLS policy to use professional_id subquery', () => {
+      expect(migration).toContain(
+        'SELECT id FROM professionals WHERE user_id = auth.uid()'
+      );
+    });
+
+    it('drops old RLS policy before creating new one', () => {
+      expect(migration).toContain('DROP POLICY IF EXISTS');
+    });
+
+    it('preserves user_id fallback for backwards compatibility', () => {
+      expect(migration).toContain('OR user_id = auth.uid()');
+    });
+  });
+});

--- a/supabase/migrations/20260304000006_add_professional_id_notifications.sql
+++ b/supabase/migrations/20260304000006_add_professional_id_notifications.sql
@@ -1,0 +1,26 @@
+-- Add professional_id to notifications table for multi-tenant isolation (#110)
+
+ALTER TABLE notifications
+  ADD COLUMN IF NOT EXISTS professional_id UUID REFERENCES professionals(id) ON DELETE CASCADE;
+
+-- Back-fill from professionals.user_id
+UPDATE notifications n
+SET professional_id = p.id
+FROM professionals p
+WHERE n.user_id = p.user_id
+  AND n.professional_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_notifications_professional
+  ON notifications(professional_id);
+
+-- Update RLS policy to use professional_id subquery pattern
+DROP POLICY IF EXISTS "Users can manage own notifications" ON notifications;
+
+CREATE POLICY "Users can manage own notifications"
+  ON notifications FOR ALL
+  USING (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+    OR user_id = auth.uid()
+  );


### PR DESCRIPTION
## Summary
- Adds `professional_id` column (FK → professionals, ON DELETE CASCADE) to `notifications` table
- Back-fills existing rows from `professionals.user_id` lookup
- Creates index `idx_notifications_professional`
- Updates RLS policy to use `professional_id IN (SELECT id FROM professionals WHERE user_id = auth.uid())` with `user_id` fallback

## Test plan
- [x] `npx vitest run src/__tests__/security/notifications-professional-id.test.ts` — 7 tests pass
- [x] `npx tsc --noEmit` — no errors
- [ ] CI green
- [ ] Run migration on Supabase after merge

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)