### PR TITLE
fix(perf): add composite index on waitlist(professional_id, service_id) (#314)

### DIFF
--- a/supabase/migrations/20260307000006_idx_waitlist_professional_service.sql
+++ b/supabase/migrations/20260307000006_idx_waitlist_professional_service.sql
@@ -1,0 +1,2 @@
+-- Fix #314: Add composite index on waitlist(professional_id, service_id)
+CREATE INDEX IF NOT EXISTS idx_waitlist_professional_service ON waitlist(professional_id, service_id);


### PR DESCRIPTION
## Summary
- Add composite index `idx_waitlist_professional_service` for waitlist queries that filter by both columns

Closes #314

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1442 tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)