### PR TITLE
fix(security): remove GET /api/auth/signout CSRF vector (#201)

### DIFF
--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -23,8 +23,3 @@ export async function POST(request: Request) {
     return NextResponse.redirect(url, 303);
   }
 }
-
-export async function GET(request: Request) {
-  // Support GET method too for direct access
-  return POST(request);
-}


### PR DESCRIPTION
## Summary
- Removed GET handler from `/api/auth/signout` that allowed CSRF logout via `<img src="/api/auth/signout">`
- All existing callers already use POST (verified: layout.tsx, mobile-nav.tsx, verify-email-pending)

Closes #201

## Test plan
- [x] `npm test` — 101 files, 1443 tests pass
- [x] Verified all callers use `method="POST"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)