### PR TITLE
fix(a11y): add beforeLabel/afterLabel props to before-after slider

### DIFF
--- a/src/__tests__/ui/before-after-alt-text.test.ts
+++ b/src/__tests__/ui/before-after-alt-text.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #153: Alt text genérico em before/after slider
+ *
+ * The public before-after-slider had hardcoded alt="Before"/"After".
+ * Now accepts beforeLabel/afterLabel props for descriptive alt text.
+ */
+
+describe('Before/after slider alt text (issue #153)', () => {
+  const source = readFileSync(
+    resolve('src/components/public-page/before-after-slider.tsx'),
+    'utf-8',
+  );
+
+  it('accepts beforeLabel prop', () => {
+    expect(source).toContain('beforeLabel');
+  });
+
+  it('accepts afterLabel prop', () => {
+    expect(source).toContain('afterLabel');
+  });
+
+  it('has default values for labels', () => {
+    expect(source).toContain("beforeLabel = 'Antes'");
+    expect(source).toContain("afterLabel = 'Depois'");
+  });
+
+  it('uses beforeLabel for before image alt text', () => {
+    expect(source).toContain('alt={beforeLabel}');
+  });
+
+  it('uses afterLabel for after image alt text', () => {
+    expect(source).toContain('alt={afterLabel}');
+  });
+
+  it('does not have hardcoded alt="Before" or alt="After"', () => {
+    expect(source).not.toContain('alt="Before"');
+    expect(source).not.toContain('alt="After"');
+  });
+
+  it('does not have hardcoded label text in JSX', () => {
+    // Labels should use the props, not hardcoded strings
+    const lines = source.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed === 'Antes' || trimmed === 'Depois') {
+        expect.fail(`Found hardcoded label "${trimmed}"`);
+      }
+    }
+  });
+
+  it('props are defined in the interface', () => {
+    const interfaceStart = source.indexOf('interface BeforeAfterSliderProps');
+    const interfaceEnd = source.indexOf('}', interfaceStart);
+    const interfaceSection = source.slice(interfaceStart, interfaceEnd + 1);
+    expect(interfaceSection).toContain('beforeLabel');
+    expect(interfaceSection).toContain('afterLabel');
+  });
+});

--- a/src/components/public-page/before-after-slider.tsx
+++ b/src/components/public-page/before-after-slider.tsx
@@ -6,9 +6,11 @@ interface BeforeAfterSliderProps {
   beforeImage: string;
   afterImage: string;
   title?: string;
+  beforeLabel?: string;
+  afterLabel?: string;
 }
 
-export function BeforeAfterSlider({ beforeImage, afterImage, title }: BeforeAfterSliderProps) {
+export function BeforeAfterSlider({ beforeImage, afterImage, title, beforeLabel = 'Antes', afterLabel = 'Depois' }: BeforeAfterSliderProps) {
   const [sliderPosition, setSliderPosition] = useState(50);
   const [isDragging, setIsDragging] = useState(false);
 
@@ -38,7 +40,7 @@ export function BeforeAfterSlider({ beforeImage, afterImage, title }: BeforeAfte
       {/* After Image (Background) */}
       <img
         src={afterImage}
-        alt="After"
+        alt={afterLabel}
         className="absolute inset-0 w-full h-full object-cover"
         draggable={false}
       />
@@ -50,7 +52,7 @@ export function BeforeAfterSlider({ beforeImage, afterImage, title }: BeforeAfte
       >
         <img
           src={beforeImage}
-          alt="Before"
+          alt={beforeLabel}
           className="absolute inset-0 w-full h-full object-cover"
           draggable={false}
         />
@@ -93,10 +95,10 @@ export function BeforeAfterSlider({ beforeImage, afterImage, title }: BeforeAfte
 
       {/* Labels */}
       <div className="absolute top-4 left-4 bg-black/70 text-white px-3 py-1 rounded text-sm font-medium">
-        Antes
+        {beforeLabel}
       </div>
       <div className="absolute top-4 right-4 bg-black/70 text-white px-3 py-1 rounded text-sm font-medium">
-        Depois
+        {afterLabel}
       </div>
 
       {/* Title */}


### PR DESCRIPTION
## Summary
- Added `beforeLabel`/`afterLabel` optional props to public `BeforeAfterSlider`
- Props used for both `alt` text and visible overlay labels
- Defaults to `'Antes'`/`'Depois'` for backward compatibility
- Removes hardcoded `alt="Before"`/`alt="After"`

## Test plan
- [x] 8 unit tests verifying props, alt text, no hardcoded strings
- [ ] CI green

Ref #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)