### PR TITLE
fix(config): restrict Supabase remote patterns to project hostname (#145)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,13 +3,17 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n.ts');
 
+// Extract project-specific Supabase hostname from env (e.g. "abcdef.supabase.co")
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const supabaseHostname = supabaseUrl ? new URL(supabaseUrl).hostname : '';
+
 const cspDirectives = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com",
   "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: blob: https://*.supabase.co",
+  `img-src 'self' data: blob: ${supabaseHostname ? `https://${supabaseHostname}` : 'https://*.supabase.co'}`,
   "font-src 'self'",
-  "connect-src 'self' https://*.supabase.co https://api.stripe.com",
+  `connect-src 'self' ${supabaseHostname ? `https://${supabaseHostname}` : 'https://*.supabase.co'} https://api.stripe.com`,
   "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
   "frame-ancestors 'none'",
   "base-uri 'self'",
@@ -27,19 +31,22 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: [
-      // Supabase Storage (avatars, covers, gallery)
-      {
-        protocol: 'https',
-        hostname: '*.supabase.co',
-        pathname: '/storage/v1/object/**',
-      },
-      // Supabase Storage via project URL
-      {
-        protocol: 'https',
-        hostname: '*.supabase.co',
-      },
-    ],
+    remotePatterns: supabaseHostname
+      ? [
+          {
+            protocol: 'https',
+            hostname: supabaseHostname,
+            pathname: '/storage/v1/object/**',
+          },
+        ]
+      : [
+          // Fallback: accept any Supabase project if env not set (dev only)
+          {
+            protocol: 'https',
+            hostname: '*.supabase.co',
+            pathname: '/storage/v1/object/**',
+          },
+        ],
   },
   async headers() {
     return [

--- a/src/__tests__/security/next-config-remote-patterns.test.ts
+++ b/src/__tests__/security/next-config-remote-patterns.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #145: Supabase remote patterns too permissive
+ *
+ * next.config.ts used *.supabase.co wildcard, accepting images from
+ * any Supabase project. Now restricts to the project-specific hostname
+ * derived from NEXT_PUBLIC_SUPABASE_URL.
+ */
+
+describe('Next.js remote patterns — Supabase restriction (issue #145)', () => {
+  const source = readFileSync(resolve('next.config.ts'), 'utf-8');
+
+  it('extracts hostname from NEXT_PUBLIC_SUPABASE_URL', () => {
+    expect(source).toContain('NEXT_PUBLIC_SUPABASE_URL');
+    expect(source).toContain('new URL(supabaseUrl).hostname');
+  });
+
+  it('uses project-specific hostname in remotePatterns when env is set', () => {
+    // Should use supabaseHostname variable, not wildcard, in the primary path
+    expect(source).toContain('hostname: supabaseHostname');
+  });
+
+  it('restricts pathname to /storage/v1/object/**', () => {
+    expect(source).toContain("pathname: '/storage/v1/object/**'");
+  });
+
+  it('removed the second wildcard pattern (no pathname restriction)', () => {
+    // The old config had a second pattern with just hostname: '*.supabase.co' and no pathname
+    // Count occurrences of *.supabase.co in remotePatterns section
+    const patternsSection = source.slice(
+      source.indexOf('remotePatterns'),
+      source.indexOf('async headers()')
+    );
+    // Wildcard should only appear in the fallback branch
+    const wildcardCount = (patternsSection.match(/\*\.supabase\.co/g) || []).length;
+    expect(wildcardCount).toBe(1); // only in fallback
+  });
+
+  it('uses project-specific hostname in CSP img-src when env is set', () => {
+    expect(source).toContain('supabaseHostname ? `https://${supabaseHostname}`');
+  });
+
+  it('uses project-specific hostname in CSP connect-src when env is set', () => {
+    const connectLine = source.split('\n').find(l => l.includes('connect-src'));
+    expect(connectLine).toContain('supabaseHostname');
+  });
+
+  it('falls back to wildcard only when env is not set', () => {
+    // Wildcard should only appear as fallback
+    const lines = source.split('\n');
+    for (const line of lines) {
+      if (line.includes("'*.supabase.co'") || line.includes('*.supabase.co')) {
+        // Should be in a fallback/conditional context
+        expect(
+          source.includes("supabaseHostname ?") || source.includes("// Fallback")
+        ).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `*.supabase.co` wildcard allowed images from any Supabase project
- Now extracts hostname from `NEXT_PUBLIC_SUPABASE_URL` for remotePatterns and CSP
- Falls back to wildcard only when env var is not set (dev)
- Removed second pattern that had no pathname restriction

## Test plan
- [x] 7 unit tests verify code structure
- [ ] CI green (excluding GDPR pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)