### PR TITLE
fix(security): require verified email before Stripe Connect account creation (#308)

### DIFF
--- a/src/app/api/stripe/connect/create-account/route.ts
+++ b/src/app/api/stripe/connect/create-account/route.ts
@@ -27,6 +27,13 @@ export async function POST(_request: NextRequest) {
       return NextResponse.json({ error: 'Professional not found' }, { status: 404 });
     }
 
+    if (!user.email_confirmed_at) {
+      return NextResponse.json(
+        { error: 'Email must be verified before connecting Stripe' },
+        { status: 403 }
+      );
+    }
+
     const stripe = getStripeServer();
     if (!stripe) {
       logger.error('[stripe/connect/create-account] STRIPE_SECRET_KEY not set');


### PR DESCRIPTION
## Summary
- Check `user.email_confirmed_at` before allowing Stripe Connect account creation
- Returns 403 if email is not verified

Closes #308

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1442 tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)