### PR TITLE
fix(security): add public flow rate limit and UUID validation to testimonials (#247)

### DIFF
--- a/src/app/api/testimonials/route.ts
+++ b/src/app/api/testimonials/route.ts
@@ -113,6 +113,20 @@ export async function POST(request: NextRequest) {
 
   // ── Fluxo público (professional_id no body → visitante enviando depoimento) ──
   if (bodyProfessionalId) {
+    // Validate UUID format
+    if (!z.string().uuid().safeParse(bodyProfessionalId).success) {
+      return NextResponse.json({ error: 'Invalid professional ID' }, { status: 400 });
+    }
+
+    // Tighter rate limit for public submissions: 5/hour per IP
+    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    if (await isRateLimited(`rl:testimonials-public:${ip}`, 5, 3600)) {
+      return NextResponse.json(
+        { error: 'Too many submissions. Try again later.' },
+        { status: 429 }
+      );
+    }
+
     try {
       const adminClient = createAdminClient();
 


### PR DESCRIPTION
## O que foi feito
- Added tighter rate limit (5/hour per IP) specifically for the public testimonial submission flow (anonymous visitors), on top of the existing general 5/min rate limit
- Added UUID validation on `professional_id` before passing to admin client
- Previous PR #271 was closed as stale (branch far behind main)

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)