### PR TITLE
fix(security): use Redis for admin rate limiting (#139)

### DIFF
--- a/src/__tests__/security/admin-rate-limit-redis.test.ts
+++ b/src/__tests__/security/admin-rate-limit-redis.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #139: Rate limiting admin in-memory resets on deploy
+ *
+ * The in-memory Map reset on every deploy, allowing brute force across deploys.
+ * Now uses Redis (INCR + EXPIRE) when available, with in-memory fallback.
+ */
+
+describe('Admin rate limiting uses Redis (issue #139)', () => {
+  const source = readFileSync(
+    resolve('src/lib/admin/session.ts'),
+    'utf-8'
+  );
+
+  it('imports Redis (ioredis)', () => {
+    expect(source).toContain("import Redis from 'ioredis'");
+  });
+
+  it('uses STORAGE_URL or REDIS_URL for connection', () => {
+    expect(source).toContain('STORAGE_URL');
+    expect(source).toContain('REDIS_URL');
+  });
+
+  it('isRateLimited is async (returns Promise)', () => {
+    expect(source).toContain('async function isRateLimited');
+    expect(source).toContain('Promise<boolean>');
+  });
+
+  it('uses Redis INCR + EXPIRE pattern', () => {
+    expect(source).toContain('client.incr(key)');
+    expect(source).toContain('client.expire(key');
+  });
+
+  it('uses a namespaced Redis key', () => {
+    expect(source).toContain('admin_rate_limit:');
+  });
+
+  it('falls back to in-memory when Redis is unavailable', () => {
+    expect(source).toContain('isRateLimitedMemory');
+  });
+
+  it('catches Redis errors and falls back gracefully', () => {
+    // Should have a try-catch around Redis calls
+    const redisSection = source.slice(source.indexOf('async function isRateLimited'));
+    expect(redisSection).toContain('} catch');
+    expect(redisSection).toContain('isRateLimitedMemory');
+  });
+
+  it('auth route awaits isRateLimited (async)', () => {
+    const authSource = readFileSync(
+      resolve('src/app/api/admin/auth/route.ts'),
+      'utf-8'
+    );
+    expect(authSource).toContain('await isRateLimited');
+  });
+});

--- a/src/__tests__/security/admin-session.test.ts
+++ b/src/__tests__/security/admin-session.test.ts
@@ -92,7 +92,7 @@ describe('Admin rate limiting (issue #19)', () => {
     const { isRateLimited } = await import('@/lib/admin/session');
     const testIp = `rate-test-${Date.now()}`;
     for (let i = 0; i < 5; i++) {
-      expect(isRateLimited(testIp)).toBe(false);
+      expect(await isRateLimited(testIp)).toBe(false);
     }
   });
 
@@ -101,18 +101,18 @@ describe('Admin rate limiting (issue #19)', () => {
     const { isRateLimited } = await import('@/lib/admin/session');
     const testIp = `rate-block-${Date.now()}`;
     for (let i = 0; i < 5; i++) {
-      isRateLimited(testIp);
+      await isRateLimited(testIp);
     }
-    expect(isRateLimited(testIp)).toBe(true);
+    expect(await isRateLimited(testIp)).toBe(true);
   });
 
   it('allows attempts from different IPs', async () => {
     vi.resetModules();
     const { isRateLimited } = await import('@/lib/admin/session');
     const ts = Date.now();
-    expect(isRateLimited(`ip-a-${ts}`)).toBe(false);
-    expect(isRateLimited(`ip-b-${ts}`)).toBe(false);
-    expect(isRateLimited(`ip-c-${ts}`)).toBe(false);
+    expect(await isRateLimited(`ip-a-${ts}`)).toBe(false);
+    expect(await isRateLimited(`ip-b-${ts}`)).toBe(false);
+    expect(await isRateLimited(`ip-c-${ts}`)).toBe(false);
   });
 });
 

