### PR TITLE
fix(security): handle slug race condition via unique_violation catch (#343)

### DIFF
--- a/src/app/api/auth/complete-profile/route.ts
+++ b/src/app/api/auth/complete-profile/route.ts
@@ -74,6 +74,10 @@ export async function POST(req: NextRequest) {
     } as never);
 
   if (insertError) {
+    // 23505 = unique_violation — slug race condition (two concurrent registrations)
+    if (insertError.code === '23505' && insertError.message?.includes('slug')) {
+      return NextResponse.json({ error: 'Este link já está em uso.' }, { status: 400 });
+    }
     logger.error('[complete-profile] insert error:', insertError);
     return NextResponse.json({ error: 'Erro ao criar perfil.' }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- Catches PostgreSQL `23505` (unique_violation) on insert in `complete-profile` when slug collides
- Returns same user-friendly error "Este link já está em uso." instead of generic 500
- Pre-check (`.maybeSingle()`) remains for fast UX feedback; DB constraint is the race-safe guard

Closes #343

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 1442 tests pass
- [x] Verified `slug VARCHAR(100) UNIQUE NOT NULL` constraint exists in init migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)