### PR TITLE
fix(security): use dedicated ADMIN_SESSION_SECRET for HMAC signing (#137)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
 # --- Admin ---
 ADMIN_PASSWORD=your-admin-password
+ADMIN_SESSION_SECRET=random-64-char-hex-string   # HMAC key for admin tokens (falls back to ADMIN_PASSWORD if unset)
 ADMIN_EMAIL=admin@example.com
 SETUP_SECRET=your-setup-secret
 

--- a/src/__tests__/security/admin-session-secret.test.ts
+++ b/src/__tests__/security/admin-session-secret.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #137: Admin password reused as HMAC secret
+ *
+ * The ADMIN_PASSWORD was used directly as HMAC signing key for admin tokens.
+ * Now uses ADMIN_SESSION_SECRET (dedicated) with fallback to ADMIN_PASSWORD.
+ */
+
+describe('Admin session uses dedicated signing secret (issue #137)', () => {
+  const source = readFileSync(
+    resolve('src/lib/admin/session.ts'),
+    'utf-8'
+  );
+
+  it('uses ADMIN_SESSION_SECRET env var', () => {
+    expect(source).toContain('ADMIN_SESSION_SECRET');
+  });
+
+  it('does not use ADMIN_PASSWORD directly in generateAdminToken or validateAdminToken', () => {
+    // ADMIN_PASSWORD should only appear in getSigningSecret as fallback, not in the token functions
+    const lines = source.split('\n');
+    for (const line of lines) {
+      if (line.includes('ADMIN_PASSWORD') && !line.includes('getSigningSecret') && !line.includes('||') && !line.includes('//') && !line.includes('*') && !line.includes('Error')) {
+        throw new Error(`ADMIN_PASSWORD used directly outside getSigningSecret: ${line.trim()}`);
+      }
+    }
+  });
+
+  it('has a getSigningSecret helper that prefers ADMIN_SESSION_SECRET', () => {
+    expect(source).toContain('getSigningSecret');
+    // Ensure ADMIN_SESSION_SECRET comes before ADMIN_PASSWORD (preferred)
+    const fnMatch = source.match(/function getSigningSecret[\s\S]*?^}/m);
+    expect(fnMatch).toBeTruthy();
+    const fnBody = fnMatch![0];
+    expect(fnBody).toContain('ADMIN_SESSION_SECRET');
+    expect(fnBody).toContain('ADMIN_PASSWORD');
+    const secretIdx = fnBody.indexOf('ADMIN_SESSION_SECRET');
+    const passwordIdx = fnBody.indexOf('ADMIN_PASSWORD');
+    expect(secretIdx).toBeLessThan(passwordIdx);
+  });
+
+  it('ADMIN_SESSION_SECRET is documented in .env.example', () => {
+    const envExample = readFileSync(resolve('.env.example'), 'utf-8');
+    expect(envExample).toContain('ADMIN_SESSION_SECRET');
+  });
+});
+
+describe('Admin session token generation and validation', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('generates and validates token with ADMIN_SESSION_SECRET', async () => {
+    process.env.ADMIN_SESSION_SECRET = 'dedicated-secret-64chars-long-for-security-purposes-1234567890ab';
+    delete process.env.ADMIN_PASSWORD;
+
+    const { generateAdminToken, validateAdminToken } = await import('@/lib/admin/session');
+    const { token } = generateAdminToken();
+    expect(validateAdminToken(token)).toBe(true);
+  });
+
+  it('falls back to ADMIN_PASSWORD when ADMIN_SESSION_SECRET is not set', async () => {
+    delete process.env.ADMIN_SESSION_SECRET;
+    process.env.ADMIN_PASSWORD = 'my-admin-password';
+
+    const { generateAdminToken, validateAdminToken } = await import('@/lib/admin/session');
+    const { token } = generateAdminToken();
+    expect(validateAdminToken(token)).toBe(true);
+  });
+
+  it('prefers ADMIN_SESSION_SECRET over ADMIN_PASSWORD', async () => {
+    process.env.ADMIN_SESSION_SECRET = 'dedicated-secret';
+    process.env.ADMIN_PASSWORD = 'password-should-not-be-used';
+
+    const { generateAdminToken, validateAdminToken } = await import('@/lib/admin/session');
+    const { token } = generateAdminToken();
+
+    // Token generated with ADMIN_SESSION_SECRET should validate with it
+    expect(validateAdminToken(token)).toBe(true);
+
+    // Now change ADMIN_SESSION_SECRET — token should be invalid
+    process.env.ADMIN_SESSION_SECRET = 'different-secret';
+    const { validateAdminToken: validate2 } = await import('@/lib/admin/session');
+    // Need fresh import due to vi.resetModules
+    vi.resetModules();
+    const mod = await import('@/lib/admin/session');
+    expect(mod.validateAdminToken(token)).toBe(false);
+  });
+
+  it('throws when neither secret is configured', async () => {
+    delete process.env.ADMIN_SESSION_SECRET;
+    delete process.env.ADMIN_PASSWORD;
+
+    const { generateAdminToken } = await import('@/lib/admin/session');
+    expect(() => generateAdminToken()).toThrow();
+  });
+
+  it('returns false for validation when neither secret is configured', async () => {
+    delete process.env.ADMIN_SESSION_SECRET;
+    delete process.env.ADMIN_PASSWORD;
+
+    const { validateAdminToken } = await import('@/lib/admin/session');
+    expect(validateAdminToken('some.token.here')).toBe(false);
+  });
+});