--- a/src/app/api/admin/auth/route.ts
+++ b/src/app/api/admin/auth/route.ts
@@ -4,7 +4,7 @@ import { generateAdminToken, isRateLimited } from '@/lib/admin/session';
 export async function POST(request: NextRequest) {
   // Rate limiting by IP
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  if (isRateLimited(ip)) {
+  if (await isRateLimited(ip)) {
     return NextResponse.json(
       { error: 'Muitas tentativas. Tente novamente em 15 minutos.' },
       { status: 429 }

--- a/src/lib/admin/session.ts
+++ b/src/lib/admin/session.ts
@@ -73,24 +73,59 @@ export function validateAdminToken(token: string | undefined): boolean {
 
 // ─── Rate Limiting ────────────────────────────────────────────────────────────
 
-const MAX_ATTEMPTS = 5;
-const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+import Redis from 'ioredis';
 
-const attempts = new Map<string, { count: number; resetAt: number }>();
+const MAX_ATTEMPTS = 5;
+const WINDOW_SECONDS = 15 * 60; // 15 minutes
+
+const REDIS_URL = process.env.STORAGE_URL || process.env.REDIS_URL;
+
+let redis: Redis | null = null;
+
+function getRedis(): Redis | null {
+  if (!REDIS_URL) return null;
+  if (redis) return redis;
+  redis = new Redis(REDIS_URL, {
+    maxRetriesPerRequest: 1,
+    connectTimeout: 3000,
+    commandTimeout: 3000,
+    lazyConnect: true,
+  });
+  return redis;
+}
+
+// In-memory fallback when Redis is not available
+const memoryAttempts = new Map<string, { count: number; resetAt: number }>();
+
+function isRateLimitedMemory(ip: string): boolean {
+  const now = Date.now();
+  const entry = memoryAttempts.get(ip);
+  if (!entry || now > entry.resetAt) {
+    memoryAttempts.set(ip, { count: 1, resetAt: now + WINDOW_SECONDS * 1000 });
+    return false;
+  }
+  entry.count++;
+  return entry.count > MAX_ATTEMPTS;
+}
 
 /**
  * Checks if an IP has exceeded the login rate limit.
+ * Uses Redis when available (persists across deploys); falls back to in-memory.
  * Returns true if the request should be BLOCKED.
  */
-export function isRateLimited(ip: string): boolean {
-  const now = Date.now();
-  const entry = attempts.get(ip);
+export async function isRateLimited(ip: string): Promise<boolean> {
+  const client = getRedis();
+  if (!client) return isRateLimitedMemory(ip);
 
-  if (!entry || now > entry.resetAt) {
-    attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
-    return false;
+  try {
+    const key = `admin_rate_limit:${ip}`;
+    const count = await client.incr(key);
+    if (count === 1) {
+      await client.expire(key, WINDOW_SECONDS);
+    }
+    return count > MAX_ATTEMPTS;
+  } catch {
+    // Redis failure → fall back to in-memory
+    return isRateLimitedMemory(ip);
   }
-
-  entry.count++;
-  return entry.count > MAX_ATTEMPTS;
 }


### PR DESCRIPTION
## Summary
- In-memory `Map` for admin login rate limiting reset on every deploy/restart
- Now uses Redis `INCR` + `EXPIRE` (same connection as conversation cache)
- Graceful fallback to in-memory when Redis is unavailable
- `isRateLimited` is now `async` — updated caller in auth route

## Files changed
- `src/lib/admin/session.ts` — Redis-based rate limiting with fallback
- `src/app/api/admin/auth/route.ts` — `await isRateLimited(ip)`
- `src/__tests__/security/admin-session.test.ts` — updated to use `await`
- `src/__tests__/security/admin-rate-limit-redis.test.ts` — 8 tests (new)

## Test plan
- [x] 8 new tests: Redis import, connection vars, async signature, INCR+EXPIRE, namespaced key, fallback, error handling, auth route await
- [x] 23 existing admin-session tests still pass (updated to async)

🤖 Generated with [Claude Code](https://claude.com/claude-code)