### PR TITLE
fix(security): use RFC 4180 CSV parser for contacts import (#135)

### DIFF
--- a/src/__tests__/lib/csv-parser.test.ts
+++ b/src/__tests__/lib/csv-parser.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { parseCSVLine } from '@/lib/csv-parser';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('parseCSVLine (issue #135)', () => {
+  it('parses simple comma-separated fields', () => {
+    expect(parseCSVLine('John,john@test.com,+351900000000,notes'))
+      .toEqual(['John', 'john@test.com', '+351900000000', 'notes']);
+  });
+
+  it('handles quoted fields with commas inside', () => {
+    expect(parseCSVLine('"Smith, John",john@test.com,+351900000000,notes'))
+      .toEqual(['Smith, John', 'john@test.com', '+351900000000', 'notes']);
+  });
+
+  it('handles escaped quotes inside quoted fields', () => {
+    expect(parseCSVLine('"She said ""hello""",test@test.com,,'))
+      .toEqual(['She said "hello"', 'test@test.com', '', '']);
+  });
+
+  it('handles empty fields', () => {
+    expect(parseCSVLine('John,,,'))
+      .toEqual(['John', '', '', '']);
+  });
+
+  it('handles single field', () => {
+    expect(parseCSVLine('John'))
+      .toEqual(['John']);
+  });
+
+  it('handles quoted field with newline-like content', () => {
+    expect(parseCSVLine('"line1 line2",email@test.com,,'))
+      .toEqual(['line1 line2', 'email@test.com', '', '']);
+  });
+
+  it('handles mixed quoted and unquoted fields', () => {
+    expect(parseCSVLine('John,"Smith, Jr.",+351900000000,"VIP, special"'))
+      .toEqual(['John', 'Smith, Jr.', '+351900000000', 'VIP, special']);
+  });
+
+  it('handles empty string', () => {
+    expect(parseCSVLine('')).toEqual(['']);
+  });
+
+  it('handles all quoted fields', () => {
+    expect(parseCSVLine('"a","b","c","d"'))
+      .toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('handles quotes at field boundaries only', () => {
+    expect(parseCSVLine('"hello",world'))
+      .toEqual(['hello', 'world']);
+  });
+});
+
+describe('contacts/import route uses parseCSVLine (issue #135)', () => {
+  it('imports parseCSVLine instead of using naive split', () => {
+    const source = readFileSync(
+      resolve('src/app/api/contacts/import/route.ts'),
+      'utf-8'
+    );
+    expect(source).toContain('parseCSVLine');
+    expect(source).not.toContain("line.split(',')");
+  });
+});

--- a/src/app/api/contacts/import/route.ts
+++ b/src/app/api/contacts/import/route.ts
@@ -1,6 +1,7 @@
 import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { parseCSVLine } from '@/lib/csv-parser';
 
 export async function POST(request: NextRequest) {
   try {
@@ -38,7 +39,8 @@ export async function POST(request: NextRequest) {
     const dataLines = lines.slice(1);
 
     const contacts = dataLines.map(line => {
-      const [name, email, phone, notes] = line.split(',').map(s => s.trim());
+      const fields = parseCSVLine(line);
+      const [name, email, phone, notes] = fields.map(s => s.trim());
       return {
         professional_id: professional.id,
         name,

--- a/src/lib/csv-parser.ts
+++ b/src/lib/csv-parser.ts
@@ -1,0 +1,45 @@
+/**
+ * RFC 4180-compliant CSV line parser.
+ * Handles quoted fields, escaped quotes (""), and commas inside quotes.
+ */
+export function parseCSVLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  let i = 0;
+
+  while (i < line.length) {
+    const char = line[i];
+
+    if (inQuotes) {
+      if (char === '"') {
+        // Escaped quote ("") or end of quoted field
+        if (i + 1 < line.length && line[i + 1] === '"') {
+          current += '"';
+          i += 2;
+        } else {
+          inQuotes = false;
+          i++;
+        }
+      } else {
+        current += char;
+        i++;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+        i++;
+      } else if (char === ',') {
+        fields.push(current);
+        current = '';
+        i++;
+      } else {
+        current += char;
+        i++;
+      }
+    }
+  }
+
+  fields.push(current);
+  return fields;
+}


### PR DESCRIPTION
## Summary
- `line.split(',')` in contacts import failed on quoted fields (e.g. `"Smith, John"`)
- Created `parseCSVLine()` — RFC 4180-compliant parser handling quoted fields, escaped quotes, commas within values
- Zero new dependencies

## Files changed
- `src/lib/csv-parser.ts` — new, ~40 lines
- `src/app/api/contacts/import/route.ts` — replaced `line.split(',')` with `parseCSVLine(line)`
- `src/__tests__/lib/csv-parser.test.ts` — 11 tests (new)

## Test plan
- [x] 10 parser tests: simple fields, quoted commas, escaped quotes, empty fields, mixed, edge cases
- [x] 1 code verification test: route uses parseCSVLine, no naive split

🤖 Generated with [Claude Code](https://claude.com/claude-code)