### PR TITLE
fix(security): add rate limiting to public bookings endpoint (#140)

### DIFF
--- a/src/__tests__/security/bookings-rate-limit.test.ts
+++ b/src/__tests__/security/bookings-rate-limit.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #140: No rate limiting on public bookings endpoint
+ *
+ * The bookings POST endpoint had no rate limiting, allowing spam of fake
+ * bookings and flood of email/WhatsApp notifications.
+ */
+
+describe('Bookings rate limiting (issue #140)', () => {
+  const source = readFileSync(
+    resolve('src/app/api/bookings/route.ts'),
+    'utf-8'
+  );
+
+  it('imports isRateLimited', () => {
+    expect(source).toContain("import { isRateLimited } from '@/lib/rate-limit'");
+  });
+
+  it('calls isRateLimited before processing', () => {
+    const rateLimitIndex = source.indexOf('isRateLimited');
+    const parseIndex = source.indexOf('request.json()');
+    expect(rateLimitIndex).toBeGreaterThan(-1);
+    expect(parseIndex).toBeGreaterThan(-1);
+    expect(rateLimitIndex).toBeLessThan(parseIndex);
+  });
+
+  it('returns 429 when rate limited', () => {
+    expect(source).toContain('429');
+  });
+
+  it('rate limits by IP (x-forwarded-for)', () => {
+    expect(source).toContain('x-forwarded-for');
+  });
+
+  it('uses a booking-specific key prefix', () => {
+    expect(source).toContain('booking:');
+  });
+
+  it('has a reasonable rate limit (10/hour)', () => {
+    expect(source).toContain('BOOKING_RATE_LIMIT');
+    expect(source).toContain('BOOKING_RATE_WINDOW');
+    // Verify the values
+    expect(source).toMatch(/BOOKING_RATE_LIMIT\s*=\s*10/);
+    expect(source).toMatch(/BOOKING_RATE_WINDOW\s*=\s*3600/);
+  });
+});
+
+describe('Rate limit utility (issue #140)', () => {
+  const source = readFileSync(
+    resolve('src/lib/rate-limit.ts'),
+    'utf-8'
+  );
+
+  it('uses Redis when available', () => {
+    expect(source).toContain("import Redis from 'ioredis'");
+    expect(source).toContain('client.incr');
+    expect(source).toContain('client.expire');
+  });
+
+  it('falls back to in-memory when Redis unavailable', () => {
+    expect(source).toContain('checkMemory');
+  });
+
+  it('catches Redis errors gracefully', () => {
+    expect(source).toContain('} catch');
+  });
+
+  it('uses namespaced Redis keys', () => {
+    expect(source).toContain('rate_limit:');
+  });
+
+  it('is a generic utility (accepts key, limit, windowSeconds)', () => {
+    expect(source).toContain('key: string');
+    expect(source).toContain('limit: number');
+    expect(source).toContain('windowSeconds: number');
+  });
+});
+
+describe('Rate limit utility — functional tests', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    // No Redis in test — uses memory fallback
+    delete process.env.STORAGE_URL;
+    delete process.env.REDIS_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('allows requests within limit', async () => {
+    const { isRateLimited } = await import('@/lib/rate-limit');
+    const key = `test-allow-${Date.now()}`;
+    for (let i = 0; i < 5; i++) {
+      expect(await isRateLimited(key, 5, 60)).toBe(false);
+    }
+  });
+
+  it('blocks requests exceeding limit', async () => {
+    const { isRateLimited } = await import('@/lib/rate-limit');
+    const key = `test-block-${Date.now()}`;
+    for (let i = 0; i < 3; i++) {
+      await isRateLimited(key, 3, 60);
+    }
+    expect(await isRateLimited(key, 3, 60)).toBe(true);
+  });
+
+  it('tracks different keys independently', async () => {
+    const { isRateLimited } = await import('@/lib/rate-limit');
+    const ts = Date.now();
+    expect(await isRateLimited(`a-${ts}`, 1, 60)).toBe(false);
+    expect(await isRateLimited(`b-${ts}`, 1, 60)).toBe(false);
+  });
+});

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -6,8 +6,21 @@ import { sendEvolutionMessage } from '@/lib/whatsapp/evolution';
 import { safeSendEmail } from '@/lib/email/safe-send';
 import { safeSendWhatsApp } from '@/lib/whatsapp/safe-send';
 import { bookingSchema, sanitizeString } from '@/lib/validation/booking-schema';
