### PR TITLE
fix(security): set admin session cookie SameSite to strict (#312)

### DIFF
--- a/src/app/api/admin/auth/route.ts
+++ b/src/app/api/admin/auth/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
   response.cookies.set('admin_session', token, {
     httpOnly: true,
     secure: true,
-    sameSite: 'lax',
+    sameSite: 'strict',
     path: '/',
     expires,
   });


### PR DESCRIPTION
## Summary
- Change `sameSite` from `'lax'` to `'strict'` on admin_session cookie
- `secure: true` was already set (line 24)

Closes #312

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1442 tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)