### PR TITLE
fix(a11y): add aria-label to icon-only buttons (#199)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -450,7 +450,9 @@
     "day3": "Wednesday",
     "day4": "Thursday",
     "day5": "Friday",
-    "day6": "Saturday"
+    "day6": "Saturday",
+    "removeBlockedDate": "Remove blocked date",
+    "removeBlockedPeriod": "Remove blocked period"
   },
   "support": {
     "title": "Support Center",
@@ -487,7 +489,8 @@
     "replyShortly": "We'll respond shortly.",
     "errorLoad": "Error loading tickets",
     "errorOpen": "Error opening ticket",
-    "errorReply": "Error sending reply"
+    "errorReply": "Error sending reply",
+    "sendReply": "Send reply"
   },
   "gallery": {
     "title": "Photo Gallery",
@@ -751,7 +754,9 @@
     "importContactsError": "Error importing contacts",
     "importWhatsAppBtn": "Import from WhatsApp",
     "importWhatsAppSuccess": "WhatsApp import complete!",
-    "importWhatsAppDesc": "{imported} contacts imported, {skipped} already existed."
+    "importWhatsAppDesc": "{imported} contacts imported, {skipped} already existed.",
+    "editClient": "Edit client",
+    "deleteClient": "Delete client"
   },
   "onboarding": {
     "title": "Set up your account",
@@ -1190,7 +1195,9 @@
     "tip2": "Facebook and WhatsApp Status",
     "tip3": "Google My Business",
     "tip4": "WhatsApp groups in your area",
-    "tip5": "Print the QR Code and place it at your establishment"
+    "tip5": "Print the QR Code and place it at your establishment",
+    "copyLink": "Copy link",
+    "openPage": "Open page"
   },
   "integrations": {
     "title": "Integrations",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -450,7 +450,9 @@
     "day3": "Miércoles",
     "day4": "Jueves",
     "day5": "Viernes",
-    "day6": "Sábado"
+    "day6": "Sábado",
+    "removeBlockedDate": "Eliminar fecha bloqueada",
+    "removeBlockedPeriod": "Eliminar período bloqueado"
   },
   "support": {
     "title": "Centro de Soporte",
@@ -487,7 +489,8 @@
     "replyShortly": "Te responderemos pronto.",
     "errorLoad": "Error al cargar tickets",
     "errorOpen": "Error al abrir ticket",
-    "errorReply": "Error al enviar respuesta"
+    "errorReply": "Error al enviar respuesta",
+    "sendReply": "Enviar respuesta"
   },
   "gallery": {
     "title": "Galería de Fotos",
@@ -751,7 +754,9 @@
     "importContactsError": "Error al importar contactos",
     "importWhatsAppBtn": "Importar de WhatsApp",
     "importWhatsAppSuccess": "¡Importación de WhatsApp completada!",
-    "importWhatsAppDesc": "{imported} contactos importados, {skipped} ya existían."
+    "importWhatsAppDesc": "{imported} contactos importados, {skipped} ya existían.",
+    "editClient": "Editar cliente",
+    "deleteClient": "Eliminar cliente"
   },
   "onboarding": {
     "title": "Configura tu cuenta",
@@ -1190,7 +1195,9 @@
     "tip2": "Facebook y WhatsApp Status",
     "tip3": "Google Mi Negocio",
     "tip4": "Grupos de WhatsApp de tu zona",
-    "tip5": "Imprime el QR Code y colócalo en tu establecimiento"
+    "tip5": "Imprime el QR Code y colócalo en tu establecimiento",
+    "copyLink": "Copiar enlace",
+    "openPage": "Abrir página"
   },
   "integrations": {
     "title": "Integraciones",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -450,7 +450,9 @@
     "day3": "Quarta",
     "day4": "Quinta",
     "day5": "Sexta",
-    "day6": "Sábado"
+    "day6": "Sábado",
+    "removeBlockedDate": "Remover data bloqueada",
+    "removeBlockedPeriod": "Remover período bloqueado"
   },
   "support": {
     "title": "Central de Suporte",
@@ -487,7 +489,8 @@
     "replyShortly": "Respondemos em breve.",
     "errorLoad": "Erro ao carregar chamados",
     "errorOpen": "Erro ao abrir chamado",
-    "errorReply": "Erro ao enviar resposta"
+    "errorReply": "Erro ao enviar resposta",
+    "sendReply": "Enviar resposta"
   },
   "gallery": {
     "title": "Galeria de Fotos",
@@ -751,7 +754,9 @@
     "importContactsError": "Erro ao importar contatos",
     "importWhatsAppBtn": "Importar do WhatsApp",
     "importWhatsAppSuccess": "Importação do WhatsApp concluída!",
-    "importWhatsAppDesc": "{imported} contatos importados, {skipped} já existiam."
+    "importWhatsAppDesc": "{imported} contatos importados, {skipped} já existiam.",
+    "editClient": "Editar cliente",
+    "deleteClient": "Excluir cliente"
   },
   "onboarding": {
     "title": "Configure sua conta",
@@ -1190,7 +1195,9 @@
     "tip2": "Facebook e WhatsApp Status",
     "tip3": "Google Meu Negócio",
     "tip4": "Grupos de WhatsApp da sua região",
-    "tip5": "Imprima o QR Code e cole no seu estabelecimento"
+    "tip5": "Imprima o QR Code e cole no seu estabelecimento",
+    "copyLink": "Copiar link",
+    "openPage": "Abrir página"
   },
   "integrations": {
     "title": "Integrações",

--- a/src/app/[locale]/(dashboard)/clients/page.tsx
+++ b/src/app/[locale]/(dashboard)/clients/page.tsx
@@ -662,8 +662,8 @@ function ManageView() {
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-2">
-                        <Button variant="ghost" size="icon" onClick={() => handleEdit(c)}><Edit className="h-4 w-4" /></Button>
-                        <Button variant="ghost" size="icon" onClick={() => handleDelete(c.id)}><Trash2 className="h-4 w-4 text-destructive" /></Button>
+                        <Button variant="ghost" size="icon" onClick={() => handleEdit(c)} aria-label={t('editClient')}><Edit className="h-4 w-4" /></Button>
+                        <Button variant="ghost" size="icon" onClick={() => handleDelete(c.id)} aria-label={t('deleteClient')}><Trash2 className="h-4 w-4 text-destructive" /></Button>
                       </div>
                     </TableCell>
                   </TableRow>

--- a/src/app/[locale]/(dashboard)/support/page.tsx
+++ b/src/app/[locale]/(dashboard)/support/page.tsx
@@ -309,6 +309,7 @@ export default function SupportPage() {
                         onClick={() => handleSendReply(ticket.id)}
                         disabled={submitting || !replyText[ticket.id]?.trim()}
                         className="self-end"
+                        aria-label={t('sendReply')}
                       >
                         <Send className="h-4 w-4" />
                       </Button>

--- a/src/components/dashboard/next-steps-card.tsx
+++ b/src/components/dashboard/next-steps-card.tsx
@@ -170,6 +170,7 @@ export function NextStepsCard() {
                   size="icon"
                   className="h-9 w-9 shrink-0"
                   onClick={() => copyToClipboard(landingUrl, 'landing')}
+                  aria-label={t('copyLink')}
                 >
                   {copied === 'landing'
                     ? <CheckCircle2 className="w-4 h-4 text-green-600" />
@@ -180,6 +181,7 @@ export function NextStepsCard() {
                   size="icon"
                   className="h-9 w-9 shrink-0"
                   onClick={() => window.open(landingUrl, '_blank')}
+                  aria-label={t('openPage')}
                 >
                   <ExternalLink className="w-4 h-4" />
                 </Button>

--- a/src/components/dashboard/schedule-manager.tsx
+++ b/src/components/dashboard/schedule-manager.tsx
@@ -274,6 +274,7 @@ export function ScheduleManager({
                         variant="ghost"
                         size="icon"
                         onClick={() => removeBlockedDate(bd.id)}
+                        aria-label={t('removeBlockedDate')}
                       >
                         <Trash2 className="h-4 w-4 text-destructive" />
                       </Button>
@@ -356,6 +357,7 @@ export function ScheduleManager({
                         variant="ghost"
                         size="icon"
                         onClick={() => removeBlockedPeriod(bp.id)}
+                        aria-label={t('removeBlockedPeriod')}
                       >
                         <Trash2 className="h-4 w-4 text-destructive" />
                       </Button>

--- a/src/components/dashboard/services-manager.tsx
+++ b/src/components/dashboard/services-manager.tsx
@@ -233,6 +233,7 @@ export function ServicesManager({
                       variant="ghost"
                       size="icon"
                       onClick={() => openEdit(service)}
+                      aria-label={tc('edit')}
                     >
                       <Pencil className="h-4 w-4" />
                     </Button>
@@ -243,6 +244,7 @@ export function ServicesManager({
                         setDeletingService(service);
                         setDeleteDialogOpen(true);
                       }}
+                      aria-label={tc('delete')}
                     >
                       <Trash2 className="h-4 w-4 text-destructive" />
                     </Button>


### PR DESCRIPTION
## Summary
- Added `aria-label` to 8 icon-only buttons across 5 components (services-manager, schedule-manager, next-steps-card, clients page, support page)
- Added translation keys for aria-labels in all 3 locales (pt-BR, en-US, es-ES)

Closes #199

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm test` — 101 files, 1443 tests pass
- [ ] Screen reader announces button purpose on each icon-only button

🤖 Generated with [Claude Code](https://claude.com/claude-code)