### PR TITLE
perf(db): add index on bookings.service_id (#202)

### DIFF
--- a/supabase/migrations/20260307000003_idx_bookings_service_id.sql
+++ b/supabase/migrations/20260307000003_idx_bookings_service_id.sql
@@ -1,0 +1,2 @@
+-- Fix #202: Add missing index on bookings.service_id (most used FK in JOINs)
+CREATE INDEX IF NOT EXISTS idx_bookings_service_id ON bookings(service_id);


### PR DESCRIPTION
## Summary
- Added `idx_bookings_service_id` index on `bookings(service_id)` — most used FK in JOINs

Closes #202

## Test plan
- [x] `npm test` — 101 files, 1442 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)