### PR TITLE
fix(perf): add missing index on services.professional_id (#305)

### DIFF
--- a/supabase/migrations/20260307000005_idx_services_professional_id.sql
+++ b/supabase/migrations/20260307000005_idx_services_professional_id.sql
@@ -1,0 +1,2 @@
+-- Fix #305: Add missing index on services.professional_id (public booking page lookups)
+CREATE INDEX IF NOT EXISTS idx_services_professional_id ON services(professional_id);


### PR DESCRIPTION
## Summary
- Add `idx_services_professional_id` index to eliminate full table scans on public booking page service lookups

Closes #305

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1442 tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)