### PR TITLE
fix(security): require E2E_TEST_SECRET on test routes (#112)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ SETUP_SECRET=your-setup-secret
 # --- Cron Jobs ---
 CRON_SECRET=your-cron-secret
 
+# --- E2E Testing ---
+E2E_TEST_SECRET=your-e2e-test-secret
+
 # --- AI / Anthropic ---
 ANTHROPIC_API_KEY=sk-ant-...
 

--- a/e2e/helpers/config.ts
+++ b/e2e/helpers/config.ts
@@ -14,4 +14,5 @@ export const TEST = {
   SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL ?? '',
   SUPABASE_SERVICE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY ?? '',
   REDIS_URL: process.env.REDIS_URL ?? '',
+  E2E_TEST_SECRET: process.env.E2E_TEST_SECRET ?? '',
 };

--- a/e2e/payment/03-booking-no-payment.spec.ts
+++ b/e2e/payment/03-booking-no-payment.spec.ts
@@ -101,6 +101,7 @@ test.describe('Página pública sem sinal', () => {
   test.beforeAll(async ({ request }) => {
     // Criar profissional efémero via test API (apenas em dev/test)
     const res = await request.post(`${BASE}/api/test/setup-professional`, {
+      headers: { 'x-test-secret': TEST.E2E_TEST_SECRET },
       data: {
         name: 'Ana Sem Sinal',
         email: `ana-no-deposit-${Date.now()}@test.com`,
@@ -124,7 +125,9 @@ test.describe('Página pública sem sinal', () => {
 
   test.afterAll(async ({ request }) => {
     if (cleanupId) {
-      await request.delete(`${BASE}/api/test/cleanup-professional/${cleanupId}`);
+      await request.delete(`${BASE}/api/test/cleanup-professional/${cleanupId}`, {
+        headers: { 'x-test-secret': TEST.E2E_TEST_SECRET },
+      });
     }
   });
 

--- a/e2e/payment/04-payment-flow.spec.ts
+++ b/e2e/payment/04-payment-flow.spec.ts
@@ -28,6 +28,7 @@ test.describe('API bookings/checkout', () => {
     if (!HAS_STRIPE) return;
 
     const res = await request.post(`${BASE}/api/test/setup-professional`, {
+      headers: { 'x-test-secret': TEST.E2E_TEST_SECRET },
       data: {
         name: 'Rita Stripe Teste',
         email: `rita-stripe-${Date.now()}@test.com`,
@@ -49,7 +50,9 @@ test.describe('API bookings/checkout', () => {
 
   test.afterAll(async ({ request }) => {
     if (ephemeralProfId) {
-      await request.delete(`${BASE}/api/test/cleanup-professional/${ephemeralProfId}`);
+      await request.delete(`${BASE}/api/test/cleanup-professional/${ephemeralProfId}`, {
+        headers: { 'x-test-secret': TEST.E2E_TEST_SECRET },
+      });
     }
   });
 
@@ -100,6 +103,7 @@ test.describe('Página pública COM sinal (ephemeral)', () => {
     if (!HAS_STRIPE) return;
 
     const res = await request.post(`${BASE}/api/test/setup-professional`, {
+      headers: { 'x-test-secret': TEST.E2E_TEST_SECRET },
       data: {
         name: 'Prof Com Sinal',
         email: `with-deposit-${Date.now()}@test.com`,
@@ -120,7 +124,9 @@ test.describe('Página pública COM sinal (ephemeral)', () => {
 
   test.afterAll(async ({ request }) => {
     if (cleanupId) {
-      await request.delete(`${BASE}/api/test/cleanup-professional/${cleanupId}`);
+      await request.delete(`${BASE}/api/test/cleanup-professional/${cleanupId}`, {
+        headers: { 'x-test-secret': TEST.E2E_TEST_SECRET },
+      });
     }
   });
 

--- a/src/__tests__/security/test-routes-secret.test.ts
+++ b/src/__tests__/security/test-routes-secret.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const API_DIR = join(__dirname, '..', '..', 'app', 'api');
+
+const TEST_ROUTES = [
+  join(API_DIR, 'test', 'setup-professional', 'route.ts'),
+  join(API_DIR, 'test', 'cleanup-professional', '[id]', 'route.ts'),
+  join(API_DIR, 'bookings', 'check', 'route.ts'),
+];
+
+describe('Test routes require E2E_TEST_SECRET header (#112)', () => {
+  for (const routePath of TEST_ROUTES) {
+    const relPath = routePath.replace(API_DIR, 'api');
+
+    describe(relPath, () => {
+      const source = readFileSync(routePath, 'utf-8');
+
+      it('checks E2E_TEST_SECRET env var', () => {
+        expect(source).toContain('E2E_TEST_SECRET');
+      });
+
+      it('validates x-test-secret header', () => {
+        expect(source).toContain("'x-test-secret'");
+      });
+
+      it('returns 403 when secret is missing or wrong', () => {
+        expect(source).toContain('status: 403');
+      });
+
+      it('still checks NODE_ENV as defense-in-depth', () => {
+        expect(source).toContain('ALLOWED_ENVS');
+      });
+    });
+  }
+});

--- a/src/app/api/bookings/check/route.ts
+++ b/src/app/api/bookings/check/route.ts
@@ -19,8 +19,13 @@ function serviceRoleClient() {
 }
 
 export async function GET(request: Request) {
-  if (!ALLOWED_ENVS.includes(process.env.NODE_ENV ?? '')) {
-    return NextResponse.json({ error: 'Not available in this environment' }, { status: 403 });
+  const testSecret = process.env.E2E_TEST_SECRET;
+  if (
+    !ALLOWED_ENVS.includes(process.env.NODE_ENV ?? '') ||
+    !testSecret ||
+    request.headers.get('x-test-secret') !== testSecret
+  ) {
+    return NextResponse.json({ error: 'Not available' }, { status: 403 });
   }
 
   const { searchParams } = new URL(request.url);

--- a/src/app/api/test/cleanup-professional/[id]/route.ts
+++ b/src/app/api/test/cleanup-professional/[id]/route.ts
@@ -22,8 +22,13 @@ export async function DELETE(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  if (!ALLOWED_ENVS.includes(process.env.NODE_ENV ?? '')) {
-    return NextResponse.json({ error: 'Not available in this environment' }, { status: 403 });
+  const testSecret = process.env.E2E_TEST_SECRET;
+  if (
+    !ALLOWED_ENVS.includes(process.env.NODE_ENV ?? '') ||
+    !testSecret ||
+    _request.headers.get('x-test-secret') !== testSecret
+  ) {
+    return NextResponse.json({ error: 'Not available' }, { status: 403 });
   }
 
   const { id: professionalId } = await params;
@@ -55,6 +60,6 @@ export async function DELETE(
     return NextResponse.json({ success: true });
   } catch (err: any) {
     logger.error('[test/cleanup-professional]', err);
-    return NextResponse.json({ error: err.message }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/test/setup-professional/route.ts
+++ b/src/app/api/test/setup-professional/route.ts
@@ -26,8 +26,13 @@ function serviceRoleClient() {
 }
 
 export async function POST(request: Request) {
-  if (!ALLOWED_ENVS.includes(process.env.NODE_ENV ?? '')) {
-    return NextResponse.json({ error: 'Not available in this environment' }, { status: 403 });
+  const testSecret = process.env.E2E_TEST_SECRET;
+  if (
+    !ALLOWED_ENVS.includes(process.env.NODE_ENV ?? '') ||
+    !testSecret ||
+    request.headers.get('x-test-secret') !== testSecret
+  ) {
+    return NextResponse.json({ error: 'Not available' }, { status: 403 });
   }
 
   const supabase = serviceRoleClient();
@@ -128,6 +133,6 @@ export async function POST(request: Request) {
     });
   } catch (err: any) {
     logger.error('[test/setup-professional]', err);
-    return NextResponse.json({ error: err.message }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- Test routes now require **both** `NODE_ENV` check AND `x-test-secret` header matching `E2E_TEST_SECRET` env var
- Affected routes: `setup-professional`, `cleanup-professional`, `bookings/check`
- E2E tests updated to pass the header via `TEST.E2E_TEST_SECRET`
- Added `E2E_TEST_SECRET` to `.env.example`
- Also fixed error message leaks (`err.message` → `'Internal server error'`) in setup/cleanup routes

## Action required after merge
- Set `E2E_TEST_SECRET` in Vercel environment variables (for CI E2E tests)

## Test plan
- [x] `npx vitest run src/__tests__/security/test-routes-secret.test.ts` — 12 tests pass
- [x] `npx tsc --noEmit` — no errors
- [ ] CI green

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)