### PR TITLE
fix: replace ioredis url.parse() with WHATWG URL API (DEP0169) (#287)

### DIFF
--- a/src/lib/admin/session.ts
+++ b/src/lib/admin/session.ts
@@ -1,5 +1,6 @@
 import { createHmac, randomUUID } from 'crypto';
 import Redis from 'ioredis';
+import { parseRedisUrl } from '@/lib/redis/parse-url';
 
 const SESSION_EXPIRY_HOURS = 8;
 const SESSION_EXPIRY_SECONDS = SESSION_EXPIRY_HOURS * 60 * 60;
@@ -21,7 +22,8 @@ let redis: Redis | null = null;
 function getRedis(): Redis | null {
   if (!REDIS_URL) return null;
   if (redis) return redis;
-  redis = new Redis(REDIS_URL, {
+  redis = new Redis({
+    ...parseRedisUrl(REDIS_URL),
     maxRetriesPerRequest: 1,
     connectTimeout: 3000,
     commandTimeout: 3000,

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,4 +1,5 @@
 import Redis from 'ioredis';
+import { parseRedisUrl } from '@/lib/redis/parse-url';
 
 const REDIS_URL = process.env.STORAGE_URL || process.env.REDIS_URL;
 
@@ -7,7 +8,8 @@ let redis: Redis | null = null;
 function getRedis(): Redis | null {
   if (!REDIS_URL) return null;
   if (redis) return redis;
-  redis = new Redis(REDIS_URL, {
+  redis = new Redis({
+    ...parseRedisUrl(REDIS_URL),
     maxRetriesPerRequest: 1,
     connectTimeout: 3000,
     commandTimeout: 3000,

--- a/src/lib/redis/conversation-cache.ts
+++ b/src/lib/redis/conversation-cache.ts
@@ -1,5 +1,6 @@
 import { logger } from '@/lib/logger';
 import Redis from 'ioredis';
+import { parseRedisUrl } from './parse-url';
 import { redisKey } from './prefix';
 
 export interface ConversationMessage {
@@ -21,7 +22,8 @@ function getRedis(): Redis | null {
   if (!isConfigured) return null;
   if (redis) return redis;
 
-  redis = new Redis(REDIS_CONNECTION_URL!, {
+  redis = new Redis({
+    ...parseRedisUrl(REDIS_CONNECTION_URL!),
     maxRetriesPerRequest: 1,     // Falha rápido (não 3 tentativas lentas)
     connectTimeout: 3000,         // 3s timeout de conexão
     commandTimeout: 3000,         // 3s timeout por comando

--- a/src/lib/redis/parse-url.ts
+++ b/src/lib/redis/parse-url.ts
@@ -1,0 +1,17 @@
+import type { RedisOptions } from 'ioredis';
+
+/**
+ * Parses a Redis connection URL using the WHATWG URL API.
+ * Avoids Node.js DEP0169 deprecation warning from ioredis using url.parse().
+ */
+export function parseRedisUrl(redisUrl: string): RedisOptions {
+  const parsed = new URL(redisUrl);
+  return {
+    host: parsed.hostname,
+    port: parsed.port ? parseInt(parsed.port, 10) : 6379,
+    password: parsed.password || undefined,
+    username: parsed.username || undefined,
+    db: parsed.pathname ? parseInt(parsed.pathname.slice(1), 10) || 0 : 0,
+    tls: parsed.protocol === 'rediss:' ? {} : undefined,
+  };
+}

--- a/src/lib/webhooks/event-dedup.ts
+++ b/src/lib/webhooks/event-dedup.ts
@@ -1,4 +1,5 @@
 import Redis from 'ioredis';
+import { parseRedisUrl } from '@/lib/redis/parse-url';
 
 const EVENT_TTL_SECONDS = 72 * 60 * 60; // 72 hours (Stripe retries up to 3 days)
 
@@ -9,7 +10,8 @@ let redis: Redis | null = null;
 function getRedis(): Redis | null {
   if (!REDIS_URL) return null;
   if (redis) return redis;
-  redis = new Redis(REDIS_URL, {
+  redis = new Redis({
+    ...parseRedisUrl(REDIS_URL),
     maxRetriesPerRequest: 1,
     connectTimeout: 3000,
     commandTimeout: 3000,


### PR DESCRIPTION
## Summary
- Created shared `parseRedisUrl()` helper in `src/lib/redis/parse-url.ts` using WHATWG `new URL()` API
- Updated all 4 Redis connection sites to pass parsed options instead of URL string to ioredis
  - `src/lib/admin/session.ts`
  - `src/lib/webhooks/event-dedup.ts`
  - `src/lib/rate-limit.ts`
  - `src/lib/redis/conversation-cache.ts`
- Eliminates Node.js DEP0169 deprecation warning about `url.parse()` security implications

Closes #287

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm test` — 101 files, 1443 tests pass
- [ ] Verify no DEP0169 warning in dev console after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)