### PR TITLE
fix(webhook): add Stripe event dedup to prevent reprocessing (#144)

### DIFF
--- a/src/__tests__/security/webhook-stripe-dedup.test.ts
+++ b/src/__tests__/security/webhook-stripe-dedup.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #144: Stripe webhook without reprocessing protection
+ *
+ * Stripe can retry webhooks on timeout, causing duplicate booking
+ * confirmations and notification spam. Now uses event ID dedup via
+ * Redis (with in-memory fallback) to skip already-processed events.
+ */
+
+describe('Stripe webhook dedup — code verification (issue #144)', () => {
+  const source = readFileSync(
+    resolve('src/app/api/webhooks/stripe-deposit/route.ts'),
+    'utf-8'
+  );
+
+  it('imports event dedup utilities', () => {
+    expect(source).toContain("import { isEventProcessed, markEventProcessed }");
+  });
+
+  it('checks isEventProcessed before processing', () => {
+    const checkIdx = source.indexOf('isEventProcessed');
+    const switchIdx = source.indexOf('switch (event.type)');
+    expect(checkIdx).toBeGreaterThan(-1);
+    expect(switchIdx).toBeGreaterThan(-1);
+    expect(checkIdx).toBeLessThan(switchIdx);
+  });
+
+  it('calls markEventProcessed after successful handling', () => {
+    const markIdx = source.lastIndexOf('markEventProcessed');
+    const returnIdx = source.lastIndexOf("{ received: true }");
+    expect(markIdx).toBeGreaterThan(-1);
+    expect(returnIdx).toBeGreaterThan(-1);
+    expect(markIdx).toBeLessThan(returnIdx);
+  });
+
+  it('returns early with deduplicated flag when event already processed', () => {
+    expect(source).toContain('deduplicated: true');
+  });
+
+  it('checkout.session.completed uses idempotent status guard', () => {
+    const checkoutSection = source.slice(
+      source.indexOf("'checkout.session.completed'"),
+      source.indexOf("'checkout.session.completed'") + 500
+    );
+    expect(checkoutSection).toContain("eq('status', 'pending_payment')");
+  });
+});
+
+describe('Event dedup utility — code verification', () => {
+  const source = readFileSync(
+    resolve('src/lib/webhooks/event-dedup.ts'),
+    'utf-8'
+  );
+
+  it('uses Redis for event storage when available', () => {
+    expect(source).toContain("import Redis from 'ioredis'");
+    expect(source).toContain('webhook_event:');
+  });
+
+  it('has in-memory fallback', () => {
+    expect(source).toContain('memoryEvents');
+  });
+
+  it('uses TTL for automatic cleanup', () => {
+    expect(source).toContain('EVENT_TTL_SECONDS');
+    expect(source).toContain("'EX'");
+  });
+
+  it('TTL covers Stripe retry window (72h)', () => {
+    expect(source).toContain('72 * 60 * 60');
+  });
+
+  it('exports isEventProcessed and markEventProcessed', () => {
+    expect(source).toContain('export async function isEventProcessed');
+    expect(source).toContain('export async function markEventProcessed');
+  });
+});
+
+describe('Event dedup utility — functional tests', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.STORAGE_URL;
+    delete process.env.REDIS_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('new event is not marked as processed', async () => {
+    const { isEventProcessed } = await import('@/lib/webhooks/event-dedup');
+    expect(await isEventProcessed(`evt_new_${Date.now()}`)).toBe(false);
+  });
+
+  it('marks and detects processed event', async () => {
+    const { isEventProcessed, markEventProcessed } = await import('@/lib/webhooks/event-dedup');
+    const eventId = `evt_test_${Date.now()}`;
+
+    expect(await isEventProcessed(eventId)).toBe(false);
+    await markEventProcessed(eventId);
+    expect(await isEventProcessed(eventId)).toBe(true);
+  });
+
+  it('different event IDs are tracked independently', async () => {
+    const { isEventProcessed, markEventProcessed } = await import('@/lib/webhooks/event-dedup');
+    const ts = Date.now();
+
+    await markEventProcessed(`evt_a_${ts}`);
+    expect(await isEventProcessed(`evt_a_${ts}`)).toBe(true);
+    expect(await isEventProcessed(`evt_b_${ts}`)).toBe(false);
+  });
+});