+import { isRateLimited } from '@/lib/rate-limit';
+
+const BOOKING_RATE_LIMIT = 10; // max bookings per window
+const BOOKING_RATE_WINDOW = 3600; // 1 hour in seconds
 
 export async function POST(request: NextRequest) {
+  // ─── Rate limiting por IP ──────────────────────────────────────────
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  if (await isRateLimited(`booking:${ip}`, BOOKING_RATE_LIMIT, BOOKING_RATE_WINDOW)) {
+    return NextResponse.json(
+      { error: 'Muitas tentativas. Tente novamente mais tarde.' },
+      { status: 429 }
+    );
+  }
+
   // ─── 1. Parse + validação Zod ────────────────────────────────────────
   let rawBody: unknown;
   try {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,55 @@
+import Redis from 'ioredis';
+
+const REDIS_URL = process.env.STORAGE_URL || process.env.REDIS_URL;
+
+let redis: Redis | null = null;
+
+function getRedis(): Redis | null {
+  if (!REDIS_URL) return null;
+  if (redis) return redis;
+  redis = new Redis(REDIS_URL, {
+    maxRetriesPerRequest: 1,
+    connectTimeout: 3000,
+    commandTimeout: 3000,
+    lazyConnect: true,
+  });
+  return redis;
+}
+
+// In-memory fallback
+const memoryStore = new Map<string, { count: number; resetAt: number }>();
+
+function checkMemory(key: string, limit: number, windowMs: number): boolean {
+  const now = Date.now();
+  const entry = memoryStore.get(key);
+  if (!entry || now > entry.resetAt) {
+    memoryStore.set(key, { count: 1, resetAt: now + windowMs });
+    return false;
+  }
+  entry.count++;
+  return entry.count > limit;
+}
+
+/**
+ * Generic rate limiter using Redis INCR+EXPIRE with in-memory fallback.
+ * Returns true if the request should be BLOCKED.
+ */
+export async function isRateLimited(
+  key: string,
+  limit: number,
+  windowSeconds: number
+): Promise<boolean> {
+  const client = getRedis();
+  if (!client) return checkMemory(key, limit, windowSeconds * 1000);
+
+  try {
+    const redisKey = `rate_limit:${key}`;
+    const count = await client.incr(redisKey);
+    if (count === 1) {
+      await client.expire(redisKey, windowSeconds);
+    }
+    return count > limit;
+  } catch {
+    return checkMemory(key, limit, windowSeconds * 1000);
+  }
+}


### PR DESCRIPTION
## Summary
- Public bookings endpoint had no rate limiting — allowed spam bookings and notification floods
- Added 10/hour per-IP rate limit using Redis INCR+EXPIRE with in-memory fallback
- Extracted reusable `src/lib/rate-limit.ts` utility (can be used by other endpoints)

## Files changed
- `src/lib/rate-limit.ts` — generic rate limiter (new)
- `src/app/api/bookings/route.ts` — added rate limiting before body parsing
- `src/__tests__/security/bookings-rate-limit.test.ts` — 14 tests (new)

## Test plan
- [x] 6 code verification tests for bookings route (import, order, 429, IP, key prefix, limits)
- [x] 5 code verification tests for rate-limit utility (Redis, fallback, errors, keys, generics)
- [x] 3 functional tests (allows within limit, blocks exceeding, independent keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)