### PR TITLE
fix(security): add rate limiting to testimonials and waitlist POST (#210)

### DIFF
--- a/src/app/api/testimonials/route.ts
+++ b/src/app/api/testimonials/route.ts
@@ -1,6 +1,7 @@
 import { logger } from '@/lib/logger';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { isRateLimited } from '@/lib/rate-limit';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
@@ -81,6 +82,11 @@ export async function GET(request: NextRequest) {
 const MAX_BODY_SIZE = 1_048_576; // 1 MB
 
 export async function POST(request: NextRequest) {
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  if (await isRateLimited(`testimonials:${ip}`, 5, 60)) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   const contentLength = parseInt(request.headers.get('content-length') ?? '0', 10);
   if (contentLength > MAX_BODY_SIZE) {
     return NextResponse.json({ error: 'Payload too large' }, { status: 413 });

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -1,5 +1,6 @@
 import { logger } from '@/lib/logger';
 import { createClient } from '@/lib/supabase/server';
+import { isRateLimited } from '@/lib/rate-limit';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
@@ -62,6 +63,11 @@ export async function GET(request: NextRequest) {
 
 // POST - Adicionar na waitlist (Public)
 export async function POST(request: NextRequest) {
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  if (await isRateLimited(`waitlist:${ip}`, 5, 60)) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   const supabase = await createClient();
   const body = await request.json();
 


### PR DESCRIPTION
## Summary
- Added IP-based rate limiting (5 req/min) to public POST endpoints:
  - `/api/testimonials` — prevents testimonial spam
  - `/api/waitlist` — prevents waitlist spam
- Uses existing `isRateLimited()` utility (Redis with in-memory fallback)

Closes #210

## Test plan
- [x] `npm test` — 101 files, 1442 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)