### PR TITLE
fix(security): use professionals.id instead of auth user.id in Instagram routes (#193)

### DIFF
--- a/src/app/api/integrations/instagram/callback/route.ts
+++ b/src/app/api/integrations/instagram/callback/route.ts
@@ -53,11 +53,24 @@ export async function GET(request: NextRequest) {
     const expiresAt = new Date()
     expiresAt.setSeconds(expiresAt.getSeconds() + expiresIn)
 
+    // Buscar professional_id real
+    const { data: professional } = await supabase
+      .from('professionals')
+      .select('id')
+      .eq('user_id', user.id)
+      .single();
+
+    if (!professional) {
+      return NextResponse.redirect(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/integrations?error=professional_not_found`
+      );
+    }
+
     // Salvar integração no banco
     const { error: dbError } = await supabase
       .from('integrations')
       .upsert({
-        professional_id: user.id,
+        professional_id: professional.id,
         type: 'instagram',
         access_token: encryptToken(longToken),
         refresh_token: null,

--- a/src/app/api/integrations/instagram/post/route.ts
+++ b/src/app/api/integrations/instagram/post/route.ts
@@ -23,11 +23,22 @@ export async function POST(request: NextRequest) {
     )
   }
 
+  // Buscar professional_id real
+  const { data: professional } = await supabase
+    .from('professionals')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (!professional) {
+    return NextResponse.json({ error: 'Professional not found' }, { status: 404 });
+  }
+
   // Buscar integração ativa
   const { data: integration, error: integrationError } = await supabase
     .from('integrations')
     .select('*')
-    .eq('professional_id', user.id)
+    .eq('professional_id', professional.id)
     .eq('type', 'instagram')
     .eq('is_active', true)
     .single()
@@ -70,7 +81,7 @@ export async function POST(request: NextRequest) {
     const { data: post, error: postError } = await supabase
       .from('instagram_posts')
       .insert({
-        professional_id: user.id,
+        professional_id: professional.id,
         integration_id: integration.id,
         post_type: postType,
         caption,
@@ -107,7 +118,7 @@ export async function POST(request: NextRequest) {
     await supabase
       .from('instagram_posts')
       .insert({
-        professional_id: user.id,
+        professional_id: professional.id,
         integration_id: integration.id,
         post_type: postType,
         caption,


### PR DESCRIPTION
## O que foi feito
- Instagram callback and post routes used `user.id` (auth.users.id) as `professional_id`, but the column references `professionals.id`
- Added professionals table lookup via `user_id` → `professionals.id` in both routes
- All 3 occurrences of `professional_id: user.id` replaced with `professional_id: professional.id`

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)