### PR TITLE
fix: add defensive limit to page-sections GET (#317)

### DIFF
--- a/src/app/api/page-sections/route.ts
+++ b/src/app/api/page-sections/route.ts
@@ -117,12 +117,13 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    // Buscar todas as seções
+    // Buscar seções (max 7 types per professional, limit as defensive guard)
     const { data: sections, error } = await supabase
       .from('page_sections')
       .select('*')
       .eq('professional_id', professional.id)
-      .order('order_index', { ascending: true });
+      .order('order_index', { ascending: true })
+      .limit(50);
 
     if (error) throw error;
 


### PR DESCRIPTION
## Summary
- Added `.limit(50)` defensive guard to page-sections GET query
- Note: actual max is 7 rows (unique constraint on professional_id + section_type with 7 valid types)
- Full pagination not needed — page editor UI requires all sections at once

Closes #317

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 1442 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)