### PR TITLE
fix: use NEXT_PUBLIC_BASE_URL for cron reminder URLs (#259)

### DIFF
--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -161,8 +161,9 @@ export async function POST(request: NextRequest) {
           .eq('booking_id', booking.id)
           .single();
 
+        const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://booking.circlehood-tech.com';
         const rescheduleLink = tokenData
-          ? `\n\nPara reagendar ou cancelar:\nhttps://circlehood-booking.vercel.app/reschedule/${tokenData.token}`
+          ? `\n\nPara reagendar ou cancelar:\n${baseUrl}/reschedule/${tokenData.token}`
           : '';
 
         // Formatar mensagem


### PR DESCRIPTION
## Summary
- Replaced hardcoded `circlehood-booking.vercel.app` with `process.env.NEXT_PUBLIC_BASE_URL` in reschedule link generation within send-reminders cron

Closes #259

## Test plan
- [x] `npm test` — 101 files, 1443 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)