### PR TITLE
fix(security): sanitize Stripe error messages in checkout (#257)

### DIFF
--- a/src/__tests__/security/stripe-connection-resilience.test.ts
+++ b/src/__tests__/security/stripe-connection-resilience.test.ts
@@ -72,10 +72,10 @@ describe('/api/bookings/checkout — error handling', () => {
   });
 
   it('rolls back booking on Stripe failure', () => {
-    // After the catch, it should cancel the booking
+    // After the Stripe session catch, it should cancel the booking
     const catchBlock = content.slice(
-      content.indexOf("logger.error('[bookings/checkout]"),
-      content.indexOf("logger.error('[bookings/checkout]") + 300
+      content.indexOf("Stripe session creation failed"),
+      content.indexOf("Stripe session creation failed") + 300
     );
     expect(catchBlock).toContain("status: 'cancelled'");
   });

--- a/src/app/api/bookings/checkout/route.ts
+++ b/src/app/api/bookings/checkout/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest) {
   if (!parsed.success) {
     const firstIssue = parsed.error.issues[0];
     return NextResponse.json(
-      { error: firstIssue?.message ?? 'Dados inválidos.', issues: parsed.error.issues },
+      { error: firstIssue?.message ?? 'Dados inválidos.' },
       { status: 400 }
     );
   }
@@ -101,7 +101,8 @@ export async function POST(request: NextRequest) {
           { status: 422 }
         );
       }
-    } catch {
+    } catch (err) {
+      logger.error('[bookings/checkout] Stripe account check failed', err);
       return NextResponse.json(
         { error: 'Não foi possível verificar a conta Stripe do profissional.' },
         { status: 502 }
@@ -192,7 +193,8 @@ export async function POST(request: NextRequest) {
         { status: 409 }
       );
     }
-    return NextResponse.json({ error: 'Failed to create booking' }, { status: 500 });
+    logger.error('[bookings/checkout] booking insert failed', bookingError);
+    return NextResponse.json({ error: 'Erro ao criar agendamento. Tente novamente.' }, { status: 500 });
   }
 
   // ─── 10. Calcular sinal + taxa plataforma ────────────────────────────────


### PR DESCRIPTION
## Summary
- Removed raw Zod `issues` array from validation error response (exposed internal field names)
- Added `logger.error` to Stripe account check and booking insert error paths
- All error responses now return generic user-friendly messages; details logged server-side only

Closes #257

## Test plan
- [x] `npm test` — 101 files, 1443 tests pass
- [x] Updated resilience test to use more specific search anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)