### PR TITLE
fix(security): stop leaking Stripe error details in connect response

### DIFF
--- a/src/__tests__/security/stripe-connect-error-leak.test.ts
+++ b/src/__tests__/security/stripe-connect-error-leak.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #148: Stripe Connect error exposes internal details
+ *
+ * The catch block in create-account/route.ts was returning `detail: message`
+ * which could leak Stripe API error details to the client. Now only a
+ * generic error message is returned; details are logged server-side only.
+ */
+
+describe('Stripe Connect error response — no internal details (issue #148)', () => {
+  const source = readFileSync(
+    resolve('src/app/api/stripe/connect/create-account/route.ts'),
+    'utf-8',
+  );
+
+  it('does not expose error detail in response', () => {
+    // The response JSON should NOT contain a "detail" field
+    expect(source).not.toContain('detail: message');
+    expect(source).not.toContain('detail: err');
+  });
+
+  it('returns a generic error message', () => {
+    expect(source).toContain("'Failed to create Stripe Connect account'");
+  });
+
+  it('logs the actual error server-side', () => {
+    expect(source).toContain("logger.error('[stripe/connect/create-account] error:'");
+  });
+
+  it('does not expose stack traces', () => {
+    expect(source).not.toContain('stack:');
+    expect(source).not.toContain('.stack');
+  });
+
+  it('other Stripe Connect routes also do not leak details', () => {
+    const routes = [
+      'src/app/api/stripe/connect/status/route.ts',
+      'src/app/api/stripe/connect/dashboard-link/route.ts',
+      'src/app/api/stripe/connect/refresh-onboarding/route.ts',
+    ];
+
+    for (const route of routes) {
+      const routeSource = readFileSync(resolve(route), 'utf-8');
+      expect(routeSource).not.toContain('detail: message');
+      expect(routeSource).not.toContain('detail: err');
+    }
+  });
+});

--- a/src/app/api/stripe/connect/create-account/route.ts
+++ b/src/app/api/stripe/connect/create-account/route.ts
@@ -106,7 +106,7 @@ export async function POST(_request: NextRequest) {
     const message = err instanceof Error ? err.message : String(err);
     logger.error('[stripe/connect/create-account] error:', message);
     return NextResponse.json(
-      { error: 'Failed to create Stripe Connect account', detail: message },
+      { error: 'Failed to create Stripe Connect account' },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary
- Removed `detail: message` from error response in `stripe/connect/create-account/route.ts`
- Internal Stripe API error messages are still logged server-side via `logger.error`
- Client only receives generic `"Failed to create Stripe Connect account"`

## Test plan
- [x] 5 unit tests verifying no detail/stack leak in create-account and all other connect routes
- [ ] CI green

Ref #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)