### PR TITLE
fix(security): add CSP and HSTS headers (#108)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,11 +3,26 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n.ts');
 
+const cspDirectives = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://*.supabase.co",
+  "font-src 'self'",
+  "connect-src 'self' https://*.supabase.co https://api.stripe.com",
+  "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+];
+
 const securityHeaders = [
   { key: 'X-Frame-Options', value: 'DENY' },
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
   { key: 'Permissions-Policy', value: 'geolocation=(), microphone=()' },
+  { key: 'Content-Security-Policy', value: cspDirectives.join('; ') },
+  { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains; preload' },
 ];
 
 const nextConfig: NextConfig = {

--- a/src/__tests__/security/security-headers.test.ts
+++ b/src/__tests__/security/security-headers.test.ts
@@ -34,4 +34,29 @@ describe('Security headers (issue #14)', () => {
   it('exports async headers() function in nextConfig', () => {
     expect(configSource).toContain('async headers()');
   });
+
+  it('sets Content-Security-Policy with default-src self', () => {
+    expect(configSource).toContain("key: 'Content-Security-Policy'");
+    expect(configSource).toContain("default-src 'self'");
+  });
+
+  it('CSP allows Stripe scripts and frames', () => {
+    expect(configSource).toContain('https://js.stripe.com');
+    expect(configSource).toContain('https://hooks.stripe.com');
+  });
+
+  it('CSP allows Supabase connections and images', () => {
+    expect(configSource).toContain('https://*.supabase.co');
+  });
+
+  it('CSP sets frame-ancestors none to prevent framing', () => {
+    expect(configSource).toContain("frame-ancestors 'none'");
+  });
+
+  it('sets Strict-Transport-Security with max-age and preload', () => {
+    expect(configSource).toContain("key: 'Strict-Transport-Security'");
+    expect(configSource).toContain('max-age=31536000');
+    expect(configSource).toContain('includeSubDomains');
+    expect(configSource).toContain('preload');
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `Content-Security-Policy` header with directives:
  - `default-src 'self'` — restrict all resources to same origin by default
  - `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com` — Next.js needs unsafe-inline/eval, Stripe.js whitelisted
  - `style-src 'self' 'unsafe-inline'` — Next.js inline styles
  - `img-src 'self' data: blob: https://*.supabase.co` — Supabase storage images
  - `connect-src 'self' https://*.supabase.co https://api.stripe.com` — API connections
  - `frame-src 'self' https://js.stripe.com https://hooks.stripe.com` — Stripe iframes
  - `frame-ancestors 'none'` — prevents embedding (mirrors X-Frame-Options)
  - `base-uri 'self'` and `form-action 'self'` — prevent base/form hijacking
- Adds `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`
- Extends existing security-headers test with 5 new assertions

## Test plan
- [x] `npx vitest run src/__tests__/security/security-headers.test.ts` — 11 tests pass
- [x] `npx tsc --noEmit` — no errors
- [ ] CI green

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)