### PR TITLE
fix(payments): rollback booking when Stripe checkout fails (#136)

### DIFF
--- a/src/__tests__/security/checkout-stripe-rollback.test.ts
+++ b/src/__tests__/security/checkout-stripe-rollback.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #136: Race condition — booking inserted before Stripe session
+ *
+ * If stripe.checkout.sessions.create() fails, the booking must be rolled back
+ * (cancelled) to free the slot. Previously, the Stripe call had no try-catch,
+ * leaving orphaned pending_payment bookings blocking slots indefinitely.
+ */
+
+describe('Checkout route Stripe rollback (issue #136)', () => {
+  const source = readFileSync(
+    resolve('src/app/api/bookings/checkout/route.ts'),
+    'utf-8'
+  );
+
+  it('wraps stripe.checkout.sessions.create in try-catch', () => {
+    const stripeCreateIndex = source.indexOf('stripe.checkout.sessions.create');
+    expect(stripeCreateIndex).toBeGreaterThan(-1);
+
+    // Find the try { that precedes the Stripe call (search backward)
+    const beforeStripe = source.slice(0, stripeCreateIndex);
+    const lastTryIndex = beforeStripe.lastIndexOf('try {');
+    expect(lastTryIndex).toBeGreaterThan(-1);
+
+    // Find the catch after the Stripe call
+    const afterStripe = source.slice(stripeCreateIndex);
+    const catchIndex = afterStripe.indexOf('} catch');
+    expect(catchIndex).toBeGreaterThan(-1);
+  });
+
+  it('cancels booking in catch block (rollback)', () => {
+    // Extract the catch block content
+    const catchIndex = source.indexOf('} catch');
+    const afterCatch = source.slice(catchIndex);
+
+    // Should cancel the booking
+    expect(afterCatch).toContain("status: 'cancelled'");
+    expect(afterCatch).toContain('booking.id');
+  });
+
+  it('returns an error response (not throwing) on Stripe failure', () => {
+    // Find the catch block after stripe.checkout.sessions.create
+    const stripeIndex = source.indexOf('stripe.checkout.sessions.create');
+    const afterStripe = source.slice(stripeIndex);
+    const catchIndex = afterStripe.indexOf('} catch');
+    const catchBlock = afterStripe.slice(catchIndex, catchIndex + 300);
+
+    // Should return a proper error response, not re-throw
+    expect(catchBlock).toContain('NextResponse.json');
+    expect(catchBlock).toContain('502');
+  });
+
+  it('also rolls back when Stripe is not configured', () => {
+    // The existing !stripe check should also cancel
+    const notConfiguredBlock = source.slice(
+      source.indexOf('if (!stripe)'),
+      source.indexOf('if (!stripe)') + 300
+    );
+    expect(notConfiguredBlock).toContain("status: 'cancelled'");
+    expect(notConfiguredBlock).toContain('503');
+  });
+
+  it('inserts booking before Stripe (intentional order for double-booking protection)', () => {
+    // Booking insert must come BEFORE Stripe session creation
+    // This is by design — the booking reserves the slot, Stripe is created after
+    const insertIndex = source.indexOf(".insert({");
+    const stripeIndex = source.indexOf("stripe.checkout.sessions.create");
+    expect(insertIndex).toBeLessThan(stripeIndex);
+  });
+
+  it('uses idempotency key for retry safety', () => {
+    expect(source).toContain('idempotencyKey');
+    expect(source).toContain('booking.id');
+  });
+});

--- a/src/app/api/bookings/checkout/route.ts
+++ b/src/app/api/bookings/checkout/route.ts
@@ -197,38 +197,45 @@ export async function POST(request: NextRequest) {
   // Idempotency key baseada no booking.id: retry-safe (mesmo booking = mesma session)
   const idempotencyKey = `cs:${booking.id}`;
 
-  const session = await stripe.checkout.sessions.create(
-    {
-      mode: 'payment',
-      line_items: [
-        {
-          price_data: {
-            currency: currencyCode,
-            product_data: {
-              name: `Sinal — ${service.name}`,
-              description: `Agendamento ${booking_date} às ${start_time}`,
+  let session;
+  try {
+    session = await stripe.checkout.sessions.create(
+      {
+        mode: 'payment',
+        line_items: [
+          {
+            price_data: {
+              currency: currencyCode,
+              product_data: {
+                name: `Sinal — ${service.name}`,
+                description: `Agendamento ${booking_date} às ${start_time}`,
+              },
+              unit_amount: depositCents,
             },
-            unit_amount: depositCents,
+            quantity: 1,
           },
-          quantity: 1,
+        ],
+        payment_intent_data: {
+          application_fee_amount: applicationFeeCents,
+          transfer_data: {
+            destination: prof.stripe_account_id as string,
+          },
         },
-      ],
-      payment_intent_data: {
-        application_fee_amount: applicationFeeCents,
-        transfer_data: {
-          destination: prof.stripe_account_id as string,
+        metadata: {
+          booking_id: booking.id,
+          type: 'deposit',
         },
+        customer_email: client_email,
+        success_url: `${BASE_URL}/booking/success?session_id={CHECKOUT_SESSION_ID}`,
+        cancel_url: `${BASE_URL}/booking/cancel`,
       },
-      metadata: {
-        booking_id: booking.id,
-        type: 'deposit',
-      },
-      customer_email: client_email,
-      success_url: `${BASE_URL}/booking/success?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${BASE_URL}/booking/cancel`,
-    },
-    { idempotencyKey }
-  );
+      { idempotencyKey }
+    );
+  } catch {
+    // Rollback: cancelar booking para liberar o slot
+    await supabase.from('bookings').update({ status: 'cancelled' }).eq('id', booking.id);
+    return NextResponse.json({ error: 'Falha ao criar sessão de pagamento.' }, { status: 502 });
+  }
 
   // ─── 12. INSERT payment ──────────────────────────────────────────────────
   await supabase.from('payments').insert({


### PR DESCRIPTION
## Summary
- `stripe.checkout.sessions.create()` had no try-catch — if Stripe API failed, booking stayed in `pending_payment` forever blocking the slot
- Now wrapped in try-catch that cancels the booking and returns 502
- Existing rollback for "Stripe not configured" (503) unchanged

## Files changed
- `src/app/api/bookings/checkout/route.ts` — added try-catch around Stripe session creation with booking rollback
- `src/__tests__/security/checkout-stripe-rollback.test.ts` — 6 tests (new)

## Test plan
- [x] 6 tests: try-catch wraps Stripe call, catch cancels booking, returns 502, existing 503 rollback preserved, insert-before-Stripe order verified, idempotency key present

🤖 Generated with [Claude Code](https://claude.com/claude-code)