### PR TITLE
fix(security): add deny-all RLS to admin-only tables (#242)

### DIFF
--- a/supabase/migrations/20260307000007_deny_all_rls_admin_tables.sql
+++ b/supabase/migrations/20260307000007_deny_all_rls_admin_tables.sql
@@ -1,0 +1,19 @@
+-- C-02: Add deny-all RLS to admin-only tables
+-- Service role bypasses RLS automatically, so these tables remain
+-- accessible to admin code while blocking anon/authenticated clients.
+
+-- sales_leads
+ALTER TABLE sales_leads ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "deny_all" ON sales_leads USING (false);
+
+-- sales_conversations
+ALTER TABLE sales_conversations ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "deny_all" ON sales_conversations USING (false);
+
+-- sales_messages
+ALTER TABLE sales_messages ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "deny_all" ON sales_messages USING (false);
+
+-- control_center_entries
+ALTER TABLE control_center_entries ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "deny_all" ON control_center_entries USING (false);


### PR DESCRIPTION
## O que foi feito
- Created migration enabling RLS with `USING (false)` deny-all policy on 4 admin-only tables: `sales_leads`, `sales_conversations`, `sales_messages`, `control_center_entries`
- Service role bypasses RLS automatically, so all admin code continues working
- Prevents data exposure if regular (anon/authenticated) client is used accidentally

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)