### PR TITLE
fix(security): add event age check to Stripe subscription webhook (#256)

### DIFF
--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getStripe } from '@/lib/stripe';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { logger } from '@/lib/logger';
 import Stripe from 'stripe';
 
 export async function POST(request: NextRequest) {
@@ -26,6 +27,14 @@ export async function POST(request: NextRequest) {
     event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
   } catch {
     return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  // Reject events older than 5 minutes (replay attack protection)
+  const EVENT_MAX_AGE_SECONDS = 300;
+  const eventAge = Math.floor(Date.now() / 1000) - event.created;
+  if (eventAge > EVENT_MAX_AGE_SECONDS) {
+    logger.warn('[stripe/webhook] rejected stale event', { id: event.id, age: eventAge });
+    return NextResponse.json({ error: 'Event too old' }, { status: 400 });
   }
 
   const supabase = createAdminClient();


### PR DESCRIPTION
## Summary
- Added 5-minute event age check to `/api/stripe/webhook` to reject stale/replayed events
- Matches the pattern already in `/api/webhooks/stripe-deposit`

Closes #256

## Test plan
- [x] `npm test` — 101 files, 1443 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)