### PR TITLE
fix(security): add rate limit and token cleanup to reschedule endpoint (#307)

### DIFF
--- a/src/app/api/reschedule/[token]/change/route.ts
+++ b/src/app/api/reschedule/[token]/change/route.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/lib/logger';
+import { isRateLimited } from '@/lib/rate-limit';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
@@ -54,6 +55,14 @@ export async function POST(
       return NextResponse.json({ error: 'Agendamento já cancelado' }, { status: 400 });
     }
 
+    // Rate limit per booking: max 5 reschedules per hour
+    if (await isRateLimited(`rl:reschedule:${tokenData.bookings.id}`, 5, 3600)) {
+      return NextResponse.json(
+        { error: 'Muitas tentativas de reagendamento. Tente novamente mais tarde.' },
+        { status: 429 }
+      );
+    }
+
     // Rejeitar datas no passado
     const now = new Date();
     const requestedDate = new Date(`${new_date}T${new_time}:00`);
@@ -96,6 +105,14 @@ export async function POST(
         used_at: new Date().toISOString(),
       })
       .eq('id', tokenData.id);
+
+    // Invalidar old unused tokens for this booking (prevent accumulation)
+    await supabase
+      .from('reschedule_tokens')
+      .update({ used: true, used_at: new Date().toISOString() })
+      .eq('booking_id', tokenData.bookings.id)
+      .eq('used', false)
+      .neq('id', tokenData.id);
 
     // Criar novo token para o booking atualizado
     await supabase.from('reschedule_tokens').insert({


### PR DESCRIPTION
## O que foi feito
- Added rate limit per `booking_id` (5 reschedules/hour) to prevent spam
- After each reschedule, invalidate all old unused tokens for that booking to prevent token accumulation in DB
- Preserves all existing validation (date format, past date rejection, slot conflict check)

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)