### PR TITLE
fix: remove redundant crons and stagger schedules (#206)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -20,52 +20,44 @@
   ],
   "crons": [
     {
-      "path": "/api/cron/send-reminders",
-      "schedule": "0 10 * * *"
-    },
-    {
-      "path": "/api/cron/refresh-analytics",
-      "schedule": "0 0 * * *"
-    },
-    {
       "path": "/api/cron/cleanup-tokens",
       "schedule": "0 2 * * *"
-    },
-    {
-      "path": "/api/cron/expire-waitlist",
-      "schedule": "0 4 * * *"
-    },
-    {
-      "path": "/api/cron/reminders",
-      "schedule": "0 20 * * *"
-    },
-    {
-      "path": "/api/cron/birthdays",
-      "schedule": "0 8 * * *"
-    },
-    {
-      "path": "/api/cron/send-campaign-messages",
-      "schedule": "0 9 * * *"
-    },
-    {
-      "path": "/api/cron/send-maintenance-reminders",
-      "schedule": "0 11 * * *"
     },
     {
       "path": "/api/cron/process-deletions",
       "schedule": "0 3 * * *"
     },
     {
-      "path": "/api/cron/send-retention-emails",
-      "schedule": "0 9 * * *"
-    },
-    {
-      "path": "/api/cron/send-trial-expiration-notifications",
-      "schedule": "0 10 * * *"
+      "path": "/api/cron/expire-waitlist",
+      "schedule": "0 4 * * *"
     },
     {
       "path": "/api/cron/expire-pending-payments",
       "schedule": "30 5 * * *"
+    },
+    {
+      "path": "/api/cron/birthdays",
+      "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/send-retention-emails",
+      "schedule": "15 9 * * *"
+    },
+    {
+      "path": "/api/cron/send-reminders",
+      "schedule": "0 10 * * *"
+    },
+    {
+      "path": "/api/cron/send-trial-expiration-notifications",
+      "schedule": "15 10 * * *"
+    },
+    {
+      "path": "/api/cron/send-maintenance-reminders",
+      "schedule": "0 11 * * *"
+    },
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "0 20 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Removed `refresh-analytics` cron (analytics now compute live)
- Removed `send-campaign-messages` cron (campaigns disabled in UI)
- Staggered `send-retention-emails` 09:00 → 09:15 (was colliding)
- Staggered `send-trial-expiration-notifications` 10:00 → 10:15
- Sorted crons chronologically for clarity

Closes #206

## Test plan
- [x] `npm test` — 101 files, 1442 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)