### PR TITLE
fix(perf): add missing index on bookings.professional_id (#304)

### DIFF
--- a/supabase/migrations/20260307000004_idx_bookings_professional_id.sql
+++ b/supabase/migrations/20260307000004_idx_bookings_professional_id.sql
@@ -1,0 +1,2 @@
+-- Fix #304: Add missing index on bookings.professional_id (most used FK in RLS filters)
+CREATE INDEX IF NOT EXISTS idx_bookings_professional_id ON bookings(professional_id);


### PR DESCRIPTION
## Summary
- Add `idx_bookings_professional_id` index to eliminate full table scans on RLS-filtered booking queries

Closes #304

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1442 tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)