### PR TITLE
fix: validate reschedule time against professional working hours (#313)

### DIFF
--- a/src/app/api/reschedule/[token]/change/route.ts
+++ b/src/app/api/reschedule/[token]/change/route.ts
@@ -47,6 +47,29 @@ export async function POST(
       return NextResponse.json({ error: 'Agendamento já cancelado' }, { status: 400 });
     }
 
+    // Verificar se novo horário está dentro do working hours do profissional
+    const dateObj = new Date(`${new_date}T00:00:00`);
+    const dayOfWeek = dateObj.getDay(); // 0=Sunday, 1=Monday, ...
+
+    const { data: workingHours } = await supabase
+      .from('working_hours')
+      .select('start_time, end_time')
+      .eq('professional_id', tokenData.bookings.professional_id)
+      .eq('day_of_week', dayOfWeek);
+
+    if (!workingHours || workingHours.length === 0) {
+      return NextResponse.json({ error: 'Profissional não atende neste dia da semana' }, { status: 400 });
+    }
+
+    const requestedTime = `${new_time}:00`;
+    const withinWorkingHours = workingHours.some(
+      (wh) => requestedTime >= wh.start_time && requestedTime < wh.end_time
+    );
+
+    if (!withinWorkingHours) {
+      return NextResponse.json({ error: 'Horário fora do expediente do profissional' }, { status: 400 });
+    }
+
     // Verificar se novo horário está disponível
     const { data: existingBooking } = await supabase
       .from('bookings')


### PR DESCRIPTION
## Summary
- Query `working_hours` table for the professional's schedule on the requested day
- Reject if no working hours configured for that day of week
- Reject if requested time falls outside working hours range
- Runs before the slot conflict check

Closes #313

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1442 tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)