### PR TITLE
fix(security): add timestamp validation to Stripe webhook

### DIFF
--- a/src/__tests__/security/webhook-timestamp-validation.test.ts
+++ b/src/__tests__/security/webhook-timestamp-validation.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #150: Webhook Stripe without timestamp validation (replay attack)
+ *
+ * The webhook handler did not verify event.created, allowing replay attacks
+ * with old events. Now rejects events older than 5 minutes.
+ */
+
+describe('Stripe webhook timestamp validation (issue #150)', () => {
+  const source = readFileSync(
+    resolve('src/app/api/webhooks/stripe-deposit/route.ts'),
+    'utf-8',
+  );
+
+  it('checks event.created timestamp', () => {
+    expect(source).toContain('event.created');
+  });
+
+  it('defines a max age constant', () => {
+    expect(source).toContain('EVENT_MAX_AGE_SECONDS');
+  });
+
+  it('max age is 300 seconds (5 minutes)', () => {
+    expect(source).toContain('EVENT_MAX_AGE_SECONDS = 300');
+  });
+
+  it('calculates event age from current time', () => {
+    expect(source).toContain('Date.now()');
+    expect(source).toContain('event.created');
+  });
+
+  it('rejects stale events with 400 status', () => {
+    // Find the stale event check section
+    const staleIdx = source.indexOf('Event too old');
+    expect(staleIdx).toBeGreaterThan(-1);
+    // Should return 400
+    const surroundingCode = source.slice(Math.max(0, staleIdx - 100), staleIdx + 100);
+    expect(surroundingCode).toContain('400');
+  });
+
+  it('logs rejected stale events', () => {
+    expect(source).toContain('rejected stale event');
+  });
+
+  it('timestamp check happens before event processing (switch)', () => {
+    const timestampIdx = source.indexOf('EVENT_MAX_AGE_SECONDS');
+    const switchIdx = source.indexOf('switch (event.type)');
+    expect(timestampIdx).toBeGreaterThan(-1);
+    expect(switchIdx).toBeGreaterThan(-1);
+    expect(timestampIdx).toBeLessThan(switchIdx);
+  });
+
+  it('timestamp check happens after dedup check', () => {
+    const dedupIdx = source.indexOf('isEventProcessed');
+    const timestampIdx = source.indexOf('EVENT_MAX_AGE_SECONDS');
+    expect(dedupIdx).toBeGreaterThan(-1);
+    expect(timestampIdx).toBeGreaterThan(-1);
+    expect(dedupIdx).toBeLessThan(timestampIdx);
+  });
+});

--- a/src/app/api/webhooks/stripe-deposit/route.ts
+++ b/src/app/api/webhooks/stripe-deposit/route.ts
@@ -39,6 +39,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ received: true, deduplicated: true });
   }
 
+  // ─── Timestamp validation: reject events older than 5 minutes (replay attack) ─
+  const EVENT_MAX_AGE_SECONDS = 300; // 5 minutes
+  const eventAge = Math.floor(Date.now() / 1000) - event.created;
+  if (eventAge > EVENT_MAX_AGE_SECONDS) {
+    logger.warn('[Webhook] rejected stale event', { id: event.id, age: eventAge });
+    return NextResponse.json({ error: 'Event too old' }, { status: 400 });
+  }
+
   const supabase = createAdminClient();
 
   switch (event.type) {


### PR DESCRIPTION
## Summary
- Added timestamp validation to reject webhook events older than 5 minutes
- Checks `event.created` against current time after dedup, before processing
- Stale events logged with `logger.warn` and rejected with 400
- Prevents replay attacks with old Stripe events

## Test plan
- [x] 8 unit tests verifying timestamp check exists, uses 300s max age, runs in correct order
- [ ] CI green

Ref #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)