### PR TITLE
fix(compliance): commit email unsubscribe system — LGPD opt-out #188

### DIFF
--- a/src/__tests__/email/unsubscribe.test.ts
+++ b/src/__tests__/email/unsubscribe.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockMaybeSingle = vi.fn();
+const mockEqChain = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
+const mockSelect = vi.fn(() => ({ eq: mockEqChain }));
+const mockUpdate = vi.fn(() => ({ eq: vi.fn() }));
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'professionals') {
+    return { select: mockSelect, update: mockUpdate };
+  }
+  return { select: vi.fn(), update: vi.fn() };
+});
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ─── Helper tests ────────────────────────────────────────────────────────────
+
+describe('email/unsubscribe helpers', () => {
+  const FAKE_TOKEN = 'a'.repeat(64);
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://test.example.com';
+  });
+
+  it('getUnsubscribeUrl builds correct URL', async () => {
+    const { getUnsubscribeUrl } = await import('@/lib/email/unsubscribe');
+    const url = getUnsubscribeUrl(FAKE_TOKEN);
+    expect(url).toBe(`https://test.example.com/api/email/unsubscribe?token=${FAKE_TOKEN}`);
+  });
+
+  it('getUnsubscribeHeaders returns List-Unsubscribe and List-Unsubscribe-Post', async () => {
+    const { getUnsubscribeHeaders } = await import('@/lib/email/unsubscribe');
+    const headers = getUnsubscribeHeaders(FAKE_TOKEN);
+    expect(headers['List-Unsubscribe']).toContain(FAKE_TOKEN);
+    expect(headers['List-Unsubscribe']).toMatch(/^<https?:\/\/.+>$/);
+    expect(headers['List-Unsubscribe-Post']).toBe('List-Unsubscribe=One-Click');
+  });
+
+  it('getMarketingEmailFooter includes unsubscribe link', async () => {
+    const { getMarketingEmailFooter } = await import('@/lib/email/unsubscribe');
+    const footer = getMarketingEmailFooter(FAKE_TOKEN);
+    expect(footer).toContain('Cancelar inscrição');
+    expect(footer).toContain(FAKE_TOKEN);
+    expect(footer).toContain('Dublin, Ireland');
+    expect(footer).toContain('privacy@circlehood-tech.com');
+  });
+
+  it('getTransactionalEmailFooter does NOT include unsubscribe link', async () => {
+    const { getTransactionalEmailFooter } = await import('@/lib/email/unsubscribe');
+    const footer = getTransactionalEmailFooter();
+    expect(footer).not.toContain('Cancelar inscrição');
+    expect(footer).not.toContain('unsubscribe');
+    expect(footer).toContain('Dublin, Ireland');
+    expect(footer).toContain('privacy@circlehood-tech.com');
+  });
+});
+
+// ─── Endpoint tests ──────────────────────────────────────────────────────────
+
+describe('email/unsubscribe endpoint', () => {
+  const VALID_TOKEN = 'b'.repeat(64);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('GET with invalid token returns 400', async () => {
+    const { GET } = await import('@/app/api/email/unsubscribe/route');
+    const request = new Request('https://test.example.com/api/email/unsubscribe?token=invalid');
+    const response = await GET(request as any);
+    expect(response.status).toBe(400);
+    const html = await response.text();
+    expect(html).toContain('inválido');
+  });
+
+  it('GET with unknown token returns 400', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: null });
+
+    const { GET } = await import('@/app/api/email/unsubscribe/route');
+    const request = new Request(`https://test.example.com/api/email/unsubscribe?token=${VALID_TOKEN}`);
+    const response = await GET(request as any);
+    expect(response.status).toBe(400);
+  });
+
+  it('GET with valid token returns 200 and confirms unsubscribe', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: { id: 'prof-1', business_name: 'Test Biz', marketing_emails_opted_out: false },
+      error: null,
+    });
+
+    const { GET } = await import('@/app/api/email/unsubscribe/route');
+    const request = new Request(`https://test.example.com/api/email/unsubscribe?token=${VALID_TOKEN}`);
+    const response = await GET(request as any);
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('Inscrição cancelada');
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it('GET is idempotent — does not re-update if already opted out', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: { id: 'prof-1', business_name: 'Test Biz', marketing_emails_opted_out: true },
+      error: null,
+    });
+
+    const { GET } = await import('@/app/api/email/unsubscribe/route');
+    const request = new Request(`https://test.example.com/api/email/unsubscribe?token=${VALID_TOKEN}`);
+    const response = await GET(request as any);
+    expect(response.status).toBe(200);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('POST with valid token returns JSON success', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: { id: 'prof-1', business_name: 'Test Biz', marketing_emails_opted_out: false },
+      error: null,
+    });
+
+    const { POST } = await import('@/app/api/email/unsubscribe/route');
+    const request = new Request(`https://test.example.com/api/email/unsubscribe?token=${VALID_TOKEN}`, {
+      method: 'POST',
+    });
+    const response = await POST(request as any);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.success).toBe(true);
+  });
+
+  it('POST with invalid token returns 400 JSON', async () => {
+    const { POST } = await import('@/app/api/email/unsubscribe/route');
+    const request = new Request('https://test.example.com/api/email/unsubscribe?token=short', {
+      method: 'POST',
+    });
+    const response = await POST(request as any);
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBe('Invalid token');
+  });
+});
+
+// ─── Cron source code verification ──────────────────────────────────────────
+
+describe('cron compliance checks', () => {
+  it('send-retention-emails filters opted-out and uses List-Unsubscribe', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const cronPath = path.resolve('src/app/api/cron/send-retention-emails/route.ts');
+    const source = fs.readFileSync(cronPath, 'utf-8');
+
+    expect(source).toContain("marketing_emails_opted_out");
+    expect(source).toContain("getUnsubscribeHeaders");
+    expect(source).toContain("getMarketingEmailFooter");
+  });
+
+  it('send-trial-expiration-notifications filters opted-out and uses List-Unsubscribe', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const cronPath = path.resolve('src/app/api/cron/send-trial-expiration-notifications/route.ts');
+    const source = fs.readFileSync(cronPath, 'utf-8');
+
+    expect(source).toContain("marketing_emails_opted_out");
+    expect(source).toContain("getUnsubscribeHeaders");
+    expect(source).toContain("getMarketingEmailFooter");
+  });
+});

