### PR TITLE
fix(reliability): add global-error.tsx for root layout crash recovery #186

### DIFF
--- a/src/__tests__/reliability/global-error.test.ts
+++ b/src/__tests__/reliability/global-error.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #186: global-error.tsx does not exist.
+ * Without it, a root layout crash causes an unrecoverable white screen.
+ */
+
+const globalErrorPath = resolve('src/app/global-error.tsx');
+
+describe('global-error.tsx exists and is self-contained (issue #186)', () => {
+  const source = existsSync(globalErrorPath)
+    ? readFileSync(globalErrorPath, 'utf-8')
+    : '';
+
+  it('file exists at src/app/global-error.tsx', () => {
+    expect(existsSync(globalErrorPath)).toBe(true);
+  });
+
+  it('is a client component', () => {
+    expect(source).toMatch(/^['"]use client['"]/);
+  });
+
+  it('exports a default function component', () => {
+    expect(source).toMatch(/export default function GlobalError/);
+  });
+
+  it('accepts error and reset props (Next.js contract)', () => {
+    expect(source).toContain('error: Error');
+    expect(source).toContain('reset: () => void');
+  });
+
+  it('renders its own <html> and <body> tags (Next.js requirement)', () => {
+    expect(source).toContain('<html');
+    expect(source).toContain('<body');
+  });
+
+  it('has a reset/retry button that calls reset()', () => {
+    expect(source).toContain('onClick={reset}');
+  });
+
+  it('has a link to home page for escape hatch', () => {
+    expect(source).toContain('href="/"');
+  });
+
+  it('does NOT import from next-intl (i18n may be broken)', () => {
+    expect(source).not.toContain('next-intl');
+  });
+
+  it('does NOT import from @/ paths (app may be broken)', () => {
+    expect(source).not.toMatch(/from ['"]@\//);
+  });
+
+  it('does NOT import from lucide-react or other UI libs', () => {
+    expect(source).not.toContain('lucide-react');
+    expect(source).not.toContain('from "react"');
+    // Only 'use client' directive needed, no React import required in modern Next.js
+  });
+
+  it('uses inline styles only (CSS may not be loaded)', () => {
+    expect(source).not.toContain('className=');
+  });
+
+  it('displays error digest when available', () => {
+    expect(source).toContain('error.digest');
+  });
+});

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+/**
+ * Global error boundary — catches errors in the root layout.
+ * Must be fully self-contained (no external imports) since the
+ * root layout, providers, fonts, and i18n may all be broken.
+ *
+ * Next.js requires global-error to include its own <html> and <body>.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="pt-BR">
+      <body
+        style={{
+          margin: 0,
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+          backgroundColor: '#f9fafb',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: '100vh',
+        }}
+      >
+        <div style={{ textAlign: 'center', maxWidth: 420, padding: 24 }}>
+          <div
+            style={{
+              fontSize: 48,
+              marginBottom: 16,
+            }}
+            aria-hidden="true"
+          >
+            ⚠️
+          </div>
+          <h1
+            style={{
+              fontSize: 20,
+              fontWeight: 600,
+              color: '#111827',
+              marginBottom: 8,
+            }}
+          >
+            Algo deu errado
+          </h1>
+          <p
+            style={{
+              fontSize: 14,
+              color: '#6b7280',
+              marginBottom: 24,
+              lineHeight: 1.5,
+            }}
+          >
+            Ocorreu um erro inesperado. Tente recarregar a página.
+          </p>
+          {error.digest && (
+            <p
+              style={{
+                fontSize: 12,
+                color: '#9ca3af',
+                marginBottom: 24,
+                fontFamily: 'monospace',
+              }}
+            >
+              Código: {error.digest}
+            </p>
+          )}
+          <div
+            style={{
+              display: 'flex',
+              gap: 12,
+              justifyContent: 'center',
+            }}
+          >
+            <button
+              onClick={reset}
+              style={{
+                padding: '10px 20px',
+                backgroundColor: '#7c3aed',
+                color: '#fff',
+                border: 'none',
+                borderRadius: 8,
+                fontSize: 14,
+                fontWeight: 500,
+                cursor: 'pointer',
+              }}
+            >
+              Tentar novamente
+            </button>
+            <a
+              href="/"
+              style={{
+                padding: '10px 20px',
+                backgroundColor: '#fff',
+                color: '#374151',
+                border: '1px solid #d1d5db',
+                borderRadius: 8,
+                fontSize: 14,
+                fontWeight: 500,
+                textDecoration: 'none',
+                cursor: 'pointer',
+              }}
+            >
+              Página inicial
+            </a>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- Creates `src/app/global-error.tsx` — a self-contained error boundary for root layout crashes
- Uses only inline styles and zero external imports (no next-intl, no lucide, no @/ paths)
- Includes its own `<html>` and `<body>` tags as required by Next.js
- Provides reset button + home link for user recovery
- Displays error digest code when available

## Why self-contained?
When the root layout crashes, providers, fonts, CSS, and i18n are all unavailable. The component must render independently.

## Test plan
- [x] 12 unit tests: file exists, client component, Next.js contract (error/reset props, html/body tags), no external imports, inline styles only, reset button, home link, error digest display
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)