### PR TITLE
fix(security): make page-sections bulk PUT atomic via RPC (#346)

### DIFF
--- a/src/app/api/page-sections/route.ts
+++ b/src/app/api/page-sections/route.ts
@@ -266,20 +266,23 @@ export async function PUT(request: NextRequest) {
       is_visible: z.boolean(),
     });
 
-    // Atualizar todas as seções
-    const updates = sections.map(async (section) => {
+    // Validate all items before sending to DB
+    const validatedUpdates = [];
+    for (const section of sections) {
       const parsed = bulkItemSchema.safeParse(section);
-      if (!parsed.success) return null;
-      const { id, order_index, is_visible } = parsed.data;
+      if (!parsed.success) {
+        return NextResponse.json({ error: 'Invalid section data' }, { status: 400 });
+      }
+      validatedUpdates.push(parsed.data);
+    }
 
-      return supabase
-        .from('page_sections')
-        .update({ order_index, is_visible })
-        .eq('id', id)
-        .eq('professional_id', professional.id);
-    });
+    // Atomic bulk update via RPC (single transaction)
+    const { error: rpcError } = await supabase.rpc('bulk_update_page_sections', {
+      p_professional_id: professional.id,
+      p_updates: JSON.stringify(validatedUpdates),
+    } as never);
 
-    await Promise.all(updates);
+    if (rpcError) throw rpcError;
 
     // Buscar seções atualizadas
     const { data: updatedSections } = await supabase

--- a/supabase/migrations/20260307000009_bulk_update_page_sections_rpc.sql
+++ b/supabase/migrations/20260307000009_bulk_update_page_sections_rpc.sql
@@ -1,0 +1,26 @@
+-- Atomic bulk update for page_sections ordering
+-- Prevents race conditions when concurrent requests reorder sections
+
+CREATE OR REPLACE FUNCTION bulk_update_page_sections(
+  p_professional_id UUID,
+  p_updates JSONB
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  item JSONB;
+BEGIN
+  FOR item IN SELECT * FROM jsonb_array_elements(p_updates)
+  LOOP
+    UPDATE page_sections
+    SET
+      order_index = (item->>'order_index')::int,
+      is_visible = (item->>'is_visible')::boolean,
+      updated_at = now()
+    WHERE id = (item->>'id')::uuid
+      AND professional_id = p_professional_id;
+  END LOOP;
+END;
+$$;


### PR DESCRIPTION
## Summary
- Created `bulk_update_page_sections` PostgreSQL function (migration 20260307000009) that runs all updates in a single transaction
- Replaced `Promise.all` of individual updates with a single `supabase.rpc()` call
- Added upfront validation of all items before sending to DB (fail-fast on invalid data)

Closes #346

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 1442 tests pass
- [ ] Apply migration in Supabase and verify bulk reorder works

🤖 Generated with [Claude Code](https://claude.com/claude-code)