### PR TITLE
fix(security): add webhook signature validation to whatsapp-support #184

### DIFF
--- a/src/__tests__/security/whatsapp-support-webhook-signature.test.ts
+++ b/src/__tests__/security/whatsapp-support-webhook-signature.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #184: /api/webhooks/whatsapp-support without signature validation
+ *
+ * The webhook accepted any payload without verifying the apikey header,
+ * allowing attackers to inject fake tickets, send WhatsApp messages,
+ * and consume Anthropic API credits.
+ */
+
+const routePath = resolve('src/app/api/webhooks/whatsapp-support/route.ts');
+const source = readFileSync(routePath, 'utf-8');
+
+describe('whatsapp-support webhook signature validation (issue #184)', () => {
+  it('imports validateEvolutionWebhook', () => {
+    expect(source).toContain("import { validateEvolutionWebhook } from '@/lib/webhooks/signature'");
+  });
+
+  it('reads apikey header from request', () => {
+    expect(source).toContain("request.headers.get('apikey')");
+  });
+
+  it('validates apikey against WHATSAPP_WEBHOOK_SECRET', () => {
+    expect(source).toContain('WHATSAPP_WEBHOOK_SECRET');
+    expect(source).toContain('validateEvolutionWebhook(apikeyHeader, process.env.WHATSAPP_WEBHOOK_SECRET)');
+  });
+
+  it('returns 401 when signature is invalid', () => {
+    expect(source).toContain("status: 401");
+    // The 401 should come BEFORE any JSON parsing or business logic
+    const signatureCheckPos = source.indexOf('validateEvolutionWebhook');
+    const jsonParsePos = source.indexOf('request.json()');
+    expect(signatureCheckPos).toBeLessThan(jsonParsePos);
+  });
+
+  it('validates signature before processing any message data', () => {
+    // Search within the POST handler body only (after "export async function POST")
+    const postBody = source.slice(source.indexOf('export async function POST'));
+    const signatureCheckPos = postBody.indexOf('validateEvolutionWebhook');
+    const adminClientPos = postBody.indexOf('createAdminClient()');
+    const aiHandlerPos = postBody.indexOf('handleWhatsAppSupportMessage(');
+    const sendReplyPos = postBody.indexOf('sendWhatsAppReply(remoteJid');
+
+    // Signature check must come before ALL business logic
+    expect(signatureCheckPos).toBeLessThan(adminClientPos);
+    expect(signatureCheckPos).toBeLessThan(aiHandlerPos);
+    expect(signatureCheckPos).toBeLessThan(sendReplyPos);
+  });
+
+  it('uses the same validation pattern as sales-bot webhook', () => {
+    const salesBotSource = readFileSync(
+      resolve('src/app/api/sales-bot/webhook/route.ts'),
+      'utf-8'
+    );
+    // Both should use validateEvolutionWebhook
+    expect(salesBotSource).toContain('validateEvolutionWebhook');
+    expect(source).toContain('validateEvolutionWebhook');
+  });
+});
+
+describe('validateEvolutionWebhook implementation', () => {
+  it('uses timing-safe comparison', () => {
+    const sigSource = readFileSync(
+      resolve('src/lib/webhooks/signature.ts'),
+      'utf-8'
+    );
+    expect(sigSource).toContain('timingSafeEqual');
+  });
+
+  it('rejects when secret is not configured', () => {
+    const sigSource = readFileSync(
+      resolve('src/lib/webhooks/signature.ts'),
+      'utf-8'
+    );
+    expect(sigSource).toContain('if (!secret) return false');
+  });
+
+  it('rejects when apikey header is missing', () => {
+    const sigSource = readFileSync(
+      resolve('src/lib/webhooks/signature.ts'),
+      'utf-8'
+    );
+    expect(sigSource).toContain('if (!apikeyHeader) return false');
+  });
+});

--- a/src/app/api/webhooks/whatsapp-support/route.ts
+++ b/src/app/api/webhooks/whatsapp-support/route.ts
@@ -21,6 +21,7 @@ import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { handleWhatsAppSupportMessage } from '@/lib/ai/support-bot';
+import { validateEvolutionWebhook } from '@/lib/webhooks/signature';
 
 async function sendWhatsAppReply(to: string, message: string) {
   const evoUrl = process.env.EVOLUTION_API_URL;
@@ -47,6 +48,12 @@ async function sendWhatsAppReply(to: string, message: string) {
 }
 
 export async function POST(request: NextRequest) {
+  // Validate Evolution API webhook signature
+  const apikeyHeader = request.headers.get('apikey');
+  if (!validateEvolutionWebhook(apikeyHeader, process.env.WHATSAPP_WEBHOOK_SECRET)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   let body: any;
   try {
     body = await request.json();


### PR DESCRIPTION
## Summary
- Adds `validateEvolutionWebhook` signature check to `/api/webhooks/whatsapp-support` endpoint
- Validates `apikey` header against `WHATSAPP_WEBHOOK_SECRET` using timing-safe comparison
- Rejects unauthorized requests with 401 **before** parsing JSON or executing any business logic
- Uses the same validation pattern already in place for the sales-bot webhook

## Security Impact
Without this fix, attackers could:
- Inject fake support tickets
- Trigger WhatsApp messages via Evolution API
- Consume Anthropic API credits through the AI support bot

## Test plan
- [x] 9 unit tests covering: import verification, header reading, secret validation, 401 response, ordering before business logic, pattern consistency with sales-bot, timing-safe comparison
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)