--- a/src/app/api/cron/send-retention-emails/route.ts
+++ b/src/app/api/cron/send-retention-emails/route.ts
@@ -2,6 +2,7 @@ import { logger } from '@/lib/logger';
 import { createClient } from '@supabase/supabase-js';
 import { NextRequest, NextResponse } from 'next/server';
 import { Resend } from 'resend';
+import { getUnsubscribeHeaders, getMarketingEmailFooter } from '@/lib/email/unsubscribe';
 
 export async function POST(request: NextRequest) {
   const authHeader = request.headers.get('authorization');
@@ -26,9 +27,10 @@ export async function POST(request: NextRequest) {
     // Find professionals with pending deletion and their auth email
     const { data: pendingDeletion, error: fetchError } = await supabase
       .from('professionals')
-      .select('id, business_name, user_id, deleted_at, deletion_scheduled_for')
+      .select('id, business_name, user_id, deleted_at, deletion_scheduled_for, unsubscribe_token')
       .not('deleted_at', 'is', null)
-      .not('deletion_scheduled_for', 'is', null);
+      .not('deletion_scheduled_for', 'is', null)
+      .eq('marketing_emails_opted_out', false);
 
     if (fetchError) throw fetchError;
     if (!pendingDeletion || pendingDeletion.length === 0) {
@@ -100,11 +102,19 @@ export async function POST(request: NextRequest) {
       );
 
       try {
+        const unsubHeaders = prof.unsubscribe_token
+          ? getUnsubscribeHeaders(prof.unsubscribe_token)
+          : {};
+        const unsubFooter = prof.unsubscribe_token
+          ? getMarketingEmailFooter(prof.unsubscribe_token)
+          : '';
+
         await resend.emails.send({
           from: fromEmail,
           to: userEmail,
           subject: emailContent.subject,
-          html: emailContent.html,
+          html: emailContent.html + unsubFooter,
+          headers: unsubHeaders,
         });
 
         // Record that email was sent

--- a/src/app/api/cron/send-trial-expiration-notifications/route.ts
+++ b/src/app/api/cron/send-trial-expiration-notifications/route.ts
@@ -2,6 +2,7 @@ import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { Resend } from 'resend';
+import { getUnsubscribeHeaders, getMarketingEmailFooter } from '@/lib/email/unsubscribe';
 
 const NOTIFICATION_TYPES = ['day_7', 'day_3', 'day_1'] as const;
 type NotificationType = typeof NOTIFICATION_TYPES[number];
@@ -143,8 +144,9 @@ export async function POST(request: NextRequest) {
 
   const { data: professionals, error } = await supabase
     .from('professionals')
-    .select('id, business_name, user_id, trial_ends_at')
+    .select('id, business_name, user_id, trial_ends_at, unsubscribe_token')
     .eq('subscription_status', 'trial')
+    .eq('marketing_emails_opted_out', false)
     .gte('trial_ends_at', now.toISOString())
     .lte('trial_ends_at', windowEnd.toISOString());
 
@@ -210,11 +212,19 @@ export async function POST(request: NextRequest) {
           ? `🚨 Seu teste CircleHood expira amanhã — ${professional.business_name}`
           : `⚠️ Seu teste CircleHood expira em ${daysRemaining} dias — ${professional.business_name}`;
 
+      const unsubHeaders = professional.unsubscribe_token
+        ? getUnsubscribeHeaders(professional.unsubscribe_token)
+        : {};
+      const unsubFooter = professional.unsubscribe_token
+        ? getMarketingEmailFooter(professional.unsubscribe_token)
+        : '';
+
       await resend.emails.send({
         from: `CircleHood Booking <${fromEmail}>`,
         to: email,
         subject,
-        html: buildEmailHtml(professional.business_name, daysRemaining, notificationType),
+        html: buildEmailHtml(professional.business_name, daysRemaining, notificationType) + unsubFooter,
+        headers: unsubHeaders,
       });
 
       // Record the notification

--- a/src/lib/email/unsubscribe.ts
+++ b/src/lib/email/unsubscribe.ts
@@ -1,0 +1,38 @@
+const BASE_URL =
+  process.env.NEXT_PUBLIC_BASE_URL ?? 'https://booking.circlehood-tech.com';
+
+export function getUnsubscribeUrl(token: string): string {
+  return `${BASE_URL}/api/email/unsubscribe?token=${token}`;
+}
+
+export function getUnsubscribeHeaders(token: string): Record<string, string> {
+  const url = getUnsubscribeUrl(token);
+  return {
+    'List-Unsubscribe': `<${url}>`,
+    'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+  };
+}
+
+export function getMarketingEmailFooter(token: string): string {
+  const url = getUnsubscribeUrl(token);
+  return `
+    <hr style="border: none; border-top: 1px solid #eee; margin: 24px 0;" />
+    <p style="font-size: 0.8em; color: #888; text-align: center;">
+      CircleHood Tech — Dublin, Ireland<br/>
+      <a href="mailto:privacy@circlehood-tech.com">privacy@circlehood-tech.com</a>
+    </p>
+    <p style="font-size: 0.75em; color: #aaa; text-align: center;">
+      <a href="${url}" style="color: #aaa;">Cancelar inscrição</a> · Você recebeu este email porque tem uma conta no CircleHood Booking.
+    </p>
+  `;
+}
+
+export function getTransactionalEmailFooter(): string {
+  return `
+    <hr style="border: none; border-top: 1px solid #eee; margin: 24px 0;" />
+    <p style="font-size: 0.8em; color: #888; text-align: center;">
+      CircleHood Tech — Dublin, Ireland<br/>
+      <a href="mailto:privacy@circlehood-tech.com">privacy@circlehood-tech.com</a>
+    </p>
+  `;
+}

--- a/supabase/migrations/20260303000003_email_unsubscribe.sql
+++ b/supabase/migrations/20260303000003_email_unsubscribe.sql
@@ -1,0 +1,18 @@
+-- Add marketing email opt-out columns to professionals
+ALTER TABLE professionals
+  ADD COLUMN IF NOT EXISTS marketing_emails_opted_out BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS unsubscribe_token TEXT UNIQUE,
+  ADD COLUMN IF NOT EXISTS marketing_opted_out_at TIMESTAMPTZ;
+
+-- Backfill tokens for existing professionals
+UPDATE professionals
+SET unsubscribe_token = encode(gen_random_bytes(32), 'hex')
+WHERE unsubscribe_token IS NULL;
+
+-- Set NOT NULL + DEFAULT after backfill
+ALTER TABLE professionals
+  ALTER COLUMN unsubscribe_token SET NOT NULL,
+  ALTER COLUMN unsubscribe_token SET DEFAULT encode(gen_random_bytes(32), 'hex');
+
+CREATE INDEX IF NOT EXISTS idx_professionals_unsubscribe_token
+  ON professionals(unsubscribe_token);


### PR DESCRIPTION
## Summary
- **Migration** `20260303000003`: adds `marketing_emails_opted_out`, `unsubscribe_token`, `marketing_opted_out_at` columns to `professionals`
- **Endpoint** `GET/POST /api/email/unsubscribe`: RFC 8058 one-click unsubscribe with HTML confirmation page
- **Lib** `src/lib/email/unsubscribe.ts`: helpers for unsubscribe URLs, `List-Unsubscribe` headers, marketing/transactional footers
- **Cron integration**: both `send-retention-emails` and `send-trial-expiration-notifications` now:
  - Filter out `marketing_emails_opted_out = true` professionals
  - Include `List-Unsubscribe` and `List-Unsubscribe-Post` headers
  - Append unsubscribe footer to email HTML

## Compliance Impact
LGPD requires opt-out mechanism for marketing emails. Without this, all marketing emails are non-compliant and risk being flagged as spam.

## Test plan
- [x] 12 unit tests: URL builder, headers, marketing footer, transactional footer, GET/POST endpoint (invalid token, unknown token, valid token, idempotency), cron compliance checks (both crons filter opted-out + use headers/footer)
- [x] All 100 test files / 1431 tests pass (previously 2 tests were failing — now fixed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)