--- a/src/lib/admin/session.ts
+++ b/src/lib/admin/session.ts
@@ -3,6 +3,14 @@ import { createHmac, randomUUID } from 'crypto';
 const SESSION_EXPIRY_HOURS = 8;
 
 /**
+ * Returns the HMAC signing secret for admin session tokens.
+ * Prefers ADMIN_SESSION_SECRET (dedicated); falls back to ADMIN_PASSWORD.
+ */
+function getSigningSecret(): string | undefined {
+  return process.env.ADMIN_SESSION_SECRET || process.env.ADMIN_PASSWORD;
+}
+
+/**
  * Generates a signed admin session token.
  * Format: `${sessionId}.${timestamp}.${signature}`
  *
@@ -10,8 +18,8 @@ const SESSION_EXPIRY_HOURS = 8;
  * Each login generates a unique token (randomUUID).
  */
 export function generateAdminToken(): { token: string; expires: Date } {
-  const secret = process.env.ADMIN_PASSWORD;
-  if (!secret) throw new Error('ADMIN_PASSWORD not configured');
+  const secret = getSigningSecret();
+  if (!secret) throw new Error('ADMIN_SESSION_SECRET (or ADMIN_PASSWORD) not configured');
 
   const sessionId = randomUUID();
   const timestamp = Date.now().toString();
@@ -33,7 +41,7 @@ export function generateAdminToken(): { token: string; expires: Date } {
 export function validateAdminToken(token: string | undefined): boolean {
   if (!token) return false;
 
-  const secret = process.env.ADMIN_PASSWORD;
+  const secret = getSigningSecret();
   if (!secret) return false;
 
   const parts = token.split('.');


### PR DESCRIPTION
## Summary
- `ADMIN_PASSWORD` was used directly as HMAC key for admin session tokens — weak passwords = forjeable tokens
- Added `getSigningSecret()` helper that prefers `ADMIN_SESSION_SECRET` (dedicated), falls back to `ADMIN_PASSWORD`
- Backward compatible: existing deployments without `ADMIN_SESSION_SECRET` continue working

## Files changed
- `src/lib/admin/session.ts` — extracted `getSigningSecret()`, replaced direct `ADMIN_PASSWORD` references
- `.env.example` — added `ADMIN_SESSION_SECRET`
- `src/__tests__/security/admin-session-secret.test.ts` — 9 tests (new)

## Test plan
- [x] 4 code verification tests (uses ADMIN_SESSION_SECRET, no direct ADMIN_PASSWORD, prefers secret, documented)
- [x] 5 functional tests (generate+validate with secret, fallback, preference, throws without config, returns false)

## Deploy note
Set `ADMIN_SESSION_SECRET` in Vercel with a strong random 64-char hex string. Existing sessions will be invalidated (users re-login).

🤖 Generated with [Claude Code](https://claude.com/claude-code)