### PR TITLE
fix(reliability): call validateServerEnv() on startup via instrumentation.ts (#198)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,6 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { validateServerEnv } = await import('@/lib/env');
+    validateServerEnv();
+  }
+}


### PR DESCRIPTION
Closes #198

## Summary
- Create `src/instrumentation.ts` that calls `validateServerEnv()` during Next.js server startup
- Only runs in Node.js runtime (not edge) to avoid issues with edge functions
- Env var misconfigurations now fail fast at startup instead of on first request

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `npm test` — 101/101 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)