### PR TITLE
fix: remove Stripe trial_period_days to prevent dual trial

### DIFF
--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -55,7 +55,6 @@ export async function POST() {
     mode: 'subscription',
     line_items: [{ price: priceId, quantity: 1 }],
     subscription_data: {
-      trial_period_days: 14,
       metadata: { professional_id: professional.id },
     },
     success_url: `${baseUrl}/dashboard?subscription=success`,


### PR DESCRIPTION
## Summary
- Removes `trial_period_days: 14` from Stripe Checkout session creation
- Trial is controlled exclusively by the app-level `trial_ends_at` field in the DB
- Previously users got 14 days (app) + 14 days (Stripe) = 28 days free

Closes #371

## Test plan
- [x] TypeScript compiles without errors
- [x] 1441 unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)