### PR TITLE
fix(api): add try/catch to 14 API routes (#207)

### DIFF
--- a/src/__tests__/reliability/api-try-catch.test.ts
+++ b/src/__tests__/reliability/api-try-catch.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #207: All API routes must have top-level try/catch
+ * to return structured JSON 500 errors instead of unhandled rejections.
+ */
+
+const routesRequiringTryCatch = [
+  'src/app/api/admin/clear-bot-cache/route.ts',
+  'src/app/api/admin/fix-triggers/route.ts',
+  'src/app/api/admin/leads/[id]/toggle-bot/route.ts',
+  'src/app/api/admin/setup-storage/route.ts',
+  'src/app/api/notifications/retry/route.ts',
+  'src/app/api/stripe/checkout/route.ts',
+  'src/app/api/stripe/connect/dashboard-link/route.ts',
+  'src/app/api/stripe/connect/refresh-onboarding/route.ts',
+  'src/app/api/stripe/connect/status/route.ts',
+  'src/app/api/stripe/portal/route.ts',
+  'src/app/api/support/tickets/[id]/replies/route.ts',
+  'src/app/api/email/unsubscribe/route.ts',
+  'src/app/api/auth/signout/route.ts',
+  'src/app/api/integrations/instagram/connect/route.ts',
+];
+
+describe('API routes have try/catch error handling (issue #207)', () => {
+  for (const route of routesRequiringTryCatch) {
+    const shortName = route.split('api/')[1];
+
+    describe(shortName, () => {
+      const source = readFileSync(resolve(route), 'utf-8');
+
+      it('has try/catch block', () => {
+        expect(source).toContain('try {');
+        expect(source).toContain('} catch');
+      });
+
+      it('imports logger', () => {
+        expect(source).toContain("from '@/lib/logger'");
+      });
+
+      it('logs errors with logger.error', () => {
+        expect(source).toContain('logger.error');
+      });
+
+      it('returns structured error response on catch', () => {
+        // Should return JSON 500 or a redirect (signout special case)
+        const hasJson500 = source.includes("{ status: 500 }");
+        const hasRedirectFallback = source.includes('NextResponse.redirect');
+        expect(hasJson500 || hasRedirectFallback).toBe(true);
+      });
+    });
+  }
+});

--- a/src/app/api/admin/clear-bot-cache/route.ts
+++ b/src/app/api/admin/clear-bot-cache/route.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { validateAdminToken } from '@/lib/admin/session';
@@ -5,23 +6,28 @@ import { clearMemoryCache } from '@/lib/ai/chatbot';
 import { ConversationCache } from '@/lib/redis/conversation-cache';
 
 export async function POST(req: NextRequest) {
-  const cookieStore = await cookies();
-  if (!(await validateAdminToken(cookieStore.get('admin_session')?.value))) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  try {
+    const cookieStore = await cookies();
+    if (!(await validateAdminToken(cookieStore.get('admin_session')?.value))) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { business_id, phone } = await req.json();
+    if (!business_id || !phone) {
+      return NextResponse.json({ error: 'business_id and phone required' }, { status: 400 });
+    }
+
+    const cacheKey = `${business_id}_${phone}`;
+
+    // Limpar Redis (Tier 1)
+    await ConversationCache.clear(cacheKey);
+
+    // Limpar in-memory (Tier 3)
+    const cleared = clearMemoryCache(cacheKey);
+
+    return NextResponse.json({ ok: true, cacheKey, memoryCleared: cleared });
+  } catch (err) {
+    logger.error('[admin/clear-bot-cache]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
-
-  const { business_id, phone } = await req.json();
-  if (!business_id || !phone) {
-    return NextResponse.json({ error: 'business_id and phone required' }, { status: 400 });
-  }
-
-  const cacheKey = `${business_id}_${phone}`;
-
-  // Limpar Redis (Tier 1)
-  await ConversationCache.clear(cacheKey);
-
-  // Limpar in-memory (Tier 3)
-  const cleared = clearMemoryCache(cacheKey);
-
-  return NextResponse.json({ ok: true, cacheKey, memoryCleared: cleared });
 }

--- a/src/app/api/admin/fix-triggers/route.ts
+++ b/src/app/api/admin/fix-triggers/route.ts
@@ -1,8 +1,10 @@
+import { logger } from '@/lib/logger';
 import { NextResponse } from 'next/server';
 
 // Rota temporária: aplica fix do trigger via pg directo
 // Usa a variável de ambiente DATABASE_URL se disponível, senão usa supabase admin
 export async function POST(request: Request) {
+  try {
   const { secret } = await request.json().catch(() => ({ secret: null }));
   if (!process.env.SETUP_SECRET || secret !== process.env.SETUP_SECRET) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -116,4 +118,8 @@ $$ LANGUAGE plpgsql;
     ],
     mgmt_response: mgmtError.substring(0, 200),
   }, { status: 503 });
+  } catch (err) {
+    logger.error('[admin/fix-triggers]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/src/app/api/admin/leads/[id]/toggle-bot/route.ts
+++ b/src/app/api/admin/leads/[id]/toggle-bot/route.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createAdminClient } from '@/lib/supabase/admin';
@@ -7,6 +8,7 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  try {
   const cookieStore = await cookies();
   if (!(await validateAdminToken(cookieStore.get('admin_session')?.value))) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -40,4 +42,8 @@ export async function POST(
     .eq('id', conversationId);
 
   return NextResponse.json({ success: true, botActive });
+  } catch (err) {
+    logger.error('[admin/leads/toggle-bot]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/src/app/api/admin/setup-storage/route.ts
+++ b/src/app/api/admin/setup-storage/route.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 
@@ -6,6 +7,7 @@ import { createClient } from '@supabase/supabase-js';
 // Call: POST /api/admin/setup-storage  { "secret": "<SETUP_SECRET>" }
 
 export async function POST(request: Request) {
+  try {
   const { secret } = await request.json();
 
   if (secret !== process.env.SETUP_SECRET) {
@@ -38,4 +40,8 @@ export async function POST(request: Request) {
   results['buckets_in_db'] = bucketNames.join(', ') || '(none)';
 
   return NextResponse.json({ ok: true, results });
+  } catch (err) {
+    logger.error('[admin/setup-storage]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -1,20 +1,27 @@
+import { logger } from '@/lib/logger';
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { cookies } from 'next/headers';
 
 export async function POST(request: Request) {
-  const supabase = await createClient();
-  await supabase.auth.signOut();
+  try {
+    const supabase = await createClient();
+    await supabase.auth.signOut();
 
-  // Clear all cookies
-  const cookieStore = await cookies();
-  cookieStore.getAll().forEach(cookie => {
-    cookieStore.delete(cookie.name);
-  });
+    // Clear all cookies
+    const cookieStore = await cookies();
+    cookieStore.getAll().forEach(cookie => {
+      cookieStore.delete(cookie.name);
+    });
 
-  const url = new URL('/login', request.url);
-  // Use 303 to force GET method on redirect (prevents 405 on /login)
-  return NextResponse.redirect(url, 303);
+    const url = new URL('/login', request.url);
+    // Use 303 to force GET method on redirect (prevents 405 on /login)
+    return NextResponse.redirect(url, 303);
+  } catch (err) {
+    logger.error('[auth/signout]', err);
+    const url = new URL('/login', request.url);
+    return NextResponse.redirect(url, 303);
+  }
 }
 
 export async function GET(request: Request) {

--- a/src/app/api/email/unsubscribe/route.ts
+++ b/src/app/api/email/unsubscribe/route.ts
@@ -1,0 +1,123 @@
+import { logger } from '@/lib/logger';
+import { NextRequest, NextResponse } from 'next/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+
+const TOKEN_REGEX = /^[a-f0-9]{64}$/;
+
+function htmlResponse(status: number, body: string): NextResponse {
+  return new NextResponse(body, {
+    status,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  });
+}
+
+async function processUnsubscribe(token: string) {
+  const supabase = createAdminClient();
+
+  const { data: professional, error } = await supabase
+    .from('professionals')
+    .select('id, business_name, marketing_emails_opted_out')
+    .eq('unsubscribe_token', token)
+    .maybeSingle();
+
+  if (error || !professional) {
+    return { success: false as const };
+  }
+
+  if (!professional.marketing_emails_opted_out) {
+    await supabase
+      .from('professionals')
+      .update({
+        marketing_emails_opted_out: true,
+        marketing_opted_out_at: new Date().toISOString(),
+      })
+      .eq('id', professional.id);
+  }
+
+  return { success: true as const, businessName: professional.business_name };
+}
+
+/**
+ * GET /api/email/unsubscribe?token=<64-char-hex>
+ * Renders an HTML confirmation page and marks the professional as opted-out.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const token = new URL(request.url).searchParams.get('token') ?? '';
+
+    if (!TOKEN_REGEX.test(token)) {
+      return htmlResponse(
+        400,
+        page('Token inválido', '<p>O link de cancelamento é inválido ou expirou.</p>')
+      );
+    }
+
+    const result = await processUnsubscribe(token);
+
+    if (!result.success) {
+      return htmlResponse(
+        400,
+        page('Token inválido', '<p>O link de cancelamento é inválido ou expirou.</p>')
+      );
+    }
+
+    return htmlResponse(
+      200,
+      page(
+        'Inscrição cancelada',
+        `<p>Pronto! Você não receberá mais emails de marketing do CircleHood Booking.</p>
+         <p style="color:#666;font-size:14px;">Emails transacionais (confirmações de agendamento, conta, etc.) continuarão sendo enviados normalmente.</p>`
+      )
+    );
+  } catch (err) {
+    logger.error('[email/unsubscribe] GET', err);
+    return htmlResponse(500, page('Erro', '<p>Ocorreu um erro ao processar sua solicitação.</p>'));
+  }
+}
+
+/**
+ * POST /api/email/unsubscribe?token=<64-char-hex>
+ * RFC 8058 one-click unsubscribe (used by email clients).
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const token = new URL(request.url).searchParams.get('token') ?? '';
+
+    if (!TOKEN_REGEX.test(token)) {
+      return NextResponse.json({ error: 'Invalid token' }, { status: 400 });
+    }
+
+    const result = await processUnsubscribe(token);
+
+    if (!result.success) {
+      return NextResponse.json({ error: 'Invalid token' }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    logger.error('[email/unsubscribe] POST', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+function page(title: string, content: string): string {
+  return `<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${title} — CircleHood Booking</title>
+  <style>
+    body { font-family: sans-serif; max-width: 480px; margin: 60px auto; padding: 0 16px; color: #111; }
+    h1 { font-size: 1.5em; }
+    p { line-height: 1.6; }
+    .footer { margin-top: 40px; font-size: 0.8em; color: #888; }
+  </style>
+</head>
+<body>
+  <h1>${title}</h1>
+  ${content}
+  <p class="footer">CircleHood Tech — Dublin, Ireland</p>
+</body>
+</html>`;
+}

--- a/src/app/api/integrations/instagram/connect/route.ts
+++ b/src/app/api/integrations/instagram/connect/route.ts
@@ -1,8 +1,10 @@
+import { logger } from '@/lib/logger'
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getAuthorizationUrl } from '@/lib/integrations/instagram'
 
 export async function GET(request: NextRequest) {
+  try {
   const supabase = await createClient()
 
   const { data: { user } } = await supabase.auth.getUser()
@@ -26,4 +28,8 @@ export async function GET(request: NextRequest) {
   const authUrl = getAuthorizationUrl(config)
 
   return NextResponse.redirect(authUrl)
+  } catch (err) {
+    logger.error('[integrations/instagram/connect]', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
 }

--- a/src/app/api/notifications/retry/route.ts
+++ b/src/app/api/notifications/retry/route.ts
@@ -1,9 +1,11 @@
+import { logger } from '@/lib/logger';
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { sendBookingConfirmationEmail } from '@/lib/resend';
 
 export async function POST(request: Request) {
+  try {
   // Auth: profissional autenticado
   const supabase = await createClient();
   const {
@@ -95,4 +97,8 @@ export async function POST(request: Request) {
   });
 
   return NextResponse.json({ success: true, message: 'Reenvio iniciado' });
+  } catch (err) {
+    logger.error('[notifications/retry]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -1,9 +1,11 @@
+import { logger } from '@/lib/logger';
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { getStripe } from '@/lib/stripe';
 import { getPlanPrice } from '@/lib/pricing';
 
 export async function POST() {
+  try {
   const supabase = await createClient();
   const {
     data: { user },
@@ -62,4 +64,8 @@ export async function POST() {
   });
 
   return NextResponse.json({ url: session.url });
+  } catch (err) {
+    logger.error('[stripe/checkout]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/src/app/api/stripe/connect/dashboard-link/route.ts
+++ b/src/app/api/stripe/connect/dashboard-link/route.ts
@@ -1,8 +1,10 @@
+import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { getStripeServer } from '@/lib/stripe/server';
 
 export async function POST(_request: NextRequest) {
+  try {
   const supabase = await createClient();
   const {
     data: { user },
@@ -32,4 +34,8 @@ export async function POST(_request: NextRequest) {
   );
 
   return NextResponse.json({ url: loginLink.url });
+  } catch (err) {
+    logger.error('[stripe/connect/dashboard-link]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/src/app/api/stripe/connect/refresh-onboarding/route.ts
+++ b/src/app/api/stripe/connect/refresh-onboarding/route.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { getStripeServer } from '@/lib/stripe/server';
@@ -5,6 +6,7 @@ import { getStripeServer } from '@/lib/stripe/server';
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://booking.circlehood-tech.com';
 
 export async function POST(_request: NextRequest) {
+  try {
   const supabase = await createClient();
   const {
     data: { user },
@@ -37,4 +39,8 @@ export async function POST(_request: NextRequest) {
   });
 
   return NextResponse.json({ url: accountLink.url });
+  } catch (err) {
+    logger.error('[stripe/connect/refresh-onboarding]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/src/app/api/stripe/connect/status/route.ts
+++ b/src/app/api/stripe/connect/status/route.ts
@@ -1,7 +1,9 @@
+import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 
 export async function GET(_request: NextRequest) {
+  try {
   const supabase = await createClient();
   const {
     data: { user },
@@ -38,4 +40,8 @@ export async function GET(_request: NextRequest) {
     payouts_enabled: connectAccount.payouts_enabled,
     onboarding_complete: connectAccount.onboarding_complete,
   });
+  } catch (err) {
+    logger.error('[stripe/connect/status]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/src/app/api/stripe/portal/route.ts
+++ b/src/app/api/stripe/portal/route.ts
@@ -1,8 +1,10 @@
+import { logger } from '@/lib/logger';
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { getStripe } from '@/lib/stripe';
 
 export async function POST() {
+  try {
   const supabase = await createClient();
   const {
     data: { user },
@@ -34,4 +36,8 @@ export async function POST() {
   });
 
   return NextResponse.json({ url: session.url });
+  } catch (err) {
+    logger.error('[stripe/portal]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/src/app/api/support/tickets/[id]/replies/route.ts
+++ b/src/app/api/support/tickets/[id]/replies/route.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 
@@ -5,6 +6,7 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  try {
   const { id } = await params;
 
   const supabase = await createClient();
@@ -29,4 +31,8 @@ export async function GET(
     .order('created_at', { ascending: true });
 
   return NextResponse.json({ replies: replies ?? [] });
+  } catch (err) {
+    logger.error('[support/tickets/replies]', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }


### PR DESCRIPTION
## Summary
- Add top-level try/catch to 14 API routes that previously returned unformatted 500 errors on unhandled exceptions
- Each catch block: logs via `logger.error` + returns structured `{ error: 'Internal server error' }` JSON with status 500
- Special case: `auth/signout` catch redirects to `/login` (consistent with its normal behavior)
- 56 tests verifying try/catch, logger import, and structured error response for all 14 routes

## Routes fixed
admin/clear-bot-cache, admin/fix-triggers, admin/leads/toggle-bot, admin/setup-storage, notifications/retry, stripe/checkout, stripe/portal, stripe/connect/dashboard-link, stripe/connect/refresh-onboarding, stripe/connect/status, support/tickets/replies, email/unsubscribe, auth/signout, integrations/instagram/connect

## Test plan
- [x] `npx vitest run src/__tests__/reliability/api-try-catch.test.ts` — 56/56 pass
- [x] `npm run test:fast` — 83/84 pass (1 pre-existing)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)