### PR TITLE
fix(security): lock down reschedule_tokens RLS — remove USING(true) #187

### DIFF
--- a/src/__tests__/security/reschedule-tokens-rls.test.ts
+++ b/src/__tests__/security/reschedule-tokens-rls.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests for Issue #187: reschedule_tokens RLS SELECT USING(true)
+ * exposes all tokens to any anon user.
+ *
+ * Fix: routes switched to createAdminClient(), RLS locked down to
+ * professional ownership only.
+ */
+
+const fixMigrationPath = resolve(
+  'supabase/migrations/20260306000002_fix_reschedule_tokens_rls.sql'
+);
+const routePath = resolve('src/app/api/reschedule/[token]/route.ts');
+const changePath = resolve('src/app/api/reschedule/[token]/change/route.ts');
+const cancelPath = resolve('src/app/api/reschedule/[token]/cancel/route.ts');
+
+describe('reschedule_tokens RLS fix (issue #187)', () => {
+  it('fix migration exists', () => {
+    expect(existsSync(fixMigrationPath)).toBe(true);
+  });
+
+  it('drops the permissive SELECT USING(true) policy', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).toContain('DROP POLICY IF EXISTS "Acesso público via token"');
+  });
+
+  it('drops the permissive INSERT WITH CHECK(true) policy', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).toContain('DROP POLICY IF EXISTS "Sistema pode criar tokens"');
+  });
+
+  it('drops the permissive UPDATE USING(true) policy', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).toContain('DROP POLICY IF EXISTS "Sistema pode atualizar tokens"');
+  });
+
+  it('new SELECT policy restricts to professional ownership via booking', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).toContain('FOR SELECT');
+    expect(sql).toContain('b.professional_id');
+    expect(sql).toContain('auth.uid()');
+    expect(sql).not.toMatch(/FOR SELECT[\s\S]*?USING\s*\(\s*true\s*\)/);
+  });
+
+  it('new UPDATE policy restricts to professional ownership via booking', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).toContain('FOR UPDATE');
+    expect(sql).not.toMatch(/FOR UPDATE[\s\S]*?USING\s*\(\s*true\s*\)/);
+  });
+
+  it('does not create a public INSERT policy', () => {
+    const sql = readFileSync(fixMigrationPath, 'utf-8');
+    expect(sql).not.toContain('FOR INSERT');
+  });
+});
+
+describe('reschedule routes use admin client (issue #187)', () => {
+  it('GET route uses createAdminClient (not createClient)', () => {
+    const source = readFileSync(routePath, 'utf-8');
+    expect(source).toContain("import { createAdminClient } from '@/lib/supabase/admin'");
+    expect(source).toContain('createAdminClient()');
+    expect(source).not.toContain("from '@/lib/supabase/server'");
+  });
+
+  it('change route uses createAdminClient (not createClient)', () => {
+    const source = readFileSync(changePath, 'utf-8');
+    expect(source).toContain("import { createAdminClient } from '@/lib/supabase/admin'");
+    expect(source).toContain('createAdminClient()');
+    expect(source).not.toContain("from '@/lib/supabase/server'");
+  });
+
+  it('cancel route already uses createAdminClient', () => {
+    const source = readFileSync(cancelPath, 'utf-8');
+    expect(source).toContain("import { createAdminClient } from '@/lib/supabase/admin'");
+  });
+
+  it('all three routes query reschedule_tokens and check for errors', () => {
+    for (const path of [routePath, changePath, cancelPath]) {
+      const source = readFileSync(path, 'utf-8');
+      expect(source).toContain(".from('reschedule_tokens')");
+      expect(source).toContain('tokenError');
+      expect(source).toContain("Token inválido");
+    }
+  });
+});

--- a/src/app/api/reschedule/[token]/change/route.ts
+++ b/src/app/api/reschedule/[token]/change/route.ts
@@ -1,5 +1,5 @@
 import { logger } from '@/lib/logger';
-import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(
@@ -10,7 +10,7 @@ export async function POST(
   const body = await request.json();
   const { new_date, new_time } = body;
 
-  const supabase = await createClient();
+  const supabase = createAdminClient();
 
   try {
     // Validar token

--- a/src/app/api/reschedule/[token]/route.ts
+++ b/src/app/api/reschedule/[token]/route.ts
@@ -1,5 +1,5 @@
 import { logger } from '@/lib/logger';
-import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
@@ -7,7 +7,7 @@ export async function GET(
   { params }: { params: Promise<{ token: string }> }
 ) {
   const { token } = await params;
-  const supabase = await createClient();
+  const supabase = createAdminClient();
 
   try {
     // Buscar token

--- a/supabase/migrations/20260306000002_fix_reschedule_tokens_rls.sql
+++ b/supabase/migrations/20260306000002_fix_reschedule_tokens_rls.sql
@@ -1,0 +1,42 @@
+-- Fix: reschedule_tokens RLS policies used USING(true) for SELECT and UPDATE,
+-- exposing ALL tokens to any anon user and allowing unauthorized token usage.
+--
+-- All reschedule routes now use createAdminClient() (service role, bypasses RLS),
+-- so we can safely remove the permissive public policies.
+--
+-- New policies:
+--   SELECT/UPDATE: only the professional who owns the booking can access
+--   INSERT: only service role (via admin client) — no public inserts
+
+-- Drop existing permissive policies
+DROP POLICY IF EXISTS "Acesso público via token" ON reschedule_tokens;
+DROP POLICY IF EXISTS "Sistema pode criar tokens" ON reschedule_tokens;
+DROP POLICY IF EXISTS "Sistema pode atualizar tokens" ON reschedule_tokens;
+
+-- Professional can view their own tokens (via booking ownership)
+CREATE POLICY "Professional can view own tokens"
+  ON reschedule_tokens FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM bookings b
+      WHERE b.id = reschedule_tokens.booking_id
+        AND b.professional_id IN (
+          SELECT p.id FROM professionals p WHERE p.user_id = auth.uid()
+        )
+    )
+  );
+
+-- Professional can update their own tokens
+CREATE POLICY "Professional can update own tokens"
+  ON reschedule_tokens FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM bookings b
+      WHERE b.id = reschedule_tokens.booking_id
+        AND b.professional_id IN (
+          SELECT p.id FROM professionals p WHERE p.user_id = auth.uid()
+        )
+    )
+  );
+
+-- No public INSERT — tokens are created by triggers or service role only


### PR DESCRIPTION
## Summary
- **RLS fix**: Dropped 3 permissive policies (`USING(true)`) on `reschedule_tokens` that exposed all tokens to anon users
- **New policies**: SELECT/UPDATE restricted to professional ownership via booking relationship + `auth.uid()`
- **Route fix**: Switched `/api/reschedule/[token]/route.ts` and `.../change/route.ts` from `createClient()` to `createAdminClient()` (cancel route already used admin client)
- No public INSERT policy — tokens created only by triggers or service role

## Security Impact
Before: any anon user could enumerate all reschedule tokens and mark them as used, enabling unauthorized rescheduling/cancellation of any booking.

## Test plan
- [x] 11 unit tests: migration drops permissive policies, new policies use auth.uid() + booking ownership, routes use createAdminClient, token validation present
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)