### PR TITLE
fix(security): validate Stripe account_id format in checkout (#114)

### DIFF
--- a/src/__tests__/security/stripe-account-id-validation.test.ts
+++ b/src/__tests__/security/stripe-account-id-validation.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const CHECKOUT_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  'app',
+  'api',
+  'bookings',
+  'checkout',
+  'route.ts'
+);
+
+describe('Stripe Connect account_id validation (#114)', () => {
+  const source = readFileSync(CHECKOUT_PATH, 'utf-8');
+
+  it('validates stripe_account_id starts with acct_ prefix', () => {
+    expect(source).toContain("startsWith('acct_')");
+  });
+
+  it('returns 422 when stripe_account_id has invalid format', () => {
+    // The validation block should return 422
+    const acctCheckIndex = source.indexOf("startsWith('acct_')");
+    const status422Index = source.indexOf('status: 422', acctCheckIndex);
+    expect(acctCheckIndex).toBeGreaterThan(-1);
+    expect(status422Index).toBeGreaterThan(-1);
+    // 422 must appear within 200 chars of the acct_ check (same block)
+    expect(status422Index - acctCheckIndex).toBeLessThan(200);
+  });
+
+  it('checks type is string before prefix check', () => {
+    expect(source).toContain("typeof prof.stripe_account_id !== 'string'");
+  });
+});

--- a/src/app/api/bookings/checkout/route.ts
+++ b/src/app/api/bookings/checkout/route.ts
@@ -78,7 +78,11 @@ export async function POST(request: NextRequest) {
   }
 
   // ─── 4. Verificar Connect ───────────────────────────────────────────────
-  if (!prof.stripe_account_id) {
+  if (
+    !prof.stripe_account_id ||
+    typeof prof.stripe_account_id !== 'string' ||
+    !prof.stripe_account_id.startsWith('acct_')
+  ) {
     return NextResponse.json(
       { error: 'Profissional não configurou conta Stripe.' },
       { status: 422 }


### PR DESCRIPTION
## Summary
- Validates `stripe_account_id` starts with `acct_` prefix before passing to Stripe API
- Adds type check (`typeof !== 'string'`) as defense-in-depth
- Returns 422 with clear error message for invalid format

## Test plan
- [x] `npx vitest run src/__tests__/security/stripe-account-id-validation.test.ts` — 3 tests pass
- [x] `npx tsc --noEmit` — no errors
- [ ] CI green

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)