### PR TITLE
fix(security): add extension whitelist to gallery upload

### DIFF
--- a/src/__tests__/security/gallery-upload-extension.test.ts
+++ b/src/__tests__/security/gallery-upload-extension.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #151: Gallery upload without extension whitelist
+ *
+ * safeExt() accepted any alphanumeric extension. Now only allows
+ * ['jpg', 'jpeg', 'png', 'webp', 'gif'], falling back to 'bin'.
+ */
+
+describe('Gallery upload extension whitelist (issue #151)', () => {
+  const source = readFileSync(
+    resolve('src/app/api/gallery/upload/route.ts'),
+    'utf-8',
+  );
+
+  it('defines ALLOWED_EXTENSIONS whitelist', () => {
+    expect(source).toContain('ALLOWED_EXTENSIONS');
+  });
+
+  it('whitelist includes jpg, jpeg, png, webp, gif', () => {
+    for (const ext of ['jpg', 'jpeg', 'png', 'webp', 'gif']) {
+      expect(source).toContain(`'${ext}'`);
+    }
+  });
+
+  it('checks extension against whitelist', () => {
+    expect(source).toContain('ALLOWED_EXTENSIONS.has(ext)');
+  });
+
+  it('falls back to bin for unknown extensions', () => {
+    expect(source).toContain("'bin'");
+  });
+
+  it('normalizes extension to lowercase', () => {
+    expect(source).toContain('.toLowerCase()');
+  });
+
+  it('does not accept arbitrary extensions', () => {
+    // The old pattern just stripped non-alphanumeric — should no longer exist alone
+    // New pattern must include whitelist check
+    const safeExtSection = source.slice(
+      source.indexOf('safeExt'),
+      source.indexOf('safeExt') + 300,
+    );
+    expect(safeExtSection).toContain('ALLOWED_EXTENSIONS');
+  });
+});

--- a/src/app/api/gallery/upload/route.ts
+++ b/src/app/api/gallery/upload/route.ts
@@ -95,9 +95,12 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Sanitize file extension to prevent path traversal
-    const safeExt = (name: string) =>
-      (name.split('.').pop() || 'bin').replace(/[^a-zA-Z0-9]/g, '');
+    // Sanitize and whitelist file extension
+    const ALLOWED_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'webp', 'gif']);
+    const safeExt = (name: string) => {
+      const ext = (name.split('.').pop() || '').replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+      return ALLOWED_EXTENSIONS.has(ext) ? ext : 'bin';
+    };
 
     let imageUrl = '';
     let beforeImageUrl = '';


### PR DESCRIPTION
## Summary
- `safeExt()` now validates against whitelist `['jpg', 'jpeg', 'png', 'webp', 'gif']`
- Unknown extensions fall back to `'bin'` instead of being accepted as-is
- Extension normalized to lowercase before checking

## Test plan
- [x] 6 unit tests verifying whitelist, lowercase normalization, fallback
- [ ] CI green

Ref #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)