### PR TITLE
fix(security): add UPDATE/DELETE RLS policies to whatsapp_messages (#116)

### DIFF
--- a/src/__tests__/security/whatsapp-messages-policies.test.ts
+++ b/src/__tests__/security/whatsapp-messages-policies.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'supabase',
+  'migrations',
+  '20260304000009_whatsapp_messages_update_delete_policies.sql'
+);
+
+describe('whatsapp_messages UPDATE/DELETE policies (#116)', () => {
+  it('migration file exists', () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true);
+  });
+
+  describe('migration content', () => {
+    const migration = readFileSync(MIGRATION_PATH, 'utf-8');
+
+    it('creates UPDATE policy', () => {
+      expect(migration).toContain('ON whatsapp_messages FOR UPDATE');
+    });
+
+    it('creates DELETE policy', () => {
+      expect(migration).toContain('ON whatsapp_messages FOR DELETE');
+    });
+
+    it('filters by conversation ownership via subquery', () => {
+      const subqueryCount = (
+        migration.match(/whatsapp_conversations\.user_id = auth\.uid\(\)/g) || []
+      ).length;
+      expect(subqueryCount).toBe(2);
+    });
+
+    it('joins on conversation_id', () => {
+      const joinCount = (
+        migration.match(/whatsapp_conversations\.id = whatsapp_messages\.conversation_id/g) || []
+      ).length;
+      expect(joinCount).toBe(2);
+    });
+  });
+});

--- a/supabase/migrations/20260304000009_whatsapp_messages_update_delete_policies.sql
+++ b/supabase/migrations/20260304000009_whatsapp_messages_update_delete_policies.sql
@@ -1,0 +1,22 @@
+-- Add UPDATE and DELETE policies to whatsapp_messages (#116)
+-- Existing policies only cover SELECT and INSERT.
+
+CREATE POLICY "Users can update messages in own conversations"
+  ON whatsapp_messages FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM whatsapp_conversations
+      WHERE whatsapp_conversations.id = whatsapp_messages.conversation_id
+      AND whatsapp_conversations.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can delete messages in own conversations"
+  ON whatsapp_messages FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM whatsapp_conversations
+      WHERE whatsapp_conversations.id = whatsapp_messages.conversation_id
+      AND whatsapp_conversations.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- Adds UPDATE and DELETE RLS policies to `whatsapp_messages` table
- Policies filter by conversation ownership via subquery join on `whatsapp_conversations.user_id = auth.uid()`
- Existing policies only covered SELECT and INSERT

## Test plan
- [x] Migration file creates UPDATE policy
- [x] Migration file creates DELETE policy
- [x] Policies filter by conversation ownership via subquery
- [x] Policies join on conversation_id
- [x] 5 tests passing

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)