### PR TITLE
fix(security): add whitelist validation for ticket status/priority (#354)

### DIFF
--- a/src/app/api/admin/support/tickets/[id]/route.ts
+++ b/src/app/api/admin/support/tickets/[id]/route.ts
@@ -17,6 +17,16 @@ export async function PATCH(
 
   const { status, priority } = await request.json();
 
+  const VALID_STATUSES = ['open', 'in_progress', 'closed', 'awaiting_response'] as const;
+  const VALID_PRIORITIES = ['low', 'medium', 'high', 'urgent'] as const;
+
+  if (status && !(VALID_STATUSES as readonly string[]).includes(status)) {
+    return NextResponse.json({ error: 'Status inválido' }, { status: 400 });
+  }
+  if (priority && !(VALID_PRIORITIES as readonly string[]).includes(priority)) {
+    return NextResponse.json({ error: 'Prioridade inválida' }, { status: 400 });
+  }
+
   const updates: Record<string, string> = {};
   if (status) updates.status = status;
   if (priority) updates.priority = priority;


### PR DESCRIPTION
## Summary
- Adds whitelist validation for `status` (open, in_progress, closed, awaiting_response) and `priority` (low, medium, high, urgent) in admin ticket PATCH
- Returns 400 for invalid values instead of passing arbitrary data to DB

Closes #354

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 1440 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)