### PR TITLE
fix(security): add body size validation to tickets and testimonials (#261)

### DIFF
--- a/src/app/api/support/tickets/route.ts
+++ b/src/app/api/support/tickets/route.ts
@@ -30,7 +30,14 @@ export async function GET() {
 }
 
 // ─── POST — create new ticket + AI bot auto-response ──────────────────────────
+const MAX_BODY_SIZE = 1_048_576; // 1 MB
+
 export async function POST(request: NextRequest) {
+  const contentLength = parseInt(request.headers.get('content-length') ?? '0', 10);
+  if (contentLength > MAX_BODY_SIZE) {
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+  }
+
   const supabase = await createClient();
   const {
     data: { user },

--- a/src/app/api/testimonials/route.ts
+++ b/src/app/api/testimonials/route.ts
@@ -78,7 +78,14 @@ export async function GET(request: NextRequest) {
 }
 
 // POST - Criar um novo depoimento
+const MAX_BODY_SIZE = 1_048_576; // 1 MB
+
 export async function POST(request: NextRequest) {
+  const contentLength = parseInt(request.headers.get('content-length') ?? '0', 10);
+  if (contentLength > MAX_BODY_SIZE) {
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+  }
+
   const body = await request.json();
   const {
     client_name,


### PR DESCRIPTION
## Summary
- Added Content-Length > 1MB check (returns 413) to POST handlers in:
  - `/api/support/tickets/route.ts`
  - `/api/testimonials/route.ts`

Closes #261

## Test plan
- [x] `npm test` — 101 files, 1443 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)