### PR TITLE
fix(analytics): eliminate N+1 queries with Supabase JOINs

### DIFF
--- a/src/__tests__/analytics/n-plus-one-queries.test.ts
+++ b/src/__tests__/analytics/n-plus-one-queries.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #146: N+1 queries in analytics endpoints
+ *
+ * All analytics routes were making 2 separate queries (bookings + services).
+ * Now they use Supabase JOINs via select('..., services(price)') to fetch
+ * everything in a single query.
+ */
+
+const routes = [
+  {
+    name: 'clients',
+    path: 'src/app/api/analytics/clients/route.ts',
+  },
+  {
+    name: 'revenue',
+    path: 'src/app/api/analytics/revenue/route.ts',
+  },
+  {
+    name: 'overview',
+    path: 'src/app/api/analytics/overview/route.ts',
+  },
+  {
+    name: 'services/ranking',
+    path: 'src/app/api/analytics/services/ranking/route.ts',
+  },
+];
+
+describe('N+1 query elimination in analytics endpoints (issue #146)', () => {
+  for (const route of routes) {
+    describe(`${route.name} route`, () => {
+      const source = readFileSync(resolve(route.path), 'utf-8');
+
+      it('uses JOIN syntax services(...) in the select', () => {
+        expect(source).toContain('services(');
+      });
+
+      it('does NOT have a separate .from("services") query', () => {
+        // The only .from() call should be for 'bookings' (or 'professionals')
+        // There should NOT be a separate .from('services') query
+        const fromServicesCalls = (source.match(/\.from\(['"]services['"]\)/g) || []).length;
+        expect(fromServicesCalls).toBe(0);
+      });
+
+      it('does NOT use .in("id", serviceIds) pattern', () => {
+        expect(source).not.toContain("'id', serviceIds");
+      });
+
+      it('does NOT build a priceMap from a second query', () => {
+        expect(source).not.toContain('priceMap');
+      });
+
+      it('has only one .from("bookings") call', () => {
+        const fromBookingsCalls = (source.match(/\.from\(['"]bookings['"]\)/g) || []).length;
+        expect(fromBookingsCalls).toBe(1);
+      });
+    });
+  }
+});

--- a/src/app/api/analytics/clients/route.ts
+++ b/src/app/api/analytics/clients/route.ts
@@ -30,30 +30,14 @@ export async function GET(request: NextRequest) {
   const offset = parseInt(searchParams.get('offset') || '0', 10);
 
   try {
-    // Buscar todos os agendamentos confirmados com preço do serviço
+    // Buscar agendamentos com preço do serviço via JOIN (single query)
     const { data: bookings, error: bookingsError } = await supabase
       .from('bookings')
-      .select('client_phone, client_name, booking_date, status, service_id')
+      .select('client_phone, client_name, booking_date, status, service_id, services(price)')
       .eq('professional_id', professional.id)
       .neq('status', 'cancelled');
 
     if (bookingsError) throw bookingsError;
-
-    // Buscar preços dos serviços
-    const serviceIds = [
-      ...new Set((bookings ?? []).map((b) => b.service_id).filter(Boolean)),
-    ];
-    const priceMap: Record<string, number> = {};
-
-    if (serviceIds.length > 0) {
-      const { data: services } = await supabase
-        .from('services')
-        .select('id, price')
-        .in('id', serviceIds);
-      for (const s of services ?? []) {
-        priceMap[s.id] = Number(s.price ?? 0);
-      }
-    }
 
     // Agregar por cliente
     const clientMap = new Map<
@@ -72,7 +56,8 @@ export async function GET(request: NextRequest) {
 
     for (const b of bookings ?? []) {
       const phone = b.client_phone ?? 'unknown';
-      const price = priceMap[b.service_id] ?? 0;
+      const svc = b.services as { price: number } | null;
+      const price = Number(svc?.price ?? 0);
 
       if (!clientMap.has(phone)) {
         clientMap.set(phone, {

--- a/src/app/api/analytics/overview/route.ts
+++ b/src/app/api/analytics/overview/route.ts
@@ -31,10 +31,10 @@ export async function GET(request: NextRequest) {
   const { start, end } = getDateRange(period, startDate, endDate);
 
   try {
-    // Buscar todos os agendamentos do período com o service_id
+    // Buscar agendamentos com preço do serviço via JOIN (single query)
     const { data: bookings, error: bookingsError } = await supabase
       .from('bookings')
-      .select('id, status, client_phone, service_id')
+      .select('id, status, client_phone, service_id, services(price)')
       .eq('professional_id', professional.id)
       .gte('booking_date', start)
       .lte('booking_date', end);
@@ -43,24 +43,13 @@ export async function GET(request: NextRequest) {
 
     const all = bookings ?? [];
 
-    // Buscar preços dos serviços utilizados
-    const serviceIds = [...new Set(all.map((b) => b.service_id).filter(Boolean))];
-    const priceMap: Record<string, number> = {};
-
-    if (serviceIds.length > 0) {
-      const { data: services } = await supabase
-        .from('services')
-        .select('id, price')
-        .in('id', serviceIds);
-      for (const s of services ?? []) {
-        priceMap[s.id] = Number(s.price ?? 0);
-      }
-    }
-
     const confirmed = all.filter((b) => b.status === 'confirmed' || b.status === 'completed');
     const cancelled = all.filter((b) => b.status === 'cancelled');
 
-    const totalRevenue = confirmed.reduce((sum, b) => sum + (priceMap[b.service_id] ?? 0), 0);
+    const totalRevenue = confirmed.reduce((sum, b) => {
+      const svc = b.services as { price: number } | null;
+      return sum + Number(svc?.price ?? 0);
+    }, 0);
     const confirmedCount = confirmed.length;
     const uniqueClients = new Set(confirmed.map((b) => b.client_phone).filter(Boolean)).size;
     const averageTicket = confirmedCount > 0 ? totalRevenue / confirmedCount : 0;

--- a/src/app/api/analytics/revenue/route.ts
+++ b/src/app/api/analytics/revenue/route.ts
@@ -36,10 +36,10 @@ export async function GET(request: NextRequest) {
   const { start, end } = getDateRange(period, startDate, endDate);
 
   try {
-    // Buscar agendamentos do período
+    // Buscar agendamentos com preço do serviço via JOIN (single query)
     const { data: bookings, error: bookingsError } = await supabase
       .from('bookings')
-      .select('booking_date, status, client_phone, service_id')
+      .select('booking_date, status, client_phone, service_id, services(price)')
       .eq('professional_id', professional.id)
       .gte('booking_date', start)
       .lte('booking_date', end);
@@ -47,20 +47,6 @@ export async function GET(request: NextRequest) {
     if (bookingsError) throw bookingsError;
 
     const all = bookings ?? [];
-
-    // Buscar preços dos serviços
-    const serviceIds = [...new Set(all.map((b) => b.service_id).filter(Boolean))];
-    const priceMap: Record<string, number> = {};
-
-    if (serviceIds.length > 0) {
-      const { data: services } = await supabase
-        .from('services')
-        .select('id, price')
-        .in('id', serviceIds);
-      for (const s of services ?? []) {
-        priceMap[s.id] = Number(s.price ?? 0);
-      }
-    }
 
     // Agrupar por período (dia/semana/mês) em JS
     const groups = new Map<
@@ -76,7 +62,8 @@ export async function GET(request: NextRequest) {
       const g = groups.get(key)!;
       g.bookings++;
       if (booking.status === 'confirmed' || booking.status === 'completed') {
-        g.revenue += priceMap[booking.service_id] ?? 0;
+        const svc = booking.services as { price: number } | null;
+        g.revenue += Number(svc?.price ?? 0);
         if (booking.client_phone) g.clients.add(booking.client_phone);
       }
       if (booking.status === 'cancelled') g.cancelled++;

--- a/src/app/api/analytics/services/ranking/route.ts
+++ b/src/app/api/analytics/services/ranking/route.ts
@@ -32,10 +32,10 @@ export async function GET(request: NextRequest) {
   const { start, end } = getDateRange(period, startDate, endDate);
 
   try {
-    // Agendamentos confirmados no período
+    // Agendamentos confirmados com dados do serviço via JOIN (single query)
     const { data: bookings, error: bookingsError } = await supabase
       .from('bookings')
-      .select('service_id')
+      .select('service_id, services(id, name, price)')
       .eq('professional_id', professional.id)
       .gte('booking_date', start)
       .lte('booking_date', end)
@@ -43,19 +43,17 @@ export async function GET(request: NextRequest) {
 
     if (bookingsError) throw bookingsError;
 
-    // Serviços ativos do profissional
-    const { data: services, error: servicesError } = await supabase
-      .from('services')
-      .select('id, name, price')
-      .eq('professional_id', professional.id)
-      .eq('is_active', true);
-
-    if (servicesError) throw servicesError;
-
-    // Contar agendamentos por serviço
-    const counts: Record<string, number> = {};
+    // Contar agendamentos por serviço e coletar info
+    const serviceMap = new Map<string, { name: string; price: number; count: number }>();
     for (const b of bookings ?? []) {
-      if (b.service_id) counts[b.service_id] = (counts[b.service_id] ?? 0) + 1;
+      const svc = b.services as { id: string; name: string; price: number } | null;
+      if (!b.service_id || !svc) continue;
+      const existing = serviceMap.get(b.service_id);
+      if (existing) {
+        existing.count++;
+      } else {
+        serviceMap.set(b.service_id, { name: svc.name, price: Number(svc.price), count: 1 });
+      }
     }
 
     const days = Math.max(
@@ -63,15 +61,14 @@ export async function GET(request: NextRequest) {
       Math.ceil((new Date(end).getTime() - new Date(start).getTime()) / 86400000),
     );
 
-    const ranking = (services ?? [])
-      .filter((s) => counts[s.id] > 0)
-      .map((s) => ({
-        service_id: s.id,
+    const ranking = Array.from(serviceMap.entries())
+      .map(([id, s]) => ({
+        service_id: id,
         service_name: s.name,
-        service_price: Number(s.price),
-        total_bookings: counts[s.id],
-        total_revenue: counts[s.id] * Number(s.price),
-        avg_bookings_per_day: counts[s.id] / days,
+        service_price: s.price,
+        total_bookings: s.count,
+        total_revenue: s.count * s.price,
+        avg_bookings_per_day: s.count / days,
       }))
       .sort((a, b) => b.total_revenue - a.total_revenue)
       .slice(0, limit);


### PR DESCRIPTION
## Summary
- Replaced 2-query pattern (bookings + services separately) with single JOIN query via `.select('..., services(price)')` in all 4 analytics endpoints
- **clients/route.ts**: removed separate services query + priceMap, uses `b.services.price` directly
- **revenue/route.ts**: same pattern — inline price from JOIN
- **overview/route.ts**: same pattern — inline price from JOIN
- **services/ranking/route.ts**: removed separate services query, builds ranking from JOIN data using Map

## Test plan
- [x] 20 unit tests verifying all 4 routes use JOIN syntax and don't have separate services queries
- [ ] CI green

Ref #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)