### PR TITLE
fix(security): replace in-memory rate limit with Redis-backed isRateLimited (#342)

### DIFF
--- a/src/__tests__/security/create-intent-validation.test.ts
+++ b/src/__tests__/security/create-intent-validation.test.ts
@@ -19,7 +19,7 @@ const source = readFileSync(routePath, 'utf-8');
 describe('create-intent rate limiting (issue #183)', () => {
   it('has rate limiting implementation', () => {
     expect(source).toContain('isRateLimited');
-    expect(source).toContain('rateLimitMap');
+    expect(source).toContain("from '@/lib/rate-limit'");
   });
 
   it('returns 429 when rate limited', () => {

--- a/src/app/api/payment/create-intent/route.ts
+++ b/src/app/api/payment/create-intent/route.ts
@@ -3,29 +3,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { getStripeServer } from '@/lib/stripe/server';
 import { calculateDeposit, toCents } from '@/lib/payment/calculate-deposit';
+import { isRateLimited } from '@/lib/rate-limit';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-// Simple IP-based rate limiting (in-memory, per serverless instance)
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
-const RATE_LIMIT_MAX = 10; // max requests per window
-const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
-
-function isRateLimited(ip: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(ip);
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return false;
-  }
-  entry.count++;
-  return entry.count > RATE_LIMIT_MAX;
-}
-
 export async function POST(request: NextRequest) {
-  // Rate limit by IP
+  // Rate limit by IP (Redis-backed, survives serverless cold starts)
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  if (isRateLimited(ip)) {
+  if (await isRateLimited(`rl:payment-intent:${ip}`, 10, 60)) {
     return NextResponse.json(
       { error: 'Muitas tentativas. Aguarde um momento.' },
       { status: 429 }


### PR DESCRIPTION
## Summary
- Replaces local `Map()`-based rate limiter in `create-intent` with Redis-backed `isRateLimited()` from `@/lib/rate-limit`
- In-memory Map resets on every serverless cold start, allowing bypass via distributed requests
- Updated test to verify Redis import instead of `rateLimitMap`

Closes #342

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 1442 tests pass (updated assertion in create-intent-validation.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)