### PR TITLE
fix(perf): memoize QR code generation in next-steps-card

### DIFF
--- a/src/__tests__/ui/qr-code-memoization.test.ts
+++ b/src/__tests__/ui/qr-code-memoization.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #152: QR code generated without memoization
+ *
+ * QRCode.toDataURL() was called inside the data fetch effect without
+ * dependency tracking. Now it runs in a separate useEffect keyed on
+ * landingUrl, and handleDownloadQR is wrapped in useCallback.
+ */
+
+describe('QR code memoization in next-steps-card (issue #152)', () => {
+  const source = readFileSync(
+    resolve('src/components/dashboard/next-steps-card.tsx'),
+    'utf-8',
+  );
+
+  it('QR code generation is in a separate useEffect with landingUrl dependency', () => {
+    // Should have useEffect with [landingUrl] for QR code
+    expect(source).toContain('[landingUrl]');
+    // The QR generation should be in this effect, not in the fetch effect
+    const qrEffectMatch = source.match(/useEffect\(\(\) => \{[\s\S]*?QRCode\.toDataURL[\s\S]*?\[landingUrl\]/);
+    expect(qrEffectMatch).not.toBeNull();
+  });
+
+  it('QR code is not generated in the data fetch effect', () => {
+    // The fetchData function should NOT contain QRCode.toDataURL
+    const fetchSection = source.slice(
+      source.indexOf('async function fetchData'),
+      source.indexOf('fetchData();'),
+    );
+    expect(fetchSection).not.toContain('QRCode.toDataURL');
+  });
+
+  it('handleDownloadQR is wrapped in useCallback', () => {
+    expect(source).toContain('useCallback');
+    expect(source).toContain('const handleDownloadQR = useCallback');
+  });
+
+  it('useCallback has proper dependencies', () => {
+    // Should depend on qrCodeUrl, businessName, slug
+    const callbackSection = source.slice(
+      source.indexOf('const handleDownloadQR = useCallback'),
+      source.indexOf('const handleDownloadQR = useCallback') + 1500,
+    );
+    expect(callbackSection).toContain('qrCodeUrl');
+    expect(callbackSection).toContain('businessName');
+    expect(callbackSection).toContain('slug');
+  });
+
+  it('QR effect has cleanup to prevent stale updates', () => {
+    expect(source).toContain('cancelled');
+  });
+});

--- a/src/components/dashboard/next-steps-card.tsx
+++ b/src/components/dashboard/next-steps-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -42,8 +42,6 @@ export function NextStepsCard() {
         setLandingUrl(url);
         setSlug(professional.slug);
         setBusinessName(professional.business_name ?? '');
-
-        QRCode.toDataURL(url, { width: 200, margin: 2 }).then(setQrCodeUrl);
       }
 
       if (whatsappConfig?.business_phone) {
@@ -53,13 +51,17 @@ export function NextStepsCard() {
     fetchData();
   }, []);
 
-  function copyToClipboard(text: string, type: 'landing' | 'whatsapp') {
-    navigator.clipboard.writeText(text);
-    setCopied(type);
-    setTimeout(() => setCopied(null), 2000);
-  }
+  // Generate QR code only when landingUrl changes (memoized)
+  useEffect(() => {
+    if (!landingUrl) return;
+    let cancelled = false;
+    QRCode.toDataURL(landingUrl, { width: 200, margin: 2 }).then((url) => {
+      if (!cancelled) setQrCodeUrl(url);
+    });
+    return () => { cancelled = true; };
+  }, [landingUrl]);
 
-  async function handleDownloadQR() {
+  const handleDownloadQR = useCallback(async () => {
     if (!qrCodeUrl) return;
 
     const canvas = document.createElement('canvas');
@@ -91,6 +93,12 @@ export function NextStepsCard() {
       link.click();
     };
     img.src = qrCodeUrl;
+  }, [qrCodeUrl, businessName, slug]);
+
+  function copyToClipboard(text: string, type: 'landing' | 'whatsapp') {
+    navigator.clipboard.writeText(text);
+    setCopied(type);
+    setTimeout(() => setCopied(null), 2000);
   }
 
   return (


### PR DESCRIPTION
## Summary
- Moved `QRCode.toDataURL()` to separate `useEffect` with `[landingUrl]` dependency
- Wrapped `handleDownloadQR` in `useCallback` with proper deps
- Added cleanup flag to prevent stale state updates on unmount

## Test plan
- [x] 5 unit tests verifying memoization patterns
- [ ] CI green

Ref #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)