### PR TITLE
fix(security): validate MIME type and magic bytes on gallery upload (#138)

### DIFF
--- a/src/__tests__/security/gallery-upload-mime.test.ts
+++ b/src/__tests__/security/gallery-upload-mime.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #138: Gallery upload missing MIME type validation
+ *
+ * The upload route accepted any file type — exe, php, svg with JS, etc.
+ * Now validates MIME type whitelist + magic bytes before uploading.
+ */
+
+describe('Gallery upload MIME validation (issue #138)', () => {
+  const source = readFileSync(
+    resolve('src/app/api/gallery/upload/route.ts'),
+    'utf-8'
+  );
+
+  it('defines ALLOWED_MIME_TYPES whitelist', () => {
+    expect(source).toContain('ALLOWED_MIME_TYPES');
+    expect(source).toContain('image/jpeg');
+    expect(source).toContain('image/png');
+    expect(source).toContain('image/webp');
+  });
+
+  it('does not allow SVG (XSS vector)', () => {
+    // SVG files can contain JavaScript — must not be in whitelist
+    expect(source).not.toContain("'image/svg+xml'");
+    expect(source).not.toContain('"image/svg+xml"');
+  });
+
+  it('validates magic bytes (not just MIME header)', () => {
+    expect(source).toContain('MAGIC_BYTES');
+    expect(source).toContain('0xFF, 0xD8, 0xFF'); // JPEG
+    expect(source).toContain('0x89, 0x50, 0x4E, 0x47'); // PNG
+    expect(source).toContain('0x52, 0x49, 0x46, 0x46'); // WebP (RIFF)
+  });
+
+  it('has a validateImageFile function', () => {
+    expect(source).toContain('validateImageFile');
+  });
+
+  it('calls validateImageFile for each file before upload', () => {
+    // Validation must happen before supabase.storage.upload
+    const validateIndex = source.indexOf('validateImageFile(f)');
+    const uploadIndex = source.indexOf("from('gallery')");
+    expect(validateIndex).toBeGreaterThan(-1);
+    expect(uploadIndex).toBeGreaterThan(-1);
+    expect(validateIndex).toBeLessThan(uploadIndex);
+  });
+
+  it('returns 400 for invalid file types', () => {
+    // Find the validation error response
+    const validateSection = source.slice(
+      source.indexOf('validateImageFile(f)'),
+      source.indexOf('validateImageFile(f)') + 200
+    );
+    expect(validateSection).toContain('400');
+  });
+
+  it('validates all files including before/after uploads', () => {
+    // filesToCheck should include file, beforeFile, afterFile
+    expect(source).toContain('[file, beforeFile, afterFile]');
+    // All go through the same validation loop
+    expect(source).toContain('for (const f of filesToCheck)');
+  });
+});

--- a/src/app/api/gallery/upload/route.ts
+++ b/src/app/api/gallery/upload/route.ts
@@ -5,6 +5,38 @@ import { NextRequest, NextResponse } from 'next/server';
 const MAX_REQUEST_SIZE = 50 * 1024 * 1024; // 50 MB total
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB per file
 
+const ALLOWED_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+]);
+
+// Magic bytes for supported image formats
+const MAGIC_BYTES: [string, number[]][] = [
+  ['image/jpeg', [0xFF, 0xD8, 0xFF]],
+  ['image/png', [0x89, 0x50, 0x4E, 0x47]],
+  ['image/webp', [0x52, 0x49, 0x46, 0x46]], // RIFF
+  ['image/gif', [0x47, 0x49, 0x46]],         // GIF
+];
+
+async function validateImageFile(file: File): Promise<string | null> {
+  if (!ALLOWED_MIME_TYPES.has(file.type)) {
+    return `Tipo de arquivo não permitido: ${file.type}. Use JPEG, PNG, WebP ou GIF.`;
+  }
+
+  const buffer = new Uint8Array(await file.slice(0, 8).arrayBuffer());
+  const matchesMagic = MAGIC_BYTES.some(([, bytes]) =>
+    bytes.every((b, i) => buffer[i] === b)
+  );
+
+  if (!matchesMagic) {
+    return 'Arquivo não é uma imagem válida.';
+  }
+
+  return null;
+}
+
 export async function POST(request: NextRequest) {
   // Validate content-length before parsing body
   const contentLength = request.headers.get('content-length');
@@ -48,7 +80,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'No file provided' }, { status: 400 });
     }
 
-    // Validate individual file sizes
+    // Validate individual file sizes and MIME types
     const filesToCheck = [file, beforeFile, afterFile].filter(Boolean) as File[];
     for (const f of filesToCheck) {
       if (f.size > MAX_FILE_SIZE) {
@@ -56,6 +88,10 @@ export async function POST(request: NextRequest) {
           { error: 'File too large. Maximum size is 5MB per file.' },
           { status: 413 }
         );
+      }
+      const validationError = await validateImageFile(f);
+      if (validationError) {
+        return NextResponse.json({ error: validationError }, { status: 400 });
       }
     }
 


### PR DESCRIPTION
## Summary
- Gallery upload accepted any file type (exe, php, svg with JS)
- Added MIME whitelist: `image/jpeg`, `image/png`, `image/webp`, `image/gif`
- Added magic bytes validation to prevent disguised files
- SVG excluded (XSS vector)
- Validates all files (main, before, after) in the same loop

## Files changed
- `src/app/api/gallery/upload/route.ts` — added `ALLOWED_MIME_TYPES`, `MAGIC_BYTES`, `validateImageFile()`
- `src/__tests__/security/gallery-upload-mime.test.ts` — 7 tests (new)

## Test plan
- [x] 7 tests: whitelist defined, SVG excluded, magic bytes present, validateImageFile exists, called before upload, returns 400, validates all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)