### PR TITLE
fix(payments): add chargeback and partial refund handlers (#115)

### DIFF
--- a/src/__tests__/security/stripe-webhook-handlers.test.ts
+++ b/src/__tests__/security/stripe-webhook-handlers.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const WEBHOOK_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  'app',
+  'api',
+  'webhooks',
+  'stripe-deposit',
+  'route.ts'
+);
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'supabase',
+  'migrations',
+  '20260304000008_payments_refund_fields.sql'
+);
+
+describe('Stripe webhook refund/chargeback handlers (#115)', () => {
+  const source = readFileSync(WEBHOOK_PATH, 'utf-8');
+
+  it('handles charge.refunded event', () => {
+    expect(source).toContain("case 'charge.refunded':");
+  });
+
+  it('handles charge.dispute.created event (chargebacks)', () => {
+    expect(source).toContain("case 'charge.dispute.created':");
+  });
+
+  it('handles payment_intent.canceled event', () => {
+    expect(source).toContain("case 'payment_intent.canceled':");
+  });
+
+  it('distinguishes full vs partial refunds', () => {
+    expect(source).toContain('partially_refunded');
+    expect(source).toContain('charge.refunded');
+  });
+
+  it('tracks refunded_amount', () => {
+    expect(source).toContain('refunded_amount');
+    expect(source).toContain('amount_refunded');
+  });
+
+  it('sets disputed status on chargeback', () => {
+    expect(source).toContain("status: 'disputed'");
+  });
+
+  it('sets cancelled status on payment_intent.canceled', () => {
+    expect(source).toContain("status: 'cancelled'");
+  });
+
+  describe('migration', () => {
+    it('migration file exists', () => {
+      expect(existsSync(MIGRATION_PATH)).toBe(true);
+    });
+
+    it('adds refunded_amount column', () => {
+      const migration = readFileSync(MIGRATION_PATH, 'utf-8');
+      expect(migration).toContain('refunded_amount');
+    });
+  });
+});

--- a/src/app/api/webhooks/stripe-deposit/route.ts
+++ b/src/app/api/webhooks/stripe-deposit/route.ts
@@ -70,11 +70,39 @@ export async function POST(request: NextRequest) {
     case 'charge.refunded': {
       const charge = event.data.object as Stripe.Charge;
       if (charge.payment_intent) {
+        const isFullRefund = charge.refunded;
         await supabase
           .from('payments')
-          .update({ status: 'refunded' })
+          .update({
+            status: isFullRefund ? 'refunded' : 'partially_refunded',
+            refunded_amount: charge.amount_refunded / 100,
+          })
           .eq('stripe_payment_intent_id', charge.payment_intent as string);
       }
+      break;
+    }
+
+    case 'charge.dispute.created': {
+      const dispute = event.data.object as Stripe.Dispute;
+      const piId =
+        typeof dispute.payment_intent === 'string'
+          ? dispute.payment_intent
+          : dispute.payment_intent?.id;
+      if (piId) {
+        await supabase
+          .from('payments')
+          .update({ status: 'disputed' })
+          .eq('stripe_payment_intent_id', piId);
+      }
+      break;
+    }
+
+    case 'payment_intent.canceled': {
+      const pi = event.data.object as Stripe.PaymentIntent;
+      await supabase
+        .from('payments')
+        .update({ status: 'cancelled' })
+        .eq('stripe_payment_intent_id', pi.id);
       break;
     }
 

--- a/supabase/migrations/20260304000008_payments_refund_fields.sql
+++ b/supabase/migrations/20260304000008_payments_refund_fields.sql
@@ -1,0 +1,4 @@
+-- Add refund tracking fields to payments table (#115)
+
+ALTER TABLE payments
+  ADD COLUMN IF NOT EXISTS refunded_amount DECIMAL(10,2) DEFAULT 0;


### PR DESCRIPTION
## Summary
- Adds `charge.dispute.created` handler → sets payment status to `'disputed'`
- Adds `payment_intent.canceled` handler → sets payment status to `'cancelled'`
- Distinguishes full vs partial refunds (`'refunded'` vs `'partially_refunded'`)
- Tracks `refunded_amount` from `charge.amount_refunded`
- Migration adds `refunded_amount DECIMAL(10,2)` column to payments table

## Test plan
- [x] `npx vitest run src/__tests__/security/stripe-webhook-handlers.test.ts` — 9 tests pass
- [x] `npx tsc --noEmit` — no errors
- [ ] CI green
- [ ] Run migration on Supabase after merge

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)