### PR TITLE
fix(security): add rate limiting and Stripe Connect check to create-intent

### DIFF
--- a/src/__tests__/payments/idempotency-key.test.ts
+++ b/src/__tests__/payments/idempotency-key.test.ts
@@ -44,7 +44,7 @@ vi.mock('@/lib/validation/booking-schema', () => ({
 
 function mockSupabase(overrides: Record<string, unknown> = {}) {
   const professional = {
-    id: 'prof-1',
+    id: '00000000-0000-4000-a000-000000000001',
     require_deposit: true,
     deposit_type: 'percentage',
     deposit_value: 30,
@@ -54,8 +54,9 @@ function mockSupabase(overrides: Record<string, unknown> = {}) {
     stripe_account_id: 'acct_test',
     ...overrides,
   };
-  const service = { id: 'svc-1', name: 'Corte', price: 100, duration_minutes: 30 };
+  const service = { id: '00000000-0000-4000-a000-000000000002', name: 'Corte', price: 100, duration_minutes: 30 };
   const booking = { id: 'booking-123' };
+  const connectAccount = { charges_enabled: true };
 
   mockFrom.mockImplementation((table: string) => {
     if (table === 'professionals') {
@@ -63,6 +64,15 @@ function mockSupabase(overrides: Record<string, unknown> = {}) {
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
             single: vi.fn().mockResolvedValue({ data: professional, error: null }),
+          }),
+        }),
+      };
+    }
+    if (table === 'stripe_connect_accounts') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({ data: connectAccount, error: null }),
           }),
         }),
       };
@@ -132,7 +142,7 @@ describe('Idempotency keys — create-intent', () => {
     const req = new Request('http://localhost/api/payment/create-intent', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ professional_id: 'prof-1', service_id: 'svc-1' }),
+      body: JSON.stringify({ professional_id: '00000000-0000-4000-a000-000000000001', service_id: '00000000-0000-4000-a000-000000000002' }),
     }) as any;
 
     const res = await POST(req);
@@ -142,7 +152,7 @@ describe('Idempotency keys — create-intent', () => {
     expect(mockStripePaymentIntentsCreate).toHaveBeenCalledTimes(1);
     const [, options] = mockStripePaymentIntentsCreate.mock.calls[0];
     expect(options).toHaveProperty('idempotencyKey');
-    expect(options.idempotencyKey).toMatch(/^pi:prof-1:svc-1:/);
+    expect(options.idempotencyKey).toMatch(/^pi:00000000-0000-4000-a000-000000000001:00000000-0000-4000-a000-000000000002:/);
   });
 
   it('uses client-provided idempotency_key when sent', async () => {
@@ -153,8 +163,8 @@ describe('Idempotency keys — create-intent', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        professional_id: 'prof-1',
-        service_id: 'svc-1',
+        professional_id: '00000000-0000-4000-a000-000000000001',
+        service_id: '00000000-0000-4000-a000-000000000002',
         idempotency_key: 'client-key-abc',
       }),
     }) as any;
@@ -174,14 +184,14 @@ describe('Idempotency keys — create-intent', () => {
     const req1 = new Request('http://localhost/api/payment/create-intent', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ professional_id: 'prof-1', service_id: 'svc-1' }),
+      body: JSON.stringify({ professional_id: '00000000-0000-4000-a000-000000000001', service_id: '00000000-0000-4000-a000-000000000002' }),
     }) as any;
     await POST(req1);
 
     const req2 = new Request('http://localhost/api/payment/create-intent', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ professional_id: 'prof-1', service_id: 'svc-1' }),
+      body: JSON.stringify({ professional_id: '00000000-0000-4000-a000-000000000001', service_id: '00000000-0000-4000-a000-000000000002' }),
     }) as any;
     await POST(req2);
 
