### PR TITLE
fix(security): validate Evolution API instance ownership (#345)

### DIFF
--- a/src/app/api/evolution/check-connection/route.ts
+++ b/src/app/api/evolution/check-connection/route.ts
@@ -21,12 +21,17 @@ export async function GET(request: NextRequest) {
     // Buscar token da instância no Supabase
     const { data: config } = await supabase
       .from('whatsapp_config')
-      .select('evolution_api_url, evolution_api_key')
+      .select('evolution_api_url, evolution_api_key, evolution_instance')
       .eq('user_id', user.id)
       .single();
 
     if (!config?.evolution_api_key) {
       return NextResponse.json({ connected: false });
+    }
+
+    // Validate instance belongs to this user
+    if (config.evolution_instance !== instance) {
+      return NextResponse.json({ error: 'Instance not authorized' }, { status: 403 });
     }
 
     const res = await fetch(`${config.evolution_api_url}/instance/connectionState/${instance}`, {

--- a/src/app/api/evolution/get-qrcode/route.ts
+++ b/src/app/api/evolution/get-qrcode/route.ts
@@ -21,12 +21,17 @@ export async function GET(request: NextRequest) {
     // Buscar token da instância no Supabase
     const { data: config } = await supabase
       .from('whatsapp_config')
-      .select('evolution_api_url, evolution_api_key')
+      .select('evolution_api_url, evolution_api_key, evolution_instance')
       .eq('user_id', user.id)
       .single();
 
     if (!config?.evolution_api_key) {
       return NextResponse.json({ error: 'Config not found' }, { status: 404 });
+    }
+
+    // Validate instance belongs to this user
+    if (config.evolution_instance !== instance) {
+      return NextResponse.json({ error: 'Instance not authorized' }, { status: 403 });
     }
 
     const res = await fetch(`${config.evolution_api_url}/instance/qrcode/${instance}`, {


### PR DESCRIPTION
## Summary
- Validates that the `instance` query param matches the user's `evolution_instance` from `whatsapp_config`
- Applied to both `get-qrcode` and `check-connection` routes (same vulnerability)
- Returns 403 if instance doesn't belong to the authenticated user

Closes #345

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 1442 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)