### PR TITLE
fix(security): remove hardcoded secrets from admin handbook

### DIFF
--- a/src/__tests__/security/no-hardcoded-secrets.test.ts
+++ b/src/__tests__/security/no-hardcoded-secrets.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const HANDBOOK_DIR = path.resolve(
+  __dirname,
+  '../../app/[locale]/(admin)/admin/handbook',
+);
+
+const FIX_TRIGGERS_PATH = path.resolve(
+  __dirname,
+  '../../app/api/admin/fix-triggers/route.ts',
+);
+
+/** Patterns that must NEVER appear in source code */
+const FORBIDDEN_PATTERNS = [
+  { pattern: /ibkkxykcrwhncvqxzynt/, label: 'Supabase project ref' },
+  {
+    pattern: /redis-15673\.c226\.eu-west-1-3\.ec2\.cloud\.redislabs\.com/,
+    label: 'Redis hostname',
+  },
+  { pattern: /re_iebgvquj/, label: 'Resend API key prefix' },
+];
+
+function readFileContent(filePath: string): string {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function getHandbookFiles(): string[] {
+  const files: string[] = [];
+  function walk(dir: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.tsx') || entry.name.endsWith('.ts'))
+        files.push(full);
+    }
+  }
+  walk(HANDBOOK_DIR);
+  return files;
+}
+
+describe('No hardcoded secrets in admin handbook', () => {
+  const handbookFiles = getHandbookFiles();
+
+  for (const file of handbookFiles) {
+    const relPath = path.relative(process.cwd(), file);
+    const content = readFileContent(file);
+
+    for (const { pattern, label } of FORBIDDEN_PATTERNS) {
+      it(`${relPath} must not contain ${label}`, () => {
+        expect(content).not.toMatch(pattern);
+      });
+    }
+  }
+});
+
+describe('No hardcoded secrets in fix-triggers route', () => {
+  const content = readFileContent(FIX_TRIGGERS_PATH);
+
+  for (const { pattern, label } of FORBIDDEN_PATTERNS) {
+    it(`fix-triggers/route.ts must not contain ${label}`, () => {
+      expect(content).not.toMatch(pattern);
+    });
+  }
+
+  it('should derive projectRef from NEXT_PUBLIC_SUPABASE_URL env var', () => {
+    expect(content).toContain('process.env.NEXT_PUBLIC_SUPABASE_URL');
+  });
+});

--- a/src/app/[locale]/(admin)/admin/handbook/diagrama/page.tsx
+++ b/src/app/[locale]/(admin)/admin/handbook/diagrama/page.tsx
@@ -200,7 +200,7 @@ export default function HandbookDiagramaPage() {
                 'Auth — email + Google OAuth',
                 'Storage — avatars + covers',
                 '~30 tabelas (professionals, bookings…)',
-                'ibkkxykcrwhncvqxzynt.supabase.co',
+                '${NEXT_PUBLIC_SUPABASE_URL}',
               ]}
               borderColor="border-emerald-300 dark:border-emerald-700"
               bgColor="bg-emerald-50 dark:bg-emerald-950/30"
@@ -212,7 +212,7 @@ export default function HandbookDiagramaPage() {
                 'Cache de histórico de conversas',
                 'Deduplicação de mensagens do bot',
                 'TTL: 24h por conversa',
-                'redis-15673.c226.eu-west-1-3',
+                '${REDIS_URL} — ver env var',
               ]}
               borderColor="border-red-300 dark:border-red-700"
               bgColor="bg-red-50 dark:bg-red-950/30"

--- a/src/app/[locale]/(admin)/admin/handbook/infra/page.tsx
+++ b/src/app/[locale]/(admin)/admin/handbook/infra/page.tsx
@@ -32,9 +32,9 @@ const services = [
     color: 'border-emerald-300 dark:border-emerald-800',
     headerBg: 'bg-emerald-50 dark:bg-emerald-950/30',
     items: [
-      { name: 'Supabase DB / Auth',  url: 'https://ibkkxykcrwhncvqxzynt.supabase.co', env: 'prod', note: 'NEXT_PUBLIC_SUPABASE_URL' },
-      { name: 'Supabase Dashboard',  url: 'https://supabase.com/dashboard/project/ibkkxykcrwhncvqxzynt', env: 'admin', note: 'Login com conta Supabase' },
-      { name: 'Supabase Auth users', url: 'https://supabase.com/dashboard/project/ibkkxykcrwhncvqxzynt/auth/users', env: 'admin', note: 'Ver/gerir utilizadores' },
+      { name: 'Supabase DB / Auth',  url: '${NEXT_PUBLIC_SUPABASE_URL}', env: 'prod', note: 'NEXT_PUBLIC_SUPABASE_URL' },
+      { name: 'Supabase Dashboard',  url: 'https://supabase.com/dashboard — ver env NEXT_PUBLIC_SUPABASE_URL para project ref', env: 'admin', note: 'Login com conta Supabase' },
+      { name: 'Supabase Auth users', url: 'https://supabase.com/dashboard → Auth → Users', env: 'admin', note: 'Ver/gerir utilizadores' },
     ],
   },
   {
@@ -42,7 +42,7 @@ const services = [
     color: 'border-red-300 dark:border-red-800',
     headerBg: 'bg-red-50 dark:bg-red-950/30',
     items: [
-      { name: 'Redis (RedisLabs)', url: 'redis://default:***@redis-15673.c226.eu-west-1-3.ec2.cloud.redislabs.com:15673', env: 'prod', note: 'REDIS_URL — conversas do bot' },
+      { name: 'Redis (RedisLabs)', url: '${REDIS_URL} — ver env var', env: 'prod', note: 'REDIS_URL — conversas do bot' },
     ],
   },
   {
@@ -80,7 +80,7 @@ const services = [
     color: 'border-blue-300 dark:border-blue-800',
     headerBg: 'bg-blue-50 dark:bg-blue-950/30',
     items: [
-      { name: 'Resend API',          url: 'https://api.resend.com',                          env: 'prod',    note: 'RESEND_API_KEY (re_iebgvquj_*)' },
+      { name: 'Resend API',          url: 'https://api.resend.com',                          env: 'prod',    note: 'RESEND_API_KEY (re_***)' },
       { name: 'Resend Dashboard',    url: 'https://resend.com/emails',                       env: 'admin',   note: 'Ver logs de email enviados' },
     ],
   },

--- a/src/app/[locale]/(admin)/admin/handbook/troubleshooting/page.tsx
+++ b/src/app/[locale]/(admin)/admin/handbook/troubleshooting/page.tsx
@@ -77,7 +77,7 @@ const troubleshootingData = [
       'Reset de senha via painel Supabase Auth',
     ],
     links: [
-      { label: 'Supabase Auth', url: 'https://supabase.com/dashboard/project/ibkkxykcrwhncvqxzynt/auth/users' },
+      { label: 'Supabase Auth', url: 'https://supabase.com/dashboard → Auth → Users' },
     ],
   },
   {

--- a/src/app/api/admin/fix-triggers/route.ts
+++ b/src/app/api/admin/fix-triggers/route.ts
@@ -12,7 +12,7 @@ export async function POST(request: Request) {
 
   // Tentar via supabase admin client com rpc exec_sql (não funciona sem a função)
   // Usar fetch directo para o endpoint de management API do Supabase
-  const projectRef = 'ibkkxykcrwhncvqxzynt';
+  const projectRef = (process.env.NEXT_PUBLIC_SUPABASE_URL ?? '').match(/https:\/\/([^.]+)\.supabase\.co/)?.[1] ?? '';
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
   const fixSQL = `
@@ -111,7 +111,7 @@ $$ LANGUAGE plpgsql;
     error: `Management API requer PAT (não service_role): ${mgmtRes.status}`,
     fix_sql: fixSQL,
     instructions: [
-      '1. Abrir: https://supabase.com/dashboard/project/ibkkxykcrwhncvqxzynt/sql/new',
+      `1. Abrir: https://supabase.com/dashboard/project/${projectRef}/sql/new`,
       '2. Colar o conteúdo de fix_sql acima',
       '3. Clicar Run',
       '4. Voltar e re-executar o script de teste',


### PR DESCRIPTION
## Summary
- Replace hardcoded Supabase project ref (`ibkkxykcrwhncvqxzynt`) with `${NEXT_PUBLIC_SUPABASE_URL}` reference in 3 handbook pages + fix-triggers route
- Replace hardcoded Redis hostname (`redis-15673.c226.eu-west-1-3.ec2.cloud.redislabs.com:15673`) with `${REDIS_URL}` placeholder
- Mask Resend API key prefix (`re_iebgvquj_*` → `re_***`)
- fix-triggers route now extracts project ref dynamically from env var

## Files changed
- `src/app/[locale]/(admin)/admin/handbook/infra/page.tsx` — 3 secrets removed
- `src/app/[locale]/(admin)/admin/handbook/diagrama/page.tsx` — 2 secrets removed
- `src/app/[locale]/(admin)/admin/handbook/troubleshooting/page.tsx` — 1 secret removed
- `src/app/api/admin/fix-triggers/route.ts` — hardcoded project ref → env var

## Test plan
- [x] 31 tests in `no-hardcoded-secrets.test.ts` verify no forbidden patterns in any handbook file or fix-triggers route
- [x] Verify projectRef derived from `NEXT_PUBLIC_SUPABASE_URL`
- [x] TypeScript check passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)