### PR TITLE
fix(security): use constant-time comparison for admin password (#301)

### DIFF
--- a/src/app/api/admin/auth/route.ts
+++ b/src/app/api/admin/auth/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
 import { generateAdminToken, revokeAdminToken, isRateLimited } from '@/lib/admin/session';
 
 export async function POST(request: NextRequest) {
@@ -13,7 +14,13 @@ export async function POST(request: NextRequest) {
 
   const { password } = await request.json();
 
-  if (!process.env.ADMIN_PASSWORD || password !== process.env.ADMIN_PASSWORD) {
+  const expected = process.env.ADMIN_PASSWORD;
+  if (
+    !expected ||
+    typeof password !== 'string' ||
+    password.length !== expected.length ||
+    !timingSafeEqual(Buffer.from(password), Buffer.from(expected))
+  ) {
     return NextResponse.json({ error: 'Senha incorreta' }, { status: 401 });
   }
 


### PR DESCRIPTION
## Summary
- Replace `password !== process.env.ADMIN_PASSWORD` with `crypto.timingSafeEqual` to prevent timing attacks
- Add `typeof` and length checks before comparison as defense-in-depth

Closes #301

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 101 files, 1442 tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)