### PR TITLE
fix(payments): improve Stripe connection resilience and error handling

### DIFF
--- a/src/__tests__/security/stripe-connection-resilience.test.ts
+++ b/src/__tests__/security/stripe-connection-resilience.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const STRIPE_SERVER = path.resolve(__dirname, '../../lib/stripe/server.ts');
+const CREATE_INTENT = path.resolve(__dirname, '../../app/api/payment/create-intent/route.ts');
+const CHECKOUT = path.resolve(__dirname, '../../app/api/bookings/checkout/route.ts');
+
+describe('Stripe server — maxNetworkRetries', () => {
+  const content = fs.readFileSync(STRIPE_SERVER, 'utf-8');
+
+  it('configures maxNetworkRetries', () => {
+    expect(content).toContain('maxNetworkRetries');
+  });
+
+  it('sets maxNetworkRetries to at least 3', () => {
+    const match = content.match(/maxNetworkRetries:\s*(\d+)/);
+    expect(match).not.toBeNull();
+    expect(Number(match![1])).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('/api/payment/create-intent — error handling', () => {
+  const content = fs.readFileSync(CREATE_INTENT, 'utf-8');
+
+  it('does NOT expose raw Stripe SDK error messages to user', () => {
+    // Must not return err.message directly
+    expect(content).not.toMatch(/error:\s*message\b/);
+    expect(content).not.toContain('err.message');
+  });
+
+  it('handles StripeConnectionError specifically', () => {
+    expect(content).toContain('StripeConnectionError');
+  });
+
+  it('returns 502 for connection errors', () => {
+    // Check that StripeConnectionError → 502
+    const connectionBlock = content.slice(
+      content.indexOf('StripeConnectionError'),
+      content.indexOf('StripeConnectionError') + 200
+    );
+    expect(connectionBlock).toContain('502');
+  });
+
+  it('returns user-friendly error message for connection failures', () => {
+    expect(content).toContain('Conexão temporariamente indisponível');
+  });
+
+  it('returns generic safe message for other errors', () => {
+    expect(content).toContain('Erro ao processar pagamento. Tente novamente.');
+  });
+
+  it('imports and uses logger', () => {
+    expect(content).toContain("import { logger } from '@/lib/logger'");
+    expect(content).toContain("logger.error('[payment/create-intent]'");
+  });
+});
+
+describe('/api/bookings/checkout — error handling', () => {
+  const content = fs.readFileSync(CHECKOUT, 'utf-8');
+
+  it('imports logger', () => {
+    expect(content).toContain("import { logger } from '@/lib/logger'");
+  });
+
+  it('logs Stripe session creation failures', () => {
+    expect(content).toContain('[bookings/checkout] Stripe session creation failed');
+  });
+
+  it('returns user-friendly error with retry suggestion', () => {
+    expect(content).toContain('Tente novamente');
+  });
+
+  it('rolls back booking on Stripe failure', () => {
+    // After the catch, it should cancel the booking
+    const catchBlock = content.slice(
+      content.indexOf("logger.error('[bookings/checkout]"),
+      content.indexOf("logger.error('[bookings/checkout]") + 300
+    );
+    expect(catchBlock).toContain("status: 'cancelled'");
+  });
+});

--- a/src/app/api/bookings/checkout/route.ts
+++ b/src/app/api/bookings/checkout/route.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { getStripeServer } from '@/lib/stripe/server';
@@ -250,10 +251,11 @@ export async function POST(request: NextRequest) {
       },
       { idempotencyKey }
     );
-  } catch {
+  } catch (err) {
+    logger.error('[bookings/checkout] Stripe session creation failed', err);
     // Rollback: cancelar booking para liberar o slot
     await supabase.from('bookings').update({ status: 'cancelled' }).eq('id', booking.id);
-    return NextResponse.json({ error: 'Falha ao criar sessão de pagamento.' }, { status: 502 });
+    return NextResponse.json({ error: 'Falha ao criar sessão de pagamento. Tente novamente.' }, { status: 502 });
   }
 
   // ─── 12. INSERT payment ──────────────────────────────────────────────────

--- a/src/app/api/payment/create-intent/route.ts
+++ b/src/app/api/payment/create-intent/route.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { getStripeServer } from '@/lib/stripe/server';
@@ -125,7 +126,17 @@ export async function POST(request: NextRequest) {
       currency: professional.currency ?? 'EUR',
     });
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : 'Erro ao criar intenção de pagamento';
-    return NextResponse.json({ error: message }, { status: 500 });
+    logger.error('[payment/create-intent]', err);
+    const isStripeError = err && typeof err === 'object' && 'type' in err;
+    if (isStripeError && (err as any).type === 'StripeConnectionError') {
+      return NextResponse.json(
+        { error: 'Conexão temporariamente indisponível. Tente novamente em alguns segundos.' },
+        { status: 502 }
+      );
+    }
+    return NextResponse.json(
+      { error: 'Erro ao processar pagamento. Tente novamente.' },
+      { status: 500 }
+    );
   }
 }

--- a/src/lib/stripe/server.ts
+++ b/src/lib/stripe/server.ts
@@ -11,7 +11,7 @@ export function getStripeServer(): Stripe | null {
   const key = process.env.STRIPE_SECRET_KEY;
   if (!key) return null;
   if (!_stripe) {
-    _stripe = new Stripe(key);
+    _stripe = new Stripe(key, { maxNetworkRetries: 3 });
   }
   return _stripe;
 }


### PR DESCRIPTION
## Summary
- **Bug**: Step 4 of booking showed raw Stripe SDK error "An error occurred with our connection to Stripe. Request was retried 2 times." to the user
- **Root cause**: `create-intent/route.ts` was returning `err.message` directly from Stripe SDK, and Stripe server only had 2 default retries
- **Fixes**:
  - Increase `maxNetworkRetries` from 2 → 3 in Stripe server config
  - Stop exposing raw Stripe SDK errors — return user-friendly messages instead
  - Handle `StripeConnectionError` specifically (returns 502 + "Conexão temporariamente indisponível")
  - Add `logger.error` to both `create-intent` and `checkout` routes
  - Add "Tente novamente" guidance to all payment error messages

## Files changed
- `src/lib/stripe/server.ts` — maxNetworkRetries: 3
- `src/app/api/payment/create-intent/route.ts` — safe error messages + logger
- `src/app/api/bookings/checkout/route.ts` — logger + retry message

## Test plan
- [x] 12 tests: maxNetworkRetries >= 3, no raw error exposure, StripeConnectionError handling, 502 status, logger imports, booking rollback on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)