### PR TITLE
fix(security): standardize admin auth to validateAdminToken

### DIFF
--- a/src/__tests__/security/admin-auth-standardized.test.ts
+++ b/src/__tests__/security/admin-auth-standardized.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { globSync } from 'fs';
+
+/**
+ * Tests for Issue #155: Standardize admin auth (3 different patterns)
+ *
+ * Admin routes used 3 patterns: validateAdminToken, x-admin-secret header,
+ * and ADMIN_EMAIL check. Now all use validateAdminToken except intentional
+ * SETUP_SECRET endpoints (one-time setup scripts).
+ */
+
+// All admin API routes that should use validateAdminToken
+const adminRoutes = [
+  'src/app/api/admin/bot-e2e-toggle/route.ts',
+  'src/app/api/admin/control-center/route.ts',
+  'src/app/api/admin/control-center/[id]/resolve/route.ts',
+  'src/app/api/admin/evolution/check-connection/route.ts',
+  'src/app/api/admin/evolution/create-instance/route.ts',
+  'src/app/api/admin/github/issues/route.ts',
+  'src/app/api/admin/github/project/route.ts',
+  'src/app/api/admin/inbox/route.ts',
+  'src/app/api/admin/leads/[id]/message/route.ts',
+  'src/app/api/admin/leads/[id]/toggle-bot/route.ts',
+  'src/app/api/admin/restore-account/route.ts',
+  'src/app/api/admin/clear-bot-cache/route.ts',
+  'src/app/api/admin/support/tickets/[id]/route.ts',
+  'src/app/api/admin/support/tickets/[id]/reply/route.ts',
+];
+
+// Setup endpoints intentionally use SETUP_SECRET (not validateAdminToken)
+const setupRoutes = [
+  'src/app/api/admin/setup-storage/route.ts',
+  'src/app/api/admin/encrypt-existing-tokens/route.ts',
+  'src/app/api/admin/fix-triggers/route.ts',
+];
+
+describe('Admin auth standardized to validateAdminToken (issue #155)', () => {
+  for (const route of adminRoutes) {
+    describe(route.split('api/admin/')[1], () => {
+      const source = readFileSync(resolve(route), 'utf-8');
+
+      it('uses validateAdminToken', () => {
+        expect(source).toContain('validateAdminToken');
+      });
+
+      it('does NOT use x-admin-secret header pattern', () => {
+        expect(source).not.toContain('x-admin-secret');
+      });
+
+      it('does NOT use ADMIN_EMAIL comparison', () => {
+        expect(source).not.toContain('ADMIN_EMAIL');
+        expect(source).not.toContain('user.email !== adminEmail');
+      });
+    });
+  }
+
+  describe('previously migrated routes', () => {
+    it('clear-bot-cache no longer uses CRON_SECRET', () => {
+      const source = readFileSync(resolve('src/app/api/admin/clear-bot-cache/route.ts'), 'utf-8');
+      expect(source).not.toContain('CRON_SECRET');
+      expect(source).toContain('validateAdminToken');
+    });
+
+    it('support/tickets/[id] no longer uses ADMIN_EMAIL', () => {
+      const source = readFileSync(resolve('src/app/api/admin/support/tickets/[id]/route.ts'), 'utf-8');
+      expect(source).not.toContain('ADMIN_EMAIL');
+      expect(source).toContain('validateAdminToken');
+    });
+
+    it('support/tickets/[id]/reply no longer uses ADMIN_EMAIL', () => {
+      const source = readFileSync(resolve('src/app/api/admin/support/tickets/[id]/reply/route.ts'), 'utf-8');
+      expect(source).not.toContain('ADMIN_EMAIL');
+      expect(source).toContain('validateAdminToken');
+    });
+  });
+
+  describe('setup routes intentionally use SETUP_SECRET (exempt)', () => {
+    for (const route of setupRoutes) {
+      it(`${route.split('api/admin/')[1]} uses SETUP_SECRET`, () => {
+        const source = readFileSync(resolve(route), 'utf-8');
+        expect(source).toContain('SETUP_SECRET');
+      });
+    }
+  });
+});

--- a/src/app/api/admin/clear-bot-cache/route.ts
+++ b/src/app/api/admin/clear-bot-cache/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { validateAdminToken } from '@/lib/admin/session';
 import { clearMemoryCache } from '@/lib/ai/chatbot';
 import { ConversationCache } from '@/lib/redis/conversation-cache';
 
 export async function POST(req: NextRequest) {
-  const secret = req.headers.get('x-admin-secret');
-  if (secret !== process.env.CRON_SECRET) {
+  const cookieStore = await cookies();
+  if (!(await validateAdminToken(cookieStore.get('admin_session')?.value))) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/admin/support/tickets/[id]/reply/route.ts
+++ b/src/app/api/admin/support/tickets/[id]/reply/route.ts
@@ -1,6 +1,7 @@
 import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { cookies } from 'next/headers';
+import { validateAdminToken } from '@/lib/admin/session';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { sendTicketReplyEmail } from '@/lib/resend';
 
@@ -11,13 +12,9 @@ export async function POST(
   const { id } = await params;
 
   // Verify admin
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  const adminEmail = process.env.ADMIN_EMAIL;
-  if (!user || !adminEmail || user.email !== adminEmail) {
-    return NextResponse.json({ error: 'Não autorizado' }, { status: 403 });
+  const cookieStore = await cookies();
+  if (!(await validateAdminToken(cookieStore.get('admin_session')?.value))) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const { message, newStatus } = await request.json();

--- a/src/app/api/admin/support/tickets/[id]/route.ts
+++ b/src/app/api/admin/support/tickets/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { cookies } from 'next/headers';
+import { validateAdminToken } from '@/lib/admin/session';
 import { createAdminClient } from '@/lib/supabase/admin';
 
 // PATCH — admin updates ticket status
@@ -9,13 +10,9 @@ export async function PATCH(
 ) {
   const { id } = await params;
 
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  const adminEmail = process.env.ADMIN_EMAIL;
-  if (!user || !adminEmail || user.email !== adminEmail) {
-    return NextResponse.json({ error: 'Não autorizado' }, { status: 403 });
+  const cookieStore = await cookies();
+  if (!(await validateAdminToken(cookieStore.get('admin_session')?.value))) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const { status, priority } = await request.json();


### PR DESCRIPTION
## Summary
- Migrated 3 admin routes from non-standard auth patterns to `validateAdminToken`:
  - `clear-bot-cache`: was using `x-admin-secret` header with CRON_SECRET
  - `support/tickets/[id]`: was using ADMIN_EMAIL email comparison
  - `support/tickets/[id]/reply`: was using ADMIN_EMAIL email comparison
- All 14 admin API routes now use the same `validateAdminToken` pattern
- SETUP_SECRET endpoints (3) intentionally kept separate (one-time setup scripts)

## Test plan
- [x] 48 unit tests verifying all admin routes use validateAdminToken, none use old patterns
- [ ] CI green

Ref #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)