### PR TITLE
fix: standardize rate limit key naming to rl:{route}:{id} (#315)

### DIFF
--- a/src/__tests__/security/translate-auth.test.ts
+++ b/src/__tests__/security/translate-auth.test.ts
@@ -28,7 +28,7 @@ describe('/api/translate — security', () => {
   });
 
   it('applies rate limiting per user', () => {
-    expect(content).toMatch(/isRateLimited\(`translate:\$\{user\.id\}`/);
+    expect(content).toMatch(/isRateLimited\(`rl:translate:\$\{user\.id\}`/);
   });
 
   it('returns 429 when rate limited', () => {

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
 
   // Rate limiting por IP — 10 attempts per hour
   const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  if (await isRateLimited(`verify:${ip}`, 10, 3600)) {
+  if (await isRateLimited(`rl:verify-email:${ip}`, 10, 3600)) {
     return NextResponse.redirect(`${baseUrl}/login?error=too_many_attempts`);
   }
 

--- a/src/app/api/available-slots/route.ts
+++ b/src/app/api/available-slots/route.ts
@@ -8,7 +8,7 @@ const SLOTS_RATE_WINDOW = 60; // 1 minute in seconds
 export async function GET(request: NextRequest) {
   // ─── Rate limiting por IP ──────────────────────────────────────────
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  if (await isRateLimited(`available-slots:${ip}`, SLOTS_RATE_LIMIT, SLOTS_RATE_WINDOW)) {
+  if (await isRateLimited(`rl:available-slots:${ip}`, SLOTS_RATE_LIMIT, SLOTS_RATE_WINDOW)) {
     return NextResponse.json(
       { error: 'Too many requests. Try again later.' },
       { status: 429 }

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -15,7 +15,7 @@ const BOOKING_RATE_WINDOW = 3600; // 1 hour in seconds
 export async function POST(request: NextRequest) {
   // ─── Rate limiting por IP ──────────────────────────────────────────
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  if (await isRateLimited(`booking:${ip}`, BOOKING_RATE_LIMIT, BOOKING_RATE_WINDOW)) {
+  if (await isRateLimited(`rl:booking:${ip}`, BOOKING_RATE_LIMIT, BOOKING_RATE_WINDOW)) {
     return NextResponse.json(
       { error: 'Muitas tentativas. Tente novamente mais tarde.' },
       { status: 429 }

--- a/src/app/api/email-campaigns/[id]/send/route.ts
+++ b/src/app/api/email-campaigns/[id]/send/route.ts
@@ -32,7 +32,7 @@ export async function POST(
   }
 
   // Rate limiting por professional_id — 5 campaigns per hour
-  if (await isRateLimited(`campaign-send:${professional.id}`, CAMPAIGN_RATE_LIMIT, CAMPAIGN_RATE_WINDOW)) {
+  if (await isRateLimited(`rl:campaign-send:${professional.id}`, CAMPAIGN_RATE_LIMIT, CAMPAIGN_RATE_WINDOW)) {
     return NextResponse.json(
       { error: 'Too many campaigns sent. Try again later.' },
       { status: 429 }

--- a/src/app/api/testimonials/route.ts
+++ b/src/app/api/testimonials/route.ts
@@ -83,7 +83,7 @@ const MAX_BODY_SIZE = 1_048_576; // 1 MB
 
 export async function POST(request: NextRequest) {
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  if (await isRateLimited(`testimonials:${ip}`, 5, 60)) {
+  if (await isRateLimited(`rl:testimonials:${ip}`, 5, 60)) {
     return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
   }
 

--- a/src/app/api/translate/route.ts
+++ b/src/app/api/translate/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
     }
 
     // 20 translation requests per minute per user
-    const limited = await isRateLimited(`translate:${user.id}`, 20, 60);
+    const limited = await isRateLimited(`rl:translate:${user.id}`, 20, 60);
     if (limited) {
       return Response.json({ error: 'Too many requests' }, { status: 429 });
     }

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -64,7 +64,7 @@ export async function GET(request: NextRequest) {
 // POST - Adicionar na waitlist (Public)
 export async function POST(request: NextRequest) {
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  if (await isRateLimited(`waitlist:${ip}`, 5, 60)) {
+  if (await isRateLimited(`rl:waitlist:${ip}`, 5, 60)) {
     return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
   }
 


### PR DESCRIPTION
## Summary
- Prefix all rate limit keys with `rl:` for consistent naming: `rl:waitlist:`, `rl:testimonials:`, `rl:booking:`, `rl:available-slots:`, `rl:translate:`, `rl:verify-email:`, `rl:campaign-send:`
- Updated test that checked old key format

Closes #315

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1442 tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)