### PR TITLE
fix(security): reject deposit value <= 0 in checkout (#258)

### DIFF
--- a/src/app/api/bookings/checkout/route.ts
+++ b/src/app/api/bookings/checkout/route.ts
@@ -110,7 +110,7 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  if (!prof.require_deposit || !prof.deposit_type || prof.deposit_value == null) {
+  if (!prof.require_deposit || !prof.deposit_type || prof.deposit_value == null || prof.deposit_value <= 0) {
     return NextResponse.json(
       { error: 'Sinal não configurado.' },
       { status: 422 }


### PR DESCRIPTION
## Summary
- Added `prof.deposit_value <= 0` check to deposit validation guard in checkout route
- Prevents creating Stripe checkout sessions with zero or negative amounts

Closes #258

## Test plan
- [x] `npm test` — 101 files, 1443 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)