### PR TITLE
fix(security): validate Stripe and deposit before booking insert (#355)

### DIFF
--- a/src/__tests__/security/checkout-stripe-rollback.test.ts
+++ b/src/__tests__/security/checkout-stripe-rollback.test.ts
@@ -3,14 +3,16 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 /**
- * Tests for Issue #136: Race condition — booking inserted before Stripe session
+ * Tests for Issue #136 + #355: Stripe session failure handling
  *
  * If stripe.checkout.sessions.create() fails, the booking must be rolled back
- * (cancelled) to free the slot. Previously, the Stripe call had no try-catch,
- * leaving orphaned pending_payment bookings blocking slots indefinitely.
+ * (cancelled) to free the slot.
+ *
+ * Issue #355: Stripe availability and deposit calculation are validated BEFORE
+ * booking insert, so no rollback is needed for those pre-checks.
  */
 
-describe('Checkout route Stripe rollback (issue #136)', () => {
+describe('Checkout route Stripe rollback (issue #136, #355)', () => {
   const source = readFileSync(
     resolve('src/app/api/bookings/checkout/route.ts'),
     'utf-8'
@@ -53,17 +55,22 @@ describe('Checkout route Stripe rollback (issue #136)', () => {
     expect(catchBlock).toContain('502');
   });
 
-  it('also rolls back when Stripe is not configured', () => {
-    // The existing !stripe check should also cancel
-    const notConfiguredBlock = source.slice(
-      source.indexOf('if (!stripe)'),
-      source.indexOf('if (!stripe)') + 300
-    );
-    expect(notConfiguredBlock).toContain("status: 'cancelled'");
-    expect(notConfiguredBlock).toContain('503');
+  it('validates Stripe availability BEFORE booking insert (#355)', () => {
+    // Stripe null check must come BEFORE booking insert
+    const stripeNullCheck = source.indexOf('if (!stripe)');
+    const bookingInsert = source.indexOf("status: 'pending_payment'");
+    expect(stripeNullCheck).toBeGreaterThan(-1);
+    expect(stripeNullCheck).toBeLessThan(bookingInsert);
   });
 
-  it('inserts booking before Stripe (intentional order for double-booking protection)', () => {
+  it('calculates deposit BEFORE booking insert (#355)', () => {
+    const depositCalc = source.indexOf('calculateDeposit(');
+    const bookingInsert = source.indexOf("status: 'pending_payment'");
+    expect(depositCalc).toBeGreaterThan(-1);
+    expect(depositCalc).toBeLessThan(bookingInsert);
+  });
+
+  it('inserts booking before Stripe session creation (intentional for slot reservation)', () => {
     // Booking insert must come BEFORE Stripe session creation
     // This is by design — the booking reserves the slot, Stripe is created after
     const insertIndex = source.indexOf(".insert({");

--- a/src/app/api/bookings/checkout/route.ts
+++ b/src/app/api/bookings/checkout/route.ts
@@ -148,7 +148,24 @@ export async function POST(request: NextRequest) {
   const endM = (totalMinutes % 60).toString().padStart(2, '0');
   const end_time = `${endH}:${endM}`;
 
-  // ─── 8. Check double-booking ─────────────────────────────────────────────
+  // ─── 8. Pre-validate Stripe + deposit BEFORE booking insert ─────────────
+  const stripe = getStripeServer();
+  if (!stripe) {
+    return NextResponse.json({ error: 'Stripe not configured' }, { status: 503 });
+  }
+
+  const depositAmount = calculateDeposit(
+    service.price,
+    prof.deposit_type as 'percentage' | 'fixed',
+    prof.deposit_value as number
+  );
+  const depositCents = toCents(depositAmount);
+  if (depositCents <= 0) {
+    return NextResponse.json({ error: 'Valor do sinal inválido.' }, { status: 400 });
+  }
+  const applicationFeeCents = Math.round(depositCents * 0.05);
+
+  // ─── 9. Check double-booking ─────────────────────────────────────────────
   const { data: conflicts } = await supabase
     .from('bookings')
     .select('id')
@@ -165,7 +182,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // ─── 9. Insert booking com status pending_payment ────────────────────────
+  // ─── 10. Insert booking com status pending_payment ────────────────────────
   const { data: booking, error: bookingError } = await supabase
     .from('bookings')
     .insert({
@@ -195,23 +212,6 @@ export async function POST(request: NextRequest) {
     }
     logger.error('[bookings/checkout] booking insert failed', bookingError);
     return NextResponse.json({ error: 'Erro ao criar agendamento. Tente novamente.' }, { status: 500 });
-  }
-
-  // ─── 10. Calcular sinal + taxa plataforma ────────────────────────────────
-  const depositAmount = calculateDeposit(
-    service.price,
-    prof.deposit_type as 'percentage' | 'fixed',
-    prof.deposit_value as number
-  );
-  const depositCents = toCents(depositAmount);
-  const applicationFeeCents = Math.round(depositCents * 0.05);
-
-  // ─── 11. Criar Stripe Checkout Session ───────────────────────────────────
-  const stripe = getStripeServer();
-  if (!stripe) {
-    // Rollback: cancelar booking criado
-    await supabase.from('bookings').update({ status: 'cancelled' }).eq('id', booking.id);
-    return NextResponse.json({ error: 'Stripe not configured' }, { status: 503 });
   }
 
   const currencyCode = (prof.currency as string)?.toLowerCase() || 'eur';


### PR DESCRIPTION
## Summary
- Moved `getStripeServer()` null check and `calculateDeposit()` BEFORE the booking insert
- Previously these ran AFTER insert, requiring rollback on failure
- Now pre-checks return early without creating orphaned `pending_payment` bookings
- Stripe session failure catch block still rolls back as before (unavoidable)
- Updated tests to verify the new order

Closes #355

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 1441 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)