--- a/src/app/api/webhooks/stripe-deposit/route.ts
+++ b/src/app/api/webhooks/stripe-deposit/route.ts
@@ -7,6 +7,7 @@ import { sendBookingConfirmationEmail } from '@/lib/resend';
 import { sendEvolutionMessage } from '@/lib/whatsapp/evolution';
 import { safeSendEmail } from '@/lib/email/safe-send';
 import { safeSendWhatsApp } from '@/lib/whatsapp/safe-send';
+import { isEventProcessed, markEventProcessed } from '@/lib/webhooks/event-dedup';
 
 export async function POST(request: NextRequest) {
   const body = await request.text();
@@ -31,6 +32,11 @@ export async function POST(request: NextRequest) {
     event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
   } catch {
     return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  // ─── Dedup: skip if event already processed (Stripe retries) ────────
+  if (await isEventProcessed(event.id)) {
+    return NextResponse.json({ received: true, deduplicated: true });
   }
 
   const supabase = createAdminClient();
@@ -238,6 +244,9 @@ export async function POST(request: NextRequest) {
       break;
     }
   }
+
+  // Mark event as processed AFTER successful handling
+  await markEventProcessed(event.id);
 
   return NextResponse.json({ received: true });
 }

--- a/src/lib/webhooks/event-dedup.ts
+++ b/src/lib/webhooks/event-dedup.ts
@@ -1,0 +1,60 @@
+import Redis from 'ioredis';
+
+const EVENT_TTL_SECONDS = 72 * 60 * 60; // 72 hours (Stripe retries up to 3 days)
+
+const REDIS_URL = process.env.STORAGE_URL || process.env.REDIS_URL;
+
+let redis: Redis | null = null;
+
+function getRedis(): Redis | null {
+  if (!REDIS_URL) return null;
+  if (redis) return redis;
+  redis = new Redis(REDIS_URL, {
+    maxRetriesPerRequest: 1,
+    connectTimeout: 3000,
+    commandTimeout: 3000,
+    lazyConnect: true,
+  });
+  return redis;
+}
+
+// In-memory fallback when Redis is unavailable
+const memoryEvents = new Map<string, number>(); // eventId → expiresAt (ms)
+
+/**
+ * Checks if a webhook event has already been processed.
+ * Uses Redis when available; falls back to in-memory Map.
+ */
+export async function isEventProcessed(eventId: string): Promise<boolean> {
+  const client = getRedis();
+  if (client) {
+    try {
+      const val = await client.get(`webhook_event:${eventId}`);
+      return val !== null;
+    } catch { /* fall through to memory */ }
+  }
+
+  const expiresAt = memoryEvents.get(eventId);
+  if (!expiresAt) return false;
+  if (Date.now() > expiresAt) {
+    memoryEvents.delete(eventId);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Marks a webhook event as processed.
+ * Stored with TTL so old entries are automatically cleaned up.
+ */
+export async function markEventProcessed(eventId: string): Promise<void> {
+  const client = getRedis();
+  if (client) {
+    try {
+      await client.set(`webhook_event:${eventId}`, '1', 'EX', EVENT_TTL_SECONDS);
+      return;
+    } catch { /* fall through to memory */ }
+  }
+
+  memoryEvents.set(eventId, Date.now() + EVENT_TTL_SECONDS * 1000);
+}


### PR DESCRIPTION
## Summary
- Stripe webhooks had no event ID dedup — retries caused duplicate confirmations and notifications
- Added `event-dedup.ts` utility: Redis-backed (in-memory fallback) event ID tracking with 72h TTL
- Webhook checks `isEventProcessed(event.id)` before processing, marks after success
- `checkout.session.completed` already had idempotent `.eq('status', 'pending_payment')` guard

## Test plan
- [x] 13 unit tests (code verification + functional dedup tests)
- [ ] CI green (excluding GDPR pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)