### PR TITLE
fix(security): replace in-memory rate limit with Redis in registration routes (#352, #353)

### DIFF
--- a/src/__tests__/security/register-rate-limit.test.ts
+++ b/src/__tests__/security/register-rate-limit.test.ts
@@ -6,17 +6,19 @@ import { resolve } from 'path';
  * Tests for Issue #189: Rate limiting missing on registration endpoints.
  * Without rate limiting, attackers can create thousands of accounts,
  * exhausting Supabase Auth quotas.
+ *
+ * Updated for #352/#353: now uses Redis-backed isRateLimited() from @/lib/rate-limit.
  */
 
 const registerPath = resolve('src/app/api/register/route.ts');
 const signupPath = resolve('src/app/api/auth/signup-with-verification/route.ts');
 
-describe('/api/register rate limiting (issue #189)', () => {
+describe('/api/register rate limiting (issue #189, #352)', () => {
   const source = readFileSync(registerPath, 'utf-8');
 
-  it('has rate limiting implementation', () => {
+  it('has Redis-backed rate limiting implementation', () => {
     expect(source).toContain('isRateLimited');
-    expect(source).toContain('rateLimitMap');
+    expect(source).toContain("from '@/lib/rate-limit'");
   });
 
   it('returns 429 when rate limited', () => {
@@ -27,28 +29,24 @@ describe('/api/register rate limiting (issue #189)', () => {
     expect(source).toContain('x-forwarded-for');
   });
 
-  it('uses a 1-hour window', () => {
-    expect(source).toContain('60 * 60 * 1000');
-  });
-
-  it('allows max 5 registrations per window', () => {
-    expect(source).toContain('RATE_LIMIT_MAX = 5');
+  it('uses rl:register key prefix', () => {
+    expect(source).toContain('rl:register:');
   });
 
   it('checks rate limit before processing request body', () => {
-    const rateLimitPos = source.indexOf('isRateLimited(ip)');
+    const rateLimitPos = source.indexOf('isRateLimited');
     const jsonParsePos = source.indexOf('req.json()');
     expect(rateLimitPos).toBeGreaterThan(-1);
     expect(rateLimitPos).toBeLessThan(jsonParsePos);
   });
 });
 
-describe('/api/auth/signup-with-verification rate limiting (issue #189)', () => {
+describe('/api/auth/signup-with-verification rate limiting (issue #189, #353)', () => {
   const source = readFileSync(signupPath, 'utf-8');
 
-  it('has rate limiting implementation', () => {
+  it('has Redis-backed rate limiting implementation', () => {
     expect(source).toContain('isRateLimited');
-    expect(source).toContain('rateLimitMap');
+    expect(source).toContain("from '@/lib/rate-limit'");
   });
 
   it('returns 429 when rate limited', () => {
@@ -59,17 +57,13 @@ describe('/api/auth/signup-with-verification rate limiting (issue #189)', () => 
     expect(source).toContain('x-forwarded-for');
   });
 
-  it('uses a 1-hour window', () => {
-    expect(source).toContain('60 * 60 * 1000');
-  });
-
-  it('allows max 5 registrations per window', () => {
-    expect(source).toContain('RATE_LIMIT_MAX = 5');
+  it('uses rl:register key prefix', () => {
+    expect(source).toContain('rl:register:');
   });
 
   it('checks rate limit before processing request body', () => {
     const postBody = source.slice(source.indexOf('export async function POST'));
-    const rateLimitPos = postBody.indexOf('isRateLimited(ip)');
+    const rateLimitPos = postBody.indexOf('isRateLimited');
     const jsonParsePos = postBody.indexOf('req.json()');
     expect(rateLimitPos).toBeGreaterThan(-1);
     expect(rateLimitPos).toBeLessThan(jsonParsePos);

--- a/src/app/api/auth/signup-with-verification/route.ts
+++ b/src/app/api/auth/signup-with-verification/route.ts
@@ -3,22 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { validateEmail, generateVerificationToken } from '@/lib/email-validation';
 import { Resend } from 'resend';
-
-// Rate limiting: 5 registrations per IP per hour
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
-const RATE_LIMIT_MAX = 5;
-const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
-
-function isRateLimited(ip: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(ip);
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return false;
-  }
-  entry.count++;
-  return entry.count > RATE_LIMIT_MAX;
-}
+import { isRateLimited } from '@/lib/rate-limit';
 
 function getFromEmail() {
   if (process.env.RESEND_FROM_EMAIL) return process.env.RESEND_FROM_EMAIL;
@@ -65,7 +50,7 @@ function buildVerificationEmailHtml(businessName: string, verifyUrl: string): st
 
 export async function POST(req: NextRequest) {
   const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  if (isRateLimited(ip)) {
+  if (await isRateLimited(`rl:register:${ip}`, 5, 3600)) {
     return NextResponse.json(
       { error: 'Muitas tentativas. Aguarde um momento.' },
       { status: 429 }

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,25 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
-
-// Rate limiting: 5 registrations per IP per hour
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
-const RATE_LIMIT_MAX = 5;
-const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
-
-function isRateLimited(ip: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(ip);
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return false;
-  }
-  entry.count++;
-  return entry.count > RATE_LIMIT_MAX;
-}
+import { isRateLimited } from '@/lib/rate-limit';
 
 export async function POST(req: NextRequest) {
   const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  if (isRateLimited(ip)) {
+  if (await isRateLimited(`rl:register:${ip}`, 5, 3600)) {
     return NextResponse.json(
       { error: 'Muitas tentativas. Aguarde um momento.' },
       { status: 429 }


### PR DESCRIPTION
## Summary
- Replaces local `Map()`-based rate limiter in both `register/route.ts` and `signup-with-verification/route.ts` with Redis-backed `isRateLimited()` from `@/lib/rate-limit`
- In-memory Map resets on every serverless cold start, allowing bypass
- Updated tests to verify Redis import

Closes #352
Closes #353

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 1440 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)