### PR TITLE
fix: add limit/offset pagination to page-sections GET (#317)

### DIFF
--- a/src/app/api/page-sections/route.ts
+++ b/src/app/api/page-sections/route.ts
@@ -92,7 +92,10 @@ const dataSchemaMap: Record<ValidSectionType, z.ZodType> = {
   contact: contactDataSchema,
 };
 
-// GET - Buscar todas as seções do profissional
+// GET - Buscar seções do profissional (com paginação)
+const MAX_LIMIT = 50;
+const DEFAULT_LIMIT = 50;
+
 export async function GET(request: NextRequest) {
   const supabase = await createClient();
 
@@ -116,13 +119,21 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Professional not found' }, { status: 404 });
   }
 
+  // Pagination params
+  const { searchParams } = new URL(request.url);
+  const limit = Math.min(
+    Math.max(parseInt(searchParams.get('limit') ?? String(DEFAULT_LIMIT), 10) || DEFAULT_LIMIT, 1),
+    MAX_LIMIT
+  );
+  const offset = Math.max(parseInt(searchParams.get('offset') ?? '0', 10) || 0, 0);
+
   try {
-    // Buscar todas as seções
     const { data: sections, error } = await supabase
       .from('page_sections')
       .select('*')
       .eq('professional_id', professional.id)
-      .order('order_index', { ascending: true });
+      .order('order_index', { ascending: true })
+      .range(offset, offset + limit - 1);
 
     if (error) throw error;
 


### PR DESCRIPTION
## Summary
- Added `limit` and `offset` query params to `GET /api/page-sections`
- `limit`: default 50, max 50, min 1
- `offset`: default 0, min 0
- Uses Supabase `.range()` for proper server-side pagination

Closes #317

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 1442 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)