### PR TITLE
fix(security): add apikey validation to WhatsApp webhook (#132)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,7 @@ EVOLUTION_INSTANCE_SALES=circlehood-sales
 WHATSAPP_SUPPORT_INSTANCE=your-support-instance
 WHATSAPP_VERIFY_TOKEN=your-verify-token
 SALES_WEBHOOK_SECRET=your-sales-webhook-secret
+WHATSAPP_WEBHOOK_SECRET=your-whatsapp-webhook-secret
 
 # --- Redis (Conversation Cache) ---
 REDIS_URL=redis://localhost:6379

--- a/src/__tests__/security/whatsapp-webhook-signature.test.ts
+++ b/src/__tests__/security/whatsapp-webhook-signature.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #132: WhatsApp webhook missing signature validation
+ *
+ * The main WhatsApp webhook (/api/whatsapp/webhook) was accepting ANY POST
+ * request without verifying the `apikey` header, allowing attackers to inject
+ * fake messages and trigger bot responses.
+ */
+
+describe('WhatsApp webhook signature validation (issue #132)', () => {
+  const source = readFileSync(
+    resolve('src/app/api/whatsapp/webhook/route.ts'),
+    'utf-8'
+  );
+
+  it('imports validateEvolutionWebhook', () => {
+    expect(source).toContain('validateEvolutionWebhook');
+  });
+
+  it('reads apikey header from request', () => {
+    expect(source).toContain("request.headers.get('apikey')");
+  });
+
+  it('uses WHATSAPP_WEBHOOK_SECRET env var', () => {
+    expect(source).toContain('WHATSAPP_WEBHOOK_SECRET');
+  });
+
+  it('returns 401 for invalid/missing apikey', () => {
+    expect(source).toContain('401');
+    // Ensure the 401 is tied to the webhook validation, not some other check
+    expect(source).toContain("{ error: 'Unauthorized' }");
+  });
+
+  it('validates signature BEFORE parsing request body', () => {
+    const validateIndex = source.indexOf('validateEvolutionWebhook');
+    const jsonParseIndex = source.indexOf('request.json()');
+    expect(validateIndex).toBeGreaterThan(-1);
+    expect(jsonParseIndex).toBeGreaterThan(-1);
+    expect(validateIndex).toBeLessThan(jsonParseIndex);
+  });
+
+  it('logs a warning when validation fails', () => {
+    expect(source).toContain('[whatsapp/webhook] Invalid or missing apikey header');
+  });
+
+  it('WHATSAPP_WEBHOOK_SECRET is documented in .env.example', () => {
+    const envExample = readFileSync(resolve('.env.example'), 'utf-8');
+    expect(envExample).toContain('WHATSAPP_WEBHOOK_SECRET');
+  });
+
+  it('follows the same pattern as sales-bot webhook', () => {
+    const salesBotSource = readFileSync(
+      resolve('src/app/api/sales-bot/webhook/route.ts'),
+      'utf-8'
+    );
+    // Both use validateEvolutionWebhook
+    expect(salesBotSource).toContain('validateEvolutionWebhook');
+    expect(source).toContain('validateEvolutionWebhook');
+
+    // Both check apikey header
+    expect(salesBotSource).toContain("request.headers.get('apikey')");
+    expect(source).toContain("request.headers.get('apikey')");
+
+    // Both return 401
+    expect(salesBotSource).toContain('401');
+    expect(source).toContain('401');
+  });
+});

--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -4,6 +4,7 @@ import { processWhatsAppMessage } from '@/lib/whatsapp/processor';
 import { isEvolutionPayload, isMetaPayload } from '@/lib/whatsapp/types';
 import { parseEvolutionPhone, sendEvolutionMessage } from '@/lib/whatsapp/evolution';
 import { createClient } from '@supabase/supabase-js';
+import { validateEvolutionWebhook } from '@/lib/webhooks/signature';
 
 const AUDIO_REPLY =
   'Desculpe, ainda não consigo ouvir áudios 🎙️ Por favor, envie sua mensagem por texto e ficarei feliz em ajudar! 😊';
@@ -49,6 +50,13 @@ const isNonProduction =
   process.env.NODE_ENV !== 'test';
 
 export async function POST(request: NextRequest) {
+  // ── Validação de assinatura do webhook ──
+  const apikeyHeader = request.headers.get('apikey');
+  if (!validateEvolutionWebhook(apikeyHeader, process.env.WHATSAPP_WEBHOOK_SECRET)) {
+    logger.warn('[whatsapp/webhook] Invalid or missing apikey header');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   try {
     const body = await request.json();
 


### PR DESCRIPTION
## Summary
- Adds `apikey` header validation to the WhatsApp webhook POST handler using `validateEvolutionWebhook`
- Rejects requests with invalid/missing apikey with 401 before parsing the body
- Follows the exact same pattern already used by the sales-bot webhook
- Adds `WHATSAPP_WEBHOOK_SECRET` env var to `.env.example`

## Files changed
- `src/app/api/whatsapp/webhook/route.ts` — added signature validation at top of POST handler
- `.env.example` — added `WHATSAPP_WEBHOOK_SECRET`
- `src/__tests__/security/whatsapp-webhook-signature.test.ts` — 8 tests (new)

## Test plan
- [x] 8 unit tests verify: import present, apikey header read, env var used, 401 returned, validation before body parse, warning logged, env documented, pattern matches sales-bot
- [x] Existing 21 webhook-signatures tests still pass
- [x] `npm run test:fast` — 764/766 pass (2 failures are pre-existing email/unsubscribe tests)

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)