### PR TITLE
fix(security): add rate limit and token cleanup to reschedule endpoint (#307)

### DIFF
--- a/src/app/api/reschedule/[token]/change/route.ts
+++ b/src/app/api/reschedule/[token]/change/route.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/lib/logger';
+import { isRateLimited } from '@/lib/rate-limit';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
@@ -47,6 +48,11 @@ export async function POST(
       return NextResponse.json({ error: 'Agendamento já cancelado' }, { status: 400 });
     }
 
+    // Rate limit per booking: max 5 reschedules per hour
+    if (await isRateLimited(`reschedule:${tokenData.bookings.id}`, 5, 3600)) {
+      return NextResponse.json({ error: 'Muitas tentativas de reagendamento. Tente novamente mais tarde.' }, { status: 429 });
+    }
+
     // Verificar se novo horário está disponível
     const { data: existingBooking } = await supabase
       .from('bookings')
@@ -82,6 +88,14 @@ export async function POST(
         used_at: new Date().toISOString(),
       })
       .eq('id', tokenData.id);
+
+    // Invalidar tokens antigos não usados para este booking
+    await supabase
+      .from('reschedule_tokens')
+      .update({ used: true, used_at: new Date().toISOString() })
+      .eq('booking_id', tokenData.bookings.id)
+      .eq('used', false)
+      .neq('id', tokenData.id);
 
     // Criar novo token para o booking atualizado
     await supabase.from('reschedule_tokens').insert({


### PR DESCRIPTION
## Summary
- Rate limit reschedule attempts per booking_id (max 5 per hour)
- Invalidate all unused tokens for the booking before creating a new one (prevents accumulation)
- Prevents DoS via token spam and repeated reschedules

Closes #307

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1442 tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)