### PR TITLE
fix(db): enforce NOT NULL on bookings.service_id (#111)

### DIFF
--- a/src/__tests__/security/bookings-service-id-not-null.test.ts
+++ b/src/__tests__/security/bookings-service-id-not-null.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'supabase',
+  'migrations',
+  '20260304000007_bookings_service_id_not_null.sql'
+);
+
+describe('bookings.service_id NOT NULL constraint (#111)', () => {
+  it('migration file exists', () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true);
+  });
+
+  describe('migration content', () => {
+    const migration = readFileSync(MIGRATION_PATH, 'utf-8');
+
+    it('cleans up orphaned rows with NULL service_id first', () => {
+      const deleteIndex = migration.indexOf('DELETE FROM bookings WHERE service_id IS NULL');
+      const alterIndex = migration.indexOf('ALTER TABLE bookings');
+      expect(deleteIndex).toBeGreaterThan(-1);
+      expect(alterIndex).toBeGreaterThan(deleteIndex);
+    });
+
+    it('adds NOT NULL constraint to service_id', () => {
+      expect(migration).toContain('ALTER TABLE bookings ALTER COLUMN service_id SET NOT NULL');
+    });
+  });
+});

--- a/supabase/migrations/20260304000007_bookings_service_id_not_null.sql
+++ b/supabase/migrations/20260304000007_bookings_service_id_not_null.sql
@@ -1,0 +1,8 @@
+-- Enforce NOT NULL on bookings.service_id (#111)
+-- A booking without a service breaks analytics and billing.
+
+-- Safety: remove any orphaned rows with NULL service_id
+DELETE FROM bookings WHERE service_id IS NULL;
+
+-- Add NOT NULL constraint
+ALTER TABLE bookings ALTER COLUMN service_id SET NOT NULL;


### PR DESCRIPTION
## Summary
- Cleans up any orphaned rows with `NULL service_id` before applying constraint
- Adds `NOT NULL` constraint to `bookings.service_id` to prevent bookings without a service
- Prevents broken analytics and billing from orphaned bookings

## Test plan
- [x] `npx vitest run src/__tests__/security/bookings-service-id-not-null.test.ts` — 3 tests pass
- [x] `npx tsc --noEmit` — no errors
- [ ] CI green
- [ ] Run migration on Supabase after merge

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)