### PR TITLE
fix(security): admin session fail-secure when Redis offline (#262)

### DIFF
--- a/src/__tests__/security/admin-session-serverless.test.ts
+++ b/src/__tests__/security/admin-session-serverless.test.ts
@@ -5,8 +5,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
  *
  * On Vercel, each serverless function has its own in-memory store.
  * A session created in one instance may not exist in another's memory.
- * Without Redis, validation must gracefully accept tokens with valid
- * HMAC+timestamp rather than locking out the user.
+ * Without Redis, validation fails secure — unknown sessions are rejected.
+ * Redis is required for cross-instance session persistence.
  */
 
 describe('Admin session serverless cross-instance behavior', () => {
@@ -31,7 +31,7 @@ describe('Admin session serverless cross-instance behavior', () => {
     expect(await validateAdminToken(token)).toBe(true);
   });
 
-  it('token is accepted in a fresh instance (simulating cross-instance)', async () => {
+  it('token is rejected in a fresh instance without Redis (fail-secure)', async () => {
     // Instance A generates the token
     const { generateAdminToken } = await import('@/lib/admin/session');
     const { token } = await generateAdminToken();
@@ -43,8 +43,8 @@ describe('Admin session serverless cross-instance behavior', () => {
     delete process.env.REDIS_URL;
 
     const { validateAdminToken } = await import('@/lib/admin/session');
-    // Instance B has no memory of this session, but HMAC+timestamp are valid
-    expect(await validateAdminToken(token)).toBe(true);
+    // Instance B has no memory of this session and no Redis — fail-secure rejects
+    expect(await validateAdminToken(token)).toBe(false);
   });
 
   it('revoked token is rejected in same instance', async () => {

--- a/src/lib/admin/session.ts
+++ b/src/lib/admin/session.ts
@@ -65,8 +65,8 @@ async function sessionExists(sessionId: string, tokenTimestamp?: number): Promis
       // 2. Stored in another serverless instance's memory — should accept
       // We can't distinguish, so check if we know about this session locally.
       if (memorySessions.has(sessionId)) return false; // We stored it, then Redis lost it — expired
-      // Unknown session: on serverless, accept gracefully since HMAC+timestamp are already valid
-      return true;
+      // Unknown session: fail-secure — reject unknown tokens
+      return false;
     } catch { /* Redis error — fall through to memory */ }
   }
   // No Redis available
@@ -78,11 +78,8 @@ async function sessionExists(sessionId: string, tokenTimestamp?: number): Promis
     }
     return true;
   }
-  // Session not found in memory and no Redis. On serverless (Vercel), this happens
-  // when the session was stored in a different instance's memory. Since the token's
-  // HMAC signature and timestamp have already been validated by the caller, accept
-  // the token gracefully rather than locking the user out.
-  return true;
+  // Session not found in memory and no Redis — fail-secure: reject unknown tokens
+  return false;
 }
 
 async function deleteSession(sessionId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Changed `sessionExists()` to return `false` for unknown sessions (was `true`)
- Prevents accepting forged tokens with valid HMAC when Redis is unavailable
- Two fail-open paths fixed: Redis key missing + no Redis available

Closes #262

## Test plan
- [x] `npm test` — 101 files, 1442 tests pass
- [x] Updated cross-instance test to expect rejection (fail-secure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)