### PR TITLE
fix(i18n): translate not-found pages and add root 404

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1233,5 +1233,10 @@
     "registerTermsAnd": "and the",
     "registerPrivacyLink": "Privacy Policy",
     "registerTermsRequired": "You must accept the Terms of Use to create an account."
+  },
+  "notFound": {
+    "title": "Page not found",
+    "professionalNotFound": "This professional does not exist or the page has been deactivated.",
+    "backHome": "Back to home"
   }
 }

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -1233,5 +1233,10 @@
     "registerTermsAnd": "y la",
     "registerPrivacyLink": "Política de Privacidad",
     "registerTermsRequired": "Debes aceptar los Términos de Uso para crear una cuenta."
+  },
+  "notFound": {
+    "title": "Página no encontrada",
+    "professionalNotFound": "Este profesional no existe o la página ha sido desactivada.",
+    "backHome": "Volver al inicio"
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1233,5 +1233,10 @@
     "registerTermsAnd": "e a",
     "registerPrivacyLink": "Política de Privacidade",
     "registerTermsRequired": "Você deve aceitar os Termos de Uso para criar uma conta."
+  },
+  "notFound": {
+    "title": "Página não encontrada",
+    "professionalNotFound": "Este profissional não existe ou a página foi desativada.",
+    "backHome": "Voltar ao início"
   }
 }

--- a/src/__tests__/i18n/not-found-i18n.test.ts
+++ b/src/__tests__/i18n/not-found-i18n.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const MESSAGES_DIR = path.resolve(__dirname, '../../../messages');
+const LOCALES = ['pt-BR', 'en-US', 'es-ES'] as const;
+
+function loadMessages(locale: string): Record<string, any> {
+  return JSON.parse(fs.readFileSync(path.join(MESSAGES_DIR, `${locale}.json`), 'utf-8'));
+}
+
+const SLUG_NOT_FOUND = path.resolve(
+  __dirname,
+  '../../app/[locale]/(public)/[slug]/not-found.tsx',
+);
+
+const ROOT_NOT_FOUND = path.resolve(
+  __dirname,
+  '../../app/not-found.tsx',
+);
+
+describe('notFound namespace — all locales', () => {
+  const EXPECTED_KEYS = ['title', 'professionalNotFound', 'backHome'];
+
+  for (const locale of LOCALES) {
+    it(`${locale} has all notFound keys`, () => {
+      const messages = loadMessages(locale);
+      expect(messages.notFound).toBeDefined();
+      for (const key of EXPECTED_KEYS) {
+        expect(messages.notFound[key], `Missing notFound.${key} in ${locale}`).toBeDefined();
+        expect(typeof messages.notFound[key]).toBe('string');
+        expect(messages.notFound[key].length).toBeGreaterThan(0);
+      }
+    });
+  }
+
+  it('all locales have same notFound keys', () => {
+    const ptKeys = Object.keys(loadMessages('pt-BR').notFound).sort();
+    const enKeys = Object.keys(loadMessages('en-US').notFound).sort();
+    const esKeys = Object.keys(loadMessages('es-ES').notFound).sort();
+    expect(enKeys).toEqual(ptKeys);
+    expect(esKeys).toEqual(ptKeys);
+  });
+});
+
+describe('[slug]/not-found.tsx — i18n', () => {
+  const content = fs.readFileSync(SLUG_NOT_FOUND, 'utf-8');
+
+  it('uses useTranslations', () => {
+    expect(content).toContain('useTranslations');
+  });
+
+  it('uses notFound namespace', () => {
+    expect(content).toContain("useTranslations('notFound')");
+  });
+
+  it('does not contain hardcoded PT-BR strings', () => {
+    expect(content).not.toContain('Página não encontrada');
+    expect(content).not.toContain('Este profissional não existe');
+    expect(content).not.toContain('Voltar ao inicio');
+  });
+});
+
+describe('Root not-found.tsx exists', () => {
+  it('file exists at src/app/not-found.tsx', () => {
+    expect(fs.existsSync(ROOT_NOT_FOUND)).toBe(true);
+  });
+
+  it('renders a 404 page', () => {
+    const content = fs.readFileSync(ROOT_NOT_FOUND, 'utf-8');
+    expect(content).toContain('404');
+    expect(content).toContain('Page not found');
+    expect(content).toContain('href="/"');
+  });
+
+  it('is a server component (no use client)', () => {
+    const content = fs.readFileSync(ROOT_NOT_FOUND, 'utf-8');
+    expect(content).not.toContain("'use client'");
+  });
+});

--- a/src/app/[locale]/(public)/[slug]/not-found.tsx
+++ b/src/app/[locale]/(public)/[slug]/not-found.tsx
@@ -1,16 +1,21 @@
+'use client';
+
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 
 export default function NotFound() {
+  const t = useTranslations('notFound');
+
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
       <div className="text-center">
-        <h1 className="text-4xl font-bold mb-2">Página não encontrada</h1>
+        <h1 className="text-4xl font-bold mb-2">{t('title')}</h1>
         <p className="text-muted-foreground mb-6">
-          Este profissional não existe ou a página foi desativada.
+          {t('professionalNotFound')}
         </p>
         <Button asChild>
-          <Link href="/">Voltar ao inicio</Link>
+          <Link href="/">{t('backHome')}</Link>
         </Button>
       </div>
     </div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function RootNotFound() {
+  return (
+    <html lang="en">
+      <body className="min-h-screen flex items-center justify-center px-4 bg-background text-foreground">
+        <div className="text-center">
+          <h1 className="text-6xl font-bold mb-2">404</h1>
+          <p className="text-xl text-muted-foreground mb-6">
+            Page not found
+          </p>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            Back to home
+          </Link>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- `[slug]/not-found.tsx`: replaced hardcoded PT-BR with `useTranslations('notFound')`
- Created `src/app/not-found.tsx` for routes outside the `[locale]` layout (plain 404 page)
- Added `notFound` namespace with 3 keys to all locales (pt-BR, en-US, es-ES)

## Test plan
- [x] 10 tests: namespace completeness, locale parity, no hardcoded strings, root file exists, server component check

🤖 Generated with [Claude Code](https://claude.com/claude-code)