@@ -200,8 +210,8 @@ describe('Idempotency keys — checkout session', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        professional_id: 'prof-1',
-        service_id: 'svc-1',
+        professional_id: '00000000-0000-4000-a000-000000000001',
+        service_id: '00000000-0000-4000-a000-000000000002',
         booking_date: '2026-03-10',
         start_time: '10:00',
         client_name: 'Test Client',

--- a/src/__tests__/security/create-intent-validation.test.ts
+++ b/src/__tests__/security/create-intent-validation.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #183: /api/payment/create-intent without proper validation
+ *
+ * The route creates Stripe PaymentIntents. It must:
+ * 1. Rate limit requests to prevent abuse
+ * 2. Validate UUID format for IDs
+ * 3. Verify Stripe Connect charges_enabled before creating PI
+ * 4. Calculate amount server-side from DB (not from body)
+ * 5. Verify service belongs to professional
+ */
+
+const routePath = resolve('src/app/api/payment/create-intent/route.ts');
+const source = readFileSync(routePath, 'utf-8');
+
+describe('create-intent rate limiting (issue #183)', () => {
+  it('has rate limiting implementation', () => {
+    expect(source).toContain('isRateLimited');
+    expect(source).toContain('rateLimitMap');
+  });
+
+  it('returns 429 when rate limited', () => {
+    expect(source).toContain('status: 429');
+  });
+
+  it('rate limits by IP address', () => {
+    expect(source).toContain('x-forwarded-for');
+  });
+});
+
+describe('create-intent UUID validation (issue #183)', () => {
+  it('validates UUID format for professional_id and service_id', () => {
+    expect(source).toContain('UUID_REGEX');
+    expect(source).toMatch(/UUID_REGEX\.test\(professional_id\)/);
+    expect(source).toMatch(/UUID_REGEX\.test\(service_id\)/);
+  });
+
+  it('returns 400 for invalid UUIDs', () => {
+    // Check there's a 400 response for invalid IDs
+    expect(source).toContain("'IDs inválidos'");
+  });
+});
+
+describe('create-intent Stripe Connect verification (issue #183)', () => {
+  it('checks charges_enabled from stripe_connect_accounts', () => {
+    expect(source).toContain("from('stripe_connect_accounts')");
+    expect(source).toContain('charges_enabled');
+  });
+
+  it('rejects if charges not enabled', () => {
+    expect(source).toContain('!connectAccount?.charges_enabled');
+  });
+});
+
+describe('create-intent amount validation (issue #183)', () => {
+  it('calculates deposit server-side using calculateDeposit', () => {
+    expect(source).toContain('calculateDeposit(');
+    expect(source).toContain("import { calculateDeposit, toCents } from '@/lib/payment/calculate-deposit'");
+  });
+
+  it('does not accept amount from request body', () => {
+    // The body destructuring should not include amount
+    const bodyDestructure = source.slice(
+      source.indexOf('const {'),
+      source.indexOf('} = body as')
+    );
+    expect(bodyDestructure).not.toContain('amount');
+  });
+
+  it('uses toCents for Stripe amount conversion', () => {
+    expect(source).toContain('toCents(depositAmount)');
+  });
+
+  it('rejects deposit amount <= 0', () => {
+    expect(source).toContain('depositAmount <= 0');
+  });
+});
+
+describe('create-intent service ownership (issue #183)', () => {
+  it('verifies service belongs to professional', () => {
+    // The services query must filter by both service_id AND professional_id
+    const servicesQuery = source.slice(source.indexOf(".from('services')"));
+    expect(servicesQuery).toContain(".eq('id', service_id)");
+    expect(servicesQuery).toContain(".eq('professional_id', professional_id)");
+  });
+});
+
+describe('create-intent does not leak sensitive info', () => {
+  it('does not expose raw Stripe errors to client', () => {
+    // Error responses should use generic messages, not raw err.message
+    expect(source).not.toContain('err.message');
+    expect(source).not.toContain('error.message');
+  });
+
+  it('logs errors server-side', () => {
+    expect(source).toContain("logger.error('[payment/create-intent]'");
+  });
+});

--- a/src/app/api/payment/create-intent/route.ts
+++ b/src/app/api/payment/create-intent/route.ts
@@ -4,7 +4,34 @@ import { createAdminClient } from '@/lib/supabase/admin';
 import { getStripeServer } from '@/lib/stripe/server';
 import { calculateDeposit, toCents } from '@/lib/payment/calculate-deposit';
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Simple IP-based rate limiting (in-memory, per serverless instance)
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT_MAX = 10; // max requests per window
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(ip);
+  if (!entry || now > entry.resetAt) {
+    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return false;
+  }
+  entry.count++;
+  return entry.count > RATE_LIMIT_MAX;
+}
+
 export async function POST(request: NextRequest) {
+  // Rate limit by IP
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  if (isRateLimited(ip)) {
+    return NextResponse.json(
+      { error: 'Muitas tentativas. Aguarde um momento.' },
+      { status: 429 }
+    );
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -25,12 +52,20 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Validate UUID format to prevent injection
+  if (!UUID_REGEX.test(professional_id) || !UUID_REGEX.test(service_id)) {
+    return NextResponse.json(
+      { error: 'IDs inválidos' },
+      { status: 400 }
+    );
+  }
+
   const supabase = createAdminClient();
 
   // Buscar configuração de depósito do profissional
   const { data: professional } = await supabase
     .from('professionals')
-    .select('require_deposit, deposit_type, deposit_value, currency')
+    .select('id, require_deposit, deposit_type, deposit_value, currency')
     .eq('id', professional_id)
     .single();
 
@@ -52,7 +87,21 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Buscar preço do serviço
+  // Verify Stripe Connect is fully onboarded (charges_enabled)
+  const { data: connectAccount } = await supabase
+    .from('stripe_connect_accounts')
+    .select('charges_enabled')
+    .eq('professional_id', professional_id)
+    .maybeSingle();
+
+  if (!connectAccount?.charges_enabled) {
+    return NextResponse.json(
+      { error: 'Pagamento online não disponível para este profissional' },
+      { status: 400 }
+    );
+  }
+
+  // Buscar preço do serviço (must belong to this professional)
   const { data: service } = await supabase
     .from('services')
     .select('price, name')
@@ -99,7 +148,6 @@ export async function POST(request: NextRequest) {
           deposit_type: professional.deposit_type,
           deposit_value: String(professional.deposit_value),
         },
-        // Permite cards e outros métodos automaticamente
         automatic_payment_methods: { enabled: true },
       },
       { idempotencyKey }


### PR DESCRIPTION
## Summary
- **[BLOCKER/P0]** `/api/payment/create-intent` lacked rate limiting, UUID validation, and Stripe Connect verification
- Add IP-based rate limiting (10 req/min per IP) to prevent PaymentIntent spam
- Add UUID format validation for `professional_id` and `service_id`
- Verify `charges_enabled` from `stripe_connect_accounts` before creating PaymentIntent
- Note: this is a public endpoint (used by booking clients), so user auth (`getUser()`) is not applicable. Amounts were already server-derived from DB.

## Test plan
- [x] 14 new tests: rate limiting, UUID validation, Stripe Connect check, amount validation, service ownership, no error leaks
- [x] Existing idempotency-key tests updated for UUID compliance (4 tests)
- [x] `npm run test:fast` passes (1387 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)