### PR TITLE
fix(security): move Evolution API credentials to env vars

### DIFF
--- a/src/app/api/admin/evolution/check-connection/route.ts
+++ b/src/app/api/admin/evolution/check-connection/route.ts
@@ -2,7 +2,6 @@ import { logger } from '@/lib/logger';
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createAdminClient } from '@/lib/supabase/admin';
-import { evolutionConfig } from '@/lib/evolution/config';
 import { validateAdminToken } from '@/lib/admin/session';
 import { decryptToken } from '@/lib/integrations/token-encryption';
 

--- a/src/lib/evolution/config.ts
+++ b/src/lib/evolution/config.ts
@@ -1,4 +1,4 @@
 export const evolutionConfig = {
-  baseUrl: 'https://realisticlobster-evolution.cloudfy.live',
-  globalApiKey: 'OOiMlhlCpCRT744u14JlAk2FuIgijqfp',
+  baseUrl: process.env.EVOLUTION_API_URL ?? '',
+  globalApiKey: process.env.EVOLUTION_API_KEY ?? '',
 };


### PR DESCRIPTION
## Summary
- Replaces hardcoded `globalApiKey` and `baseUrl` in `src/lib/evolution/config.ts` with `process.env.EVOLUTION_API_URL` and `process.env.EVOLUTION_API_KEY`
- Removes unused `evolutionConfig` import from admin check-connection route
- The exposed key **must be rotated** in the Evolution API dashboard

## Action required after merge
1. Add `EVOLUTION_API_URL` and `EVOLUTION_API_KEY` to Vercel env vars
2. Rotate the key in the Evolution API dashboard (invalidate the old one)

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)