### PR TITLE
fix(ui): add error boundary to dashboard routes

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -15,7 +15,11 @@
     "search": "Search",
     "actions": "Actions",
     "optional": "optional",
-    "required": "required"
+    "required": "required",
+    "errorBoundaryTitle": "Something went wrong",
+    "errorBoundaryDescription": "An unexpected error occurred. Please try again.",
+    "tryAgain": "Try again",
+    "backToDashboard": "Back to dashboard"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -15,7 +15,11 @@
     "search": "Buscar",
     "actions": "Acciones",
     "optional": "opcional",
-    "required": "obligatorio"
+    "required": "obligatorio",
+    "errorBoundaryTitle": "Algo salió mal",
+    "errorBoundaryDescription": "Ocurrió un error inesperado. Inténtalo de nuevo.",
+    "tryAgain": "Intentar de nuevo",
+    "backToDashboard": "Volver al panel"
   },
   "nav": {
     "dashboard": "Panel",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -15,7 +15,11 @@
     "search": "Buscar",
     "actions": "Ações",
     "optional": "opcional",
-    "required": "obrigatório"
+    "required": "obrigatório",
+    "errorBoundaryTitle": "Algo deu errado",
+    "errorBoundaryDescription": "Ocorreu um erro inesperado. Tente novamente.",
+    "tryAgain": "Tentar novamente",
+    "backToDashboard": "Voltar ao painel"
   },
   "nav": {
     "dashboard": "Painel",

--- a/src/__tests__/ui/error-boundaries.test.ts
+++ b/src/__tests__/ui/error-boundaries.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #149: Missing error boundaries (error.tsx) in dashboard routes
+ *
+ * Unhandled errors were crashing the entire page. Now error.tsx files
+ * provide graceful error UI with retry and navigation options.
+ */
+
+describe('Error boundaries in dashboard routes (issue #149)', () => {
+  const dashboardErrorPath = resolve('src/app/[locale]/(dashboard)/error.tsx');
+
+  it('dashboard error.tsx exists', () => {
+    expect(existsSync(dashboardErrorPath)).toBe(true);
+  });
+
+  describe('dashboard error.tsx content', () => {
+    const source = readFileSync(dashboardErrorPath, 'utf-8');
+
+    it('is a client component', () => {
+      expect(source).toContain("'use client'");
+    });
+
+    it('accepts error and reset props', () => {
+      expect(source).toContain('error:');
+      expect(source).toContain('reset:');
+    });
+
+    it('uses useTranslations for i18n', () => {
+      expect(source).toContain("useTranslations('common')");
+    });
+
+    it('has a retry button that calls reset', () => {
+      expect(source).toContain('onClick={reset}');
+    });
+
+    it('has a back to dashboard link', () => {
+      expect(source).toContain('href="/dashboard"');
+    });
+
+    it('logs the error server-side', () => {
+      expect(source).toContain('logger.error');
+    });
+
+    it('does not expose error details to the user', () => {
+      expect(source).not.toContain('error.message');
+      expect(source).not.toContain('error.stack');
+      expect(source).not.toContain('{error.');
+    });
+  });
+
+  describe('locale files have error boundary keys', () => {
+    const locales = ['pt-BR', 'en-US', 'es-ES'];
+    const requiredKeys = ['errorBoundaryTitle', 'errorBoundaryDescription', 'tryAgain', 'backToDashboard'];
+
+    for (const locale of locales) {
+      describe(locale, () => {
+        const messages = JSON.parse(readFileSync(resolve(`messages/${locale}.json`), 'utf-8'));
+
+        for (const key of requiredKeys) {
+          it(`has common.${key}`, () => {
+            expect(messages.common[key]).toBeDefined();
+            expect(messages.common[key].length).toBeGreaterThan(0);
+          });
+        }
+      });
+    }
+  });
+});

--- a/src/app/[locale]/(dashboard)/error.tsx
+++ b/src/app/[locale]/(dashboard)/error.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+import { AlertTriangle } from 'lucide-react';
+import { logger } from '@/lib/logger';
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations('common');
+
+  useEffect(() => {
+    logger.error('[DashboardError]', error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center p-6">
+      <div className="text-center max-w-md">
+        <AlertTriangle className="w-12 h-12 text-amber-500 mx-auto mb-4" />
+        <h2 className="text-xl font-semibold mb-2">{t('errorBoundaryTitle')}</h2>
+        <p className="text-gray-600 mb-6">{t('errorBoundaryDescription')}</p>
+        <div className="flex gap-3 justify-center">
+          <button
+            onClick={reset}
+            className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors text-sm font-medium"
+          >
+            {t('tryAgain')}
+          </button>
+          <a
+            href="/dashboard"
+            className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium"
+          >
+            {t('backToDashboard')}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Added `error.tsx` at the dashboard layout level (`src/app/[locale]/(dashboard)/error.tsx`)
- Catches unhandled errors gracefully instead of crashing the entire page
- Shows retry button (calls `reset()`) and back-to-dashboard link
- Logs error server-side, does not expose details to user
- i18n: 4 new keys in all 3 locales (pt-BR, en-US, es-ES)

## Test plan
- [x] 20 unit tests verifying error boundary exists, is client component, has retry/nav, i18n keys
- [ ] CI green

Ref #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)