### PR TITLE
feat(ui): add Suspense fallbacks with skeletons (#156)

### DIFF
--- a/src/__tests__/ui/suspense-fallbacks.test.ts
+++ b/src/__tests__/ui/suspense-fallbacks.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #156: Suspense fallbacks with skeletons
+ *
+ * Dashboard pages load async data. Without loading.tsx / Suspense,
+ * users see a blank page. Now we have a Skeleton component and
+ * a loading.tsx at the dashboard layout level.
+ */
+
+describe('Skeleton UI component (issue #156)', () => {
+  const skeletonPath = 'src/components/ui/skeleton.tsx';
+
+  it('skeleton component exists', () => {
+    expect(existsSync(resolve(skeletonPath))).toBe(true);
+  });
+
+  it('exports Skeleton component', () => {
+    const source = readFileSync(resolve(skeletonPath), 'utf-8');
+    expect(source).toContain('export { Skeleton }');
+  });
+
+  it('uses animate-pulse for loading animation', () => {
+    const source = readFileSync(resolve(skeletonPath), 'utf-8');
+    expect(source).toContain('animate-pulse');
+  });
+
+  it('uses cn utility for className merging', () => {
+    const source = readFileSync(resolve(skeletonPath), 'utf-8');
+    expect(source).toContain("from '@/lib/utils'");
+    expect(source).toContain('cn(');
+  });
+
+  it('accepts className and HTML div props', () => {
+    const source = readFileSync(resolve(skeletonPath), 'utf-8');
+    expect(source).toContain('className');
+    expect(source).toContain('...props');
+  });
+});
+
+describe('Dashboard loading.tsx (issue #156)', () => {
+  const loadingPath = 'src/app/[locale]/(dashboard)/loading.tsx';
+
+  it('loading.tsx exists at dashboard layout level', () => {
+    expect(existsSync(resolve(loadingPath))).toBe(true);
+  });
+
+  it('imports Skeleton component', () => {
+    const source = readFileSync(resolve(loadingPath), 'utf-8');
+    expect(source).toContain("from '@/components/ui/skeleton'");
+  });
+
+  it('exports default function', () => {
+    const source = readFileSync(resolve(loadingPath), 'utf-8');
+    expect(source).toContain('export default function');
+  });
+
+  it('renders KPI card skeletons', () => {
+    const source = readFileSync(resolve(loadingPath), 'utf-8');
+    // Should have multiple skeleton placeholders for KPI cards
+    const skeletonCount = (source.match(/<Skeleton/g) || []).length;
+    expect(skeletonCount).toBeGreaterThanOrEqual(4);
+  });
+
+  it('renders content area skeletons', () => {
+    const source = readFileSync(resolve(loadingPath), 'utf-8');
+    // Should have list-item-like skeletons (rounded-full for avatars)
+    expect(source).toContain('rounded-full');
+  });
+
+  it('uses responsive grid layout', () => {
+    const source = readFileSync(resolve(loadingPath), 'utf-8');
+    expect(source).toContain('grid-cols-1');
+    expect(source).toContain('md:grid-cols-2');
+  });
+
+  it('is NOT a client component (no use client directive)', () => {
+    const source = readFileSync(resolve(loadingPath), 'utf-8');
+    expect(source).not.toContain("'use client'");
+  });
+});
+
+describe('No other loading.tsx files missing', () => {
+  it('dashboard layout level loading.tsx covers all sub-routes', () => {
+    // The (dashboard) layout loading.tsx acts as fallback for all
+    // nested routes. This is the recommended Next.js pattern.
+    const source = readFileSync(resolve('src/app/[locale]/(dashboard)/loading.tsx'), 'utf-8');
+    expect(source).toContain('Skeleton');
+  });
+});

--- a/src/app/[locale]/(dashboard)/loading.tsx
+++ b/src/app/[locale]/(dashboard)/loading.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-6 p-6">
+      {/* Page title */}
+      <Skeleton className="h-8 w-48" />
+
+      {/* KPI cards row */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-lg border bg-white p-6 space-y-3">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-8 w-16" />
+            <Skeleton className="h-3 w-32" />
+          </div>
+        ))}
+      </div>
+
+      {/* Content area */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="rounded-lg border bg-white p-6 space-y-4">
+          <Skeleton className="h-5 w-36" />
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3">
+              <Skeleton className="h-10 w-10 rounded-full" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="rounded-lg border bg-white p-6 space-y-4">
+          <Skeleton className="h-5 w-36" />
+          <Skeleton className="h-40 w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from '@/lib/utils';
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('animate-pulse rounded-md bg-gray-200', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };


### PR DESCRIPTION
## Summary
- Add `Skeleton` UI component (`animate-pulse` pattern, shadcn-compatible)
- Add `loading.tsx` at `(dashboard)/` layout level — all dashboard pages now show skeleton placeholders during server-side loading instead of blank screens
- 13 tests covering component structure and loading.tsx correctness

## Test plan
- [x] `npx vitest run src/__tests__/ui/suspense-fallbacks.test.ts` — 13/13 pass
- [x] `npm run test:fast` — 81/82 pass (1 pre-existing failure in email/unsubscribe)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)