### PR TITLE
fix(db): remove notification_queue reference from loyalty stamp trigger #185

### DIFF
--- a/src/__tests__/database/loyalty-stamp-trigger.test.ts
+++ b/src/__tests__/database/loyalty-stamp-trigger.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #185: Trigger add_loyalty_stamp_on_completion references
+ * notification_queue which was dropped in migration 20260303000007.
+ *
+ * Any booking marked as 'completed' would crash with:
+ *   "relation notification_queue does not exist"
+ */
+
+const fixMigrationPath = resolve(
+  'supabase/migrations/20260306000001_fix_loyalty_stamp_no_notification_queue.sql'
+);
+const dropMigrationPath = resolve(
+  'supabase/migrations/20260303000007_drop_notification_queue.sql'
+);
+const originalTriggerPath = resolve(
+  'supabase/migrations/20260218000000_fix_booking_triggers.sql'
+);
+
+describe('loyalty stamp trigger fix (issue #185)', () => {
+  it('fix migration exists', () => {
+    expect(existsSync(fixMigrationPath)).toBe(true);
+  });
+
+  it('fix migration recreates add_loyalty_stamp_on_completion function', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION add_loyalty_stamp_on_completion()');
+  });
+
+  it('fix migration does NOT INSERT INTO notification_queue', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).not.toContain('INSERT INTO notification_queue');
+    // The function body (between $$ ... $$) must not reference notification_queue
+    const bodyMatch = sql.match(/\$\$\s*([\s\S]*?)\s*\$\$/);
+    expect(bodyMatch).not.toBeNull();
+    expect(bodyMatch![1]).not.toContain('notification_queue');
+  });
+
+  it('fix migration preserves loyalty_cards upsert logic', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).toContain('INSERT INTO loyalty_cards');
+    expect(sql).toContain('ON CONFLICT (professional_id, contact_phone)');
+    expect(sql).toContain('current_stamps = loyalty_cards.current_stamps + 1');
+  });
+
+  it('fix migration preserves reward calculation (stamps / 10)', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).toContain('v_loyalty_card.current_stamps / 10');
+    expect(sql).toContain('rewards_available = rewards_available + v_new_rewards');
+  });
+
+  it('fix migration preserves loyalty_transactions inserts', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).toContain("INSERT INTO loyalty_transactions");
+    expect(sql).toContain("'reward_earned'");
+    expect(sql).toContain("'stamp_earned'");
+  });
+
+  it('fix migration only triggers on status change to completed', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).toContain("OLD.status != 'completed' AND NEW.status = 'completed'");
+  });
+
+  it('fix migration runs AFTER the drop migration (ordering)', () => {
+    // 20260306000001 > 20260303000007
+    const fixTimestamp = '20260306000001';
+    const dropTimestamp = '20260303000007';
+    expect(fixTimestamp > dropTimestamp).toBe(true);
+  });
+
+  it('original trigger migration DID reference notification_queue (confirming the bug)', () => {
+    const sql = readFileSync(originalTriggerPath, 'utf-8');
+    expect(sql).toContain('INSERT INTO notification_queue');
+  });
+
+  it('drop migration removed notification_queue table', () => {
+    const sql = readFileSync(dropMigrationPath, 'utf-8');
+    expect(sql).toContain('DROP TABLE IF EXISTS notification_queue CASCADE');
+  });
+});

--- a/supabase/migrations/20260306000001_fix_loyalty_stamp_no_notification_queue.sql
+++ b/supabase/migrations/20260306000001_fix_loyalty_stamp_no_notification_queue.sql
@@ -1,0 +1,65 @@
+-- Fix: add_loyalty_stamp_on_completion referencia notification_queue (dropada em 20260303000007)
+-- Qualquer booking marcado como 'completed' causava crash:
+--   "relation notification_queue does not exist"
+--
+-- Correção: recriar a função SEM o INSERT em notification_queue.
+-- A lógica de loyalty (stamps, rewards, transactions) permanece intacta.
+
+CREATE OR REPLACE FUNCTION add_loyalty_stamp_on_completion()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_loyalty_card RECORD;
+  v_new_stamps integer;
+  v_new_rewards integer;
+BEGIN
+  IF OLD.status != 'completed' AND NEW.status = 'completed' THEN
+
+    INSERT INTO loyalty_cards (
+      professional_id,
+      contact_id,
+      contact_phone,
+      contact_name,
+      current_stamps,
+      total_stamps
+    ) VALUES (
+      NEW.professional_id,
+      NEW.contact_id,
+      NEW.client_phone,
+      NEW.client_name,
+      1,
+      1
+    )
+    ON CONFLICT (professional_id, contact_phone)
+    DO UPDATE SET
+      current_stamps = loyalty_cards.current_stamps + 1,
+      total_stamps = loyalty_cards.total_stamps + 1,
+      updated_at = now()
+    RETURNING * INTO v_loyalty_card;
+
+    v_new_rewards := (v_loyalty_card.current_stamps / 10)::integer;
+
+    IF v_new_rewards > 0 THEN
+      UPDATE loyalty_cards SET
+        current_stamps = v_loyalty_card.current_stamps % 10,
+        rewards_available = rewards_available + v_new_rewards,
+        updated_at = now()
+      WHERE id = v_loyalty_card.id;
+
+      INSERT INTO loyalty_transactions (loyalty_card_id, booking_id, type, stamps_change, notes)
+      VALUES (
+        v_loyalty_card.id, NEW.id, 'reward_earned', v_new_rewards,
+        format('Ganhou %s recompensa(s)!', v_new_rewards)
+      );
+    END IF;
+
+    INSERT INTO loyalty_transactions (loyalty_card_id, booking_id, type, stamps_change, notes)
+    VALUES (
+      v_loyalty_card.id, NEW.id, 'stamp_earned', 1,
+      'Carimbo ganho por serviço completado'
+    );
+
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- Trigger `add_loyalty_stamp_on_completion` referenced `notification_queue` table (dropped in migration `20260303000007`)
- Every booking marked as `completed` crashed with "relation notification_queue does not exist"
- New migration recreates the function without the `INSERT INTO notification_queue`, preserving all loyalty logic (stamps, rewards, transactions)

## Test plan
- [x] 10 unit tests: migration exists, no notification_queue in function body, loyalty logic preserved (upsert, rewards, transactions), correct ordering after drop migration, confirms original bug
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)