### PR TITLE
fix(db): payments.booking_id ON DELETE SET NULL (#200)

### DIFF
--- a/supabase/migrations/20260307000001_payments_booking_id_set_null.sql
+++ b/supabase/migrations/20260307000001_payments_booking_id_set_null.sql
@@ -1,0 +1,9 @@
+-- Fix #200: Change payments.booking_id from ON DELETE CASCADE to ON DELETE SET NULL
+-- Preserves payment records for audit/accounting when a booking is deleted.
+
+ALTER TABLE payments
+  DROP CONSTRAINT IF EXISTS payments_booking_id_fkey;
+
+ALTER TABLE payments
+  ADD CONSTRAINT payments_booking_id_fkey
+  FOREIGN KEY (booking_id) REFERENCES bookings(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- Changed `payments.booking_id` FK from `ON DELETE CASCADE` to `ON DELETE SET NULL`
- Preserves payment records when bookings are deleted (audit/accounting)

Closes #200

## Test plan
- [x] `npm test` — 101 files, 1443 tests pass
- [ ] Verify in Supabase: deleting a booking sets `payments.booking_id = NULL` instead of deleting the payment row

🤖 Generated with [Claude Code](https://claude.com/claude-code)