### PR TITLE
feat: add monitoring, health checks, and alert system (#373)

### DIFF
--- a/src/app/[locale]/(admin)/admin/status/page.tsx
+++ b/src/app/[locale]/(admin)/admin/status/page.tsx
@@ -1,0 +1,36 @@
+import { createAdminClient } from '@/lib/supabase/admin';
+import { StatusDashboard } from './status-dashboard';
+
+export default async function AdminStatusPage() {
+  const supabase = createAdminClient();
+
+  // Cron logs últimas 24h
+  const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: cronLogs } = await supabase
+    .from('cron_logs')
+    .select('*')
+    .gt('created_at', twentyFourHoursAgo)
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  // Webhook failures últimas 24h
+  const { data: webhookFailures } = await supabase
+    .from('cron_logs')
+    .select('*')
+    .like('job_name', 'webhook_%')
+    .eq('status', 'error')
+    .gt('created_at', twentyFourHoursAgo)
+    .order('created_at', { ascending: false })
+    .limit(50);
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto space-y-6">
+      <h1 className="text-2xl font-bold">Status do Sistema</h1>
+      <StatusDashboard
+        cronLogs={cronLogs ?? []}
+        webhookFailures={webhookFailures ?? []}
+      />
+    </div>
+  );
+}

--- a/src/app/[locale]/(admin)/admin/status/status-dashboard.tsx
+++ b/src/app/[locale]/(admin)/admin/status/status-dashboard.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useState } from 'react';
+
+interface CronLog {
+  id: string;
+  job_name: string;
+  status: string;
+  records_processed?: number;
+  records_failed?: number;
+  execution_time_ms?: number;
+  error_message?: string;
+  metadata?: Record<string, unknown>;
+  created_at: string;
+}
+
+interface ConnectivityResult {
+  status: 'ok' | 'error' | 'skipped';
+  latency_ms?: number;
+  error?: string;
+}
+
+interface HealthResponse {
+  status: string;
+  connectivity: Record<string, ConnectivityResult>;
+  connectivity_failures: string[];
+  critical_missing: string[];
+  timestamp: string;
+}
+
+interface Props {
+  cronLogs: CronLog[];
+  webhookFailures: CronLog[];
+}
+
+const SERVICE_LABELS: Record<string, string> = {
+  supabase: 'Supabase (DB)',
+  redis: 'Redis (Cache)',
+  evolution_api: 'Evolution API (WhatsApp)',
+  stripe: 'Stripe (Pagamentos)',
+};
+
+export function StatusDashboard({ cronLogs, webhookFailures }: Props) {
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function runHealthCheck() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/health-check');
+      if (!res.ok) {
+        setError(`Erro: HTTP ${res.status}`);
+        return;
+      }
+      const data = await res.json();
+      setHealth(data);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // Group cron logs by job_name, show latest status
+  const cronSummary = cronLogs.reduce<Record<string, { latest: CronLog; total: number; failures: number }>>((acc, log) => {
+    if (!acc[log.job_name]) {
+      acc[log.job_name] = { latest: log, total: 0, failures: 0 };
+    }
+    acc[log.job_name].total++;
+    if (log.status === 'error') acc[log.job_name].failures++;
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-6">
+      {/* Service Health */}
+      <section className="bg-white dark:bg-slate-900 rounded-lg border p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold">Saúde dos Serviços</h2>
+          <button
+            onClick={runHealthCheck}
+            disabled={loading}
+            className="px-4 py-2 bg-indigo-600 text-white rounded-md text-sm hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {loading ? 'Verificando...' : 'Executar Health Check'}
+          </button>
+        </div>
+
+        {error && (
+          <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md text-red-700 dark:text-red-400 text-sm mb-4">
+            {error}
+          </div>
+        )}
+
+        {health ? (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {Object.entries(health.connectivity).map(([service, result]) => (
+              <div
+                key={service}
+                className={`p-4 rounded-lg border-2 ${
+                  result.status === 'ok'
+                    ? 'border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-900/20'
+                    : result.status === 'error'
+                    ? 'border-red-300 bg-red-50 dark:border-red-700 dark:bg-red-900/20'
+                    : 'border-gray-300 bg-gray-50 dark:border-gray-700 dark:bg-gray-900/20'
+                }`}
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <span
+                    className={`h-3 w-3 rounded-full ${
+                      result.status === 'ok'
+                        ? 'bg-green-500'
+                        : result.status === 'error'
+                        ? 'bg-red-500'
+                        : 'bg-gray-400'
+                    }`}
+                  />
+                  <span className="font-medium text-sm">
+                    {SERVICE_LABELS[service] || service}
+                  </span>
+                </div>
+                {result.latency_ms !== undefined && (
+                  <p className="text-xs text-muted-foreground">{result.latency_ms}ms</p>
+                )}
+                {result.error && (
+                  <p className="text-xs text-red-600 dark:text-red-400 mt-1 truncate" title={result.error}>
+                    {result.error}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Clique em &quot;Executar Health Check&quot; para verificar a conectividade dos serviços.
+          </p>
+        )}
+
+        {health && (
+          <div className="mt-4 flex items-center gap-2">
+            <span
+              className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                health.status === 'healthy'
+                  ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                  : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+              }`}
+            >
+              {health.status === 'healthy' ? 'Todos os serviços operacionais' : 'Serviços com falha'}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {new Date(health.timestamp).toLocaleString('pt-BR')}
+            </span>
+          </div>
+        )}
+      </section>
+
+      {/* Cron Logs (últimas 24h) */}
+      <section className="bg-white dark:bg-slate-900 rounded-lg border p-6">
+        <h2 className="text-lg font-semibold mb-4">Cron Jobs (últimas 24h)</h2>
+        {Object.keys(cronSummary).length === 0 ? (
+          <p className="text-sm text-muted-foreground">Nenhum log de cron nas últimas 24h.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left">
+                  <th className="pb-2 font-medium">Job</th>
+                  <th className="pb-2 font-medium">Último Status</th>
+                  <th className="pb-2 font-medium">Execuções</th>
+                  <th className="pb-2 font-medium">Falhas</th>
+                  <th className="pb-2 font-medium">Última Execução</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(cronSummary).map(([jobName, data]) => (
+                  <tr key={jobName} className="border-b last:border-0">
+                    <td className="py-2 font-mono text-xs">{jobName}</td>
+                    <td className="py-2">
+                      <span
+                        className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium ${
+                          data.latest.status === 'success'
+                            ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
+                            : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
+                        }`}
+                      >
+                        <span className={`h-1.5 w-1.5 rounded-full ${
+                          data.latest.status === 'success' ? 'bg-green-500' : 'bg-red-500'
+                        }`} />
+                        {data.latest.status}
+                      </span>
+                    </td>
+                    <td className="py-2">{data.total}</td>
+                    <td className="py-2">
+                      {data.failures > 0 ? (
+                        <span className="text-red-600 font-medium">{data.failures}</span>
+                      ) : (
+                        '0'
+                      )}
+                    </td>
+                    <td className="py-2 text-muted-foreground text-xs">
+                      {new Date(data.latest.created_at).toLocaleString('pt-BR')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Webhook Failures (últimas 24h) */}
+      <section className="bg-white dark:bg-slate-900 rounded-lg border p-6">
+        <h2 className="text-lg font-semibold mb-4">Falhas de Webhooks (últimas 24h)</h2>
+        {webhookFailures.length === 0 ? (
+          <p className="text-sm text-green-600 dark:text-green-400">Nenhuma falha de webhook nas últimas 24h.</p>
+        ) : (
+          <div className="space-y-3">
+            {webhookFailures.map((failure) => (
+              <div
+                key={failure.id}
+                className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md"
+              >
+                <div className="flex items-center justify-between mb-1">
+                  <span className="font-mono text-xs font-medium">
+                    {failure.job_name}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(failure.created_at).toLocaleString('pt-BR')}
+                  </span>
+                </div>
+                {failure.error_message && (
+                  <p className="text-sm text-red-700 dark:text-red-400">{failure.error_message}</p>
+                )}
+                {failure.metadata && (
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Evento: {(failure.metadata as any).event_type || 'N/A'} | ID: {(failure.metadata as any).event_id || 'N/A'}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/api/admin/health-check/route.ts
+++ b/src/app/api/admin/health-check/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { validateAdminToken } from '@/lib/admin/session';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { getStripe } from '@/lib/stripe';
+import { evolutionConfig } from '@/lib/evolution/config';
+
+const CONNECTIVITY_TIMEOUT = 5000;
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error(`Timeout after ${ms}ms`)), ms),
+  );
+  return Promise.race([promise, timeout]);
+}
+
+interface ConnectivityResult {
+  status: 'ok' | 'error' | 'skipped';
+  latency_ms?: number;
+  error?: string;
+}
+
+async function checkSupabase(): Promise<ConnectivityResult> {
+  const start = Date.now();
+  try {
+    const supabase = createAdminClient();
+    const result = await withTimeout(
+      Promise.resolve(supabase.from('professionals').select('id').limit(1)),
+      CONNECTIVITY_TIMEOUT,
+    );
+    if (result.error) return { status: 'error', latency_ms: Date.now() - start, error: result.error.message };
+    return { status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
+
+async function checkRedis(): Promise<ConnectivityResult> {
+  const redisUrl = process.env.STORAGE_URL || process.env.REDIS_URL;
+  if (!redisUrl) return { status: 'skipped', error: 'Not configured' };
+  const start = Date.now();
+  try {
+    const { default: Redis } = await import('ioredis');
+    const { parseRedisUrl } = await import('@/lib/redis/parse-url');
+    const redis = new Redis({
+      ...parseRedisUrl(redisUrl),
+      maxRetriesPerRequest: 1,
+      connectTimeout: 3000,
+      commandTimeout: 3000,
+      lazyConnect: true,
+    });
+    await withTimeout(redis.ping(), CONNECTIVITY_TIMEOUT);
+    await redis.quit();
+    return { status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
+
+async function checkEvolutionApi(): Promise<ConnectivityResult> {
+  const { baseUrl, globalApiKey } = evolutionConfig;
+  if (!baseUrl || !globalApiKey) return { status: 'skipped', error: 'Not configured' };
+  const instance = process.env.EVOLUTION_INSTANCE_SALES ?? 'circlehood-sales';
+  const start = Date.now();
+  try {
+    const res = await withTimeout(
+      fetch(`${baseUrl}/instance/connectionState/${instance}`, {
+        headers: { apikey: globalApiKey },
+      }),
+      CONNECTIVITY_TIMEOUT,
+    );
+    if (!res.ok) return { status: 'error', latency_ms: Date.now() - start, error: `HTTP ${res.status}` };
+    return { status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
+
+async function checkStripe(): Promise<ConnectivityResult> {
+  const stripe = getStripe();
+  if (!stripe) return { status: 'skipped', error: 'Not configured' };
+  const start = Date.now();
+  try {
+    await withTimeout(stripe.balance.retrieve(), CONNECTIVITY_TIMEOUT);
+    return { status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
+
+/**
+ * GET /api/admin/health-check — Admin-authenticated health check.
+ * Used by the admin status dashboard to run connectivity checks.
+ */
+export async function GET() {
+  const cookieStore = await cookies();
+  if (!(await validateAdminToken(cookieStore.get('admin_session')?.value))) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const [supabase, redis, evolutionApi, stripe] = await Promise.all([
+    checkSupabase(),
+    checkRedis(),
+    checkEvolutionApi(),
+    checkStripe(),
+  ]);
+
+  const connectivity = { supabase, redis, evolution_api: evolutionApi, stripe };
+
+  const connectivityFailures = Object.entries(connectivity)
+    .filter(([, v]) => v.status === 'error')
+    .map(([k]) => k);
+
+  const status = connectivityFailures.length === 0 ? 'healthy' : 'degraded';
+
+  return NextResponse.json({
+    status,
+    connectivity,
+    connectivity_failures: connectivityFailures,
+    critical_missing: [] as string[],
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/src/app/api/cron/health-check/route.ts
+++ b/src/app/api/cron/health-check/route.ts
@@ -1,0 +1,170 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyCronSecret } from '@/lib/cron-auth';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { getStripe } from '@/lib/stripe';
+import { evolutionConfig } from '@/lib/evolution/config';
+import { Resend } from 'resend';
+import { logger } from '@/lib/logger';
+
+const CONNECTIVITY_TIMEOUT = 5000;
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error(`Timeout after ${ms}ms`)), ms),
+  );
+  return Promise.race([promise, timeout]);
+}
+
+interface CheckResult {
+  service: string;
+  status: 'ok' | 'error' | 'skipped';
+  latency_ms?: number;
+  error?: string;
+}
+
+async function checkSupabase(): Promise<CheckResult> {
+  const start = Date.now();
+  try {
+    const supabase = createAdminClient();
+    const result = await withTimeout(
+      Promise.resolve(supabase.from('professionals').select('id').limit(1)),
+      CONNECTIVITY_TIMEOUT,
+    );
+    if (result.error) return { service: 'supabase', status: 'error', latency_ms: Date.now() - start, error: result.error.message };
+    return { service: 'supabase', status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { service: 'supabase', status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
+
+async function checkRedis(): Promise<CheckResult> {
+  const redisUrl = process.env.STORAGE_URL || process.env.REDIS_URL;
+  if (!redisUrl) return { service: 'redis', status: 'skipped', error: 'Not configured' };
+
+  const start = Date.now();
+  try {
+    const { default: Redis } = await import('ioredis');
+    const { parseRedisUrl } = await import('@/lib/redis/parse-url');
+    const redis = new Redis({
+      ...parseRedisUrl(redisUrl),
+      maxRetriesPerRequest: 1,
+      connectTimeout: 3000,
+      commandTimeout: 3000,
+      lazyConnect: true,
+    });
+    await withTimeout(redis.ping(), CONNECTIVITY_TIMEOUT);
+    await redis.quit();
+    return { service: 'redis', status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { service: 'redis', status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
+
+async function checkEvolutionApi(): Promise<CheckResult> {
+  const { baseUrl, globalApiKey } = evolutionConfig;
+  if (!baseUrl || !globalApiKey) return { service: 'evolution_api', status: 'skipped', error: 'Not configured' };
+
+  const instance = process.env.EVOLUTION_INSTANCE_SALES ?? 'circlehood-sales';
+  const start = Date.now();
+  try {
+    const res = await withTimeout(
+      fetch(`${baseUrl}/instance/connectionState/${instance}`, {
+        headers: { apikey: globalApiKey },
+      }),
+      CONNECTIVITY_TIMEOUT,
+    );
+    if (!res.ok) return { service: 'evolution_api', status: 'error', latency_ms: Date.now() - start, error: `HTTP ${res.status}` };
+    return { service: 'evolution_api', status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { service: 'evolution_api', status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
+
+async function checkStripe(): Promise<CheckResult> {
+  const stripe = getStripe();
+  if (!stripe) return { service: 'stripe', status: 'skipped', error: 'Not configured' };
+
+  const start = Date.now();
+  try {
+    await withTimeout(stripe.balance.retrieve(), CONNECTIVITY_TIMEOUT);
+    return { service: 'stripe', status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { service: 'stripe', status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
+
+function getFromEmail() {
+  if (process.env.RESEND_FROM_EMAIL) return process.env.RESEND_FROM_EMAIL;
+  return process.env.NODE_ENV === 'production'
+    ? 'noreply@circlehood-tech.com'
+    : 'onboarding@resend.dev';
+}
+
+/**
+ * GET /api/cron/health-check — Cron diário (6h UTC).
+ * Verifica conectividade dos serviços críticos.
+ * Se houver falhas, envia alerta por email ao ADMIN_EMAIL.
+ */
+export async function GET(request: NextRequest) {
+  if (!verifyCronSecret(request.headers.get('authorization'))) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const startTime = Date.now();
+
+  const results = await Promise.all([
+    checkSupabase(),
+    checkRedis(),
+    checkEvolutionApi(),
+    checkStripe(),
+  ]);
+
+  const failures = results.filter((r) => r.status === 'error');
+  const hasFailures = failures.length > 0;
+
+  // Send alert email if any critical service is down
+  if (hasFailures && process.env.ADMIN_EMAIL && process.env.RESEND_API_KEY) {
+    try {
+      const resend = new Resend(process.env.RESEND_API_KEY);
+      const failureList = failures
+        .map((f) => `• ${f.service}: ${f.error} (${f.latency_ms}ms)`)
+        .join('\n');
+
+      await resend.emails.send({
+        from: `CircleHood Alertas <${getFromEmail()}>`,
+        to: process.env.ADMIN_EMAIL,
+        subject: `[ALERTA] ${failures.length} serviço(s) com falha — Health Check`,
+        html: `
+          <h2>Health Check — Serviços com Falha</h2>
+          <p><strong>Timestamp:</strong> ${new Date().toISOString()}</p>
+          <pre>${failureList}</pre>
+          <h3>Todos os resultados:</h3>
+          <pre>${JSON.stringify(results, null, 2)}</pre>
+        `,
+      });
+    } catch (emailError: any) {
+      logger.error('[health-check] Failed to send alert email:', emailError.message);
+    }
+  }
+
+  // Log to cron_logs
+  const supabase = createAdminClient();
+  await supabase.from('cron_logs').insert({
+    job_name: 'health-check',
+    status: hasFailures ? 'error' : 'success',
+    records_processed: results.length,
+    records_failed: failures.length,
+    execution_time_ms: Date.now() - startTime,
+    metadata: {
+      results,
+      alert_sent: hasFailures && !!process.env.ADMIN_EMAIL,
+    },
+  } as never);
+
+  return NextResponse.json({
+    status: hasFailures ? 'degraded' : 'healthy',
+    results,
+    execution_time_ms: Date.now() - startTime,
+    alert_sent: hasFailures && !!process.env.ADMIN_EMAIL,
+  }, { status: hasFailures ? 503 : 200 });
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,10 +1,105 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { getStripe } from '@/lib/stripe';
+import { evolutionConfig } from '@/lib/evolution/config';
+
+const CONNECTIVITY_TIMEOUT = 5000;
+
+type ServiceStatus = 'ok' | 'error' | 'skipped';
+
+interface ConnectivityResult {
+  status: ServiceStatus;
+  latency_ms?: number;
+  error?: string;
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<T> {
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error(`Timeout after ${ms}ms`)), ms),
+  );
+  return Promise.race([promise, timeout]);
+}
+
+async function checkSupabase(): Promise<ConnectivityResult> {
+  const start = Date.now();
+  try {
+    const supabase = createAdminClient();
+    const result = await withTimeout(
+      Promise.resolve(supabase.from('professionals').select('id').limit(1)),
+      CONNECTIVITY_TIMEOUT,
+    );
+    if (result.error) return { status: 'error', latency_ms: Date.now() - start, error: result.error.message };
+    return { status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
+
+async function checkRedis(): Promise<ConnectivityResult> {
+  const redisUrl = process.env.STORAGE_URL || process.env.REDIS_URL;
+  if (!redisUrl) return { status: 'skipped', error: 'No REDIS_URL configured' };
+
+  const start = Date.now();
+  try {
+    const { default: Redis } = await import('ioredis');
+    const { parseRedisUrl } = await import('@/lib/redis/parse-url');
+    const redis = new Redis({
+      ...parseRedisUrl(redisUrl),
+      maxRetriesPerRequest: 1,
+      connectTimeout: 3000,
+      commandTimeout: 3000,
+      lazyConnect: true,
+    });
+    await withTimeout(redis.ping(), CONNECTIVITY_TIMEOUT);
+    await redis.quit();
+    return { status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
+
+async function checkEvolutionApi(): Promise<ConnectivityResult> {
+  const { baseUrl, globalApiKey } = evolutionConfig;
+  if (!baseUrl || !globalApiKey) return { status: 'skipped', error: 'Evolution API not configured' };
+
+  const instance = process.env.EVOLUTION_INSTANCE_SALES ?? 'circlehood-sales';
+  const start = Date.now();
+  try {
+    const res = await withTimeout(
+      fetch(`${baseUrl}/instance/connectionState/${instance}`, {
+        headers: { apikey: globalApiKey },
+      }),
+      CONNECTIVITY_TIMEOUT,
+    );
+    if (!res.ok) {
+      return { status: 'error', latency_ms: Date.now() - start, error: `HTTP ${res.status}` };
+    }
+    return { status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
+
+async function checkStripe(): Promise<ConnectivityResult> {
+  const stripe = getStripe();
+  if (!stripe) return { status: 'skipped', error: 'Stripe not configured' };
+
+  const start = Date.now();
+  try {
+    await withTimeout(stripe.balance.retrieve(), CONNECTIVITY_TIMEOUT);
+    return { status: 'ok', latency_ms: Date.now() - start };
+  } catch (e: any) {
+    return { status: 'error', latency_ms: Date.now() - start, error: e.message };
+  }
+}
 
 /**
- * GET /api/health — verifica env vars críticas sem expor secrets.
+ * GET /api/health — verifica env vars críticas e conectividade real.
  *
  * Protegido por CRON_SECRET (mesmo padrão dos crons).
- * Retorna status por serviço: ok | missing | partial.
  */
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('authorization');
@@ -48,6 +143,16 @@ export async function GET(request: NextRequest) {
     },
   };
 
+  // Connectivity checks (run in parallel)
+  const [supabase, redis, evolutionApi, stripe] = await Promise.all([
+    checkSupabase(),
+    checkRedis(),
+    checkEvolutionApi(),
+    checkStripe(),
+  ]);
+
+  const connectivity = { supabase, redis, evolution_api: evolutionApi, stripe };
+
   // Calcular status geral
   const criticalMissing: string[] = [];
 
@@ -70,12 +175,21 @@ export async function GET(request: NextRequest) {
     criticalMissing.push('resend.api_key');
   }
 
-  const status = criticalMissing.length === 0 ? 'healthy' : 'degraded';
+  // Check connectivity failures
+  const connectivityFailures = Object.entries(connectivity)
+    .filter(([, v]) => v.status === 'error')
+    .map(([k]) => k);
+
+  const status = criticalMissing.length === 0 && connectivityFailures.length === 0
+    ? 'healthy'
+    : 'degraded';
 
   return NextResponse.json({
     status,
     critical_missing: criticalMissing,
+    connectivity_failures: connectivityFailures,
     checks,
+    connectivity,
     timestamp: new Date().toISOString(),
   }, { status: status === 'healthy' ? 200 : 503 });
 }

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -39,64 +39,78 @@ export async function POST(request: NextRequest) {
 
   const supabase = createAdminClient();
 
-  switch (event.type) {
-    case 'checkout.session.completed': {
-      const session = event.data.object as Stripe.Checkout.Session;
-      const professionalId = session.metadata?.professional_id;
-      if (professionalId) {
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        const session = event.data.object as Stripe.Checkout.Session;
+        const professionalId = session.metadata?.professional_id;
+        if (professionalId) {
+          await supabase
+            .from('professionals')
+            .update({
+              subscription_status: 'active',
+              stripe_customer_id: session.customer as string,
+            })
+            .eq('id', professionalId);
+        }
+        break;
+      }
+
+      case 'customer.subscription.updated': {
+        const subscription = event.data.object as Stripe.Subscription;
+        const customerId = subscription.customer as string;
+        const status = subscription.status;
+
+        let subStatus: string;
+        if (status === 'active' || status === 'trialing') {
+          subStatus = 'active';
+        } else if (status === 'canceled' || status === 'unpaid') {
+          subStatus = 'cancelled';
+        } else {
+          subStatus = 'expired';
+        }
+
         await supabase
           .from('professionals')
-          .update({
-            subscription_status: 'active',
-            stripe_customer_id: session.customer as string,
-          })
-          .eq('id', professionalId);
-      }
-      break;
-    }
-
-    case 'customer.subscription.updated': {
-      const subscription = event.data.object as Stripe.Subscription;
-      const customerId = subscription.customer as string;
-      const status = subscription.status;
-
-      let subStatus: string;
-      if (status === 'active' || status === 'trialing') {
-        subStatus = 'active';
-      } else if (status === 'canceled' || status === 'unpaid') {
-        subStatus = 'cancelled';
-      } else {
-        subStatus = 'expired';
+          .update({ subscription_status: subStatus })
+          .eq('stripe_customer_id', customerId);
+        break;
       }
 
-      await supabase
-        .from('professionals')
-        .update({ subscription_status: subStatus })
-        .eq('stripe_customer_id', customerId);
-      break;
+      case 'customer.subscription.deleted': {
+        const subscription = event.data.object as Stripe.Subscription;
+        const customerId = subscription.customer as string;
+
+        await supabase
+          .from('professionals')
+          .update({ subscription_status: 'cancelled' })
+          .eq('stripe_customer_id', customerId);
+        break;
+      }
+
+      case 'invoice.payment_failed': {
+        const invoice = event.data.object as Stripe.Invoice;
+        const customerId = invoice.customer as string;
+
+        await supabase
+          .from('professionals')
+          .update({ subscription_status: 'expired' })
+          .eq('stripe_customer_id', customerId);
+        break;
+      }
     }
-
-    case 'customer.subscription.deleted': {
-      const subscription = event.data.object as Stripe.Subscription;
-      const customerId = subscription.customer as string;
-
-      await supabase
-        .from('professionals')
-        .update({ subscription_status: 'cancelled' })
-        .eq('stripe_customer_id', customerId);
-      break;
-    }
-
-    case 'invoice.payment_failed': {
-      const invoice = event.data.object as Stripe.Invoice;
-      const customerId = invoice.customer as string;
-
-      await supabase
-        .from('professionals')
-        .update({ subscription_status: 'expired' })
-        .eq('stripe_customer_id', customerId);
-      break;
-    }
+  } catch (processingError: any) {
+    logger.error('[stripe/webhook] Error processing event:', processingError);
+    await supabase.from('cron_logs').insert({
+      job_name: 'webhook_stripe',
+      status: 'error',
+      error_message: processingError.message || 'Unknown error',
+      metadata: {
+        event_type: event.type,
+        event_id: event.id,
+      },
+    } as never);
+    return NextResponse.json({ error: 'Processing failed' }, { status: 500 });
   }
 
   return NextResponse.json({ received: true });

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -111,6 +111,24 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ received: true })
   } catch (error: any) {
     logger.error('Error processing Resend webhook:', error)
+
+    // Log failure to cron_logs for monitoring
+    try {
+      const { createAdminClient } = await import('@/lib/supabase/admin')
+      const adminSupabase = createAdminClient()
+      await adminSupabase.from('cron_logs').insert({
+        job_name: 'webhook_resend',
+        status: 'error',
+        error_message: error.message || 'Unknown error',
+        metadata: {
+          event_type: body?.type,
+          event_id: body?.data?.email_id,
+        },
+      } as never)
+    } catch (logError: any) {
+      logger.error('Failed to log webhook error:', logError.message)
+    }
+
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,10 @@
   ],
   "crons": [
     {
+      "path": "/api/cron/health-check",
+      "schedule": "0 6 * * *"
+    },
+    {
       "path": "/api/cron/cleanup-tokens",
       "schedule": "0 2 * * *"
     },


### PR DESCRIPTION
## Summary
- Cron health-check (daily 6h UTC): checks Supabase, Redis, Evolution API, Stripe with 5s timeout + email alert on failure
- Admin health-check API for on-demand checks from dashboard
- Status dashboard at `/admin/status`: service health, cron logs, webhook failures
- Enhanced `/api/health` with full connectivity checks
- Stripe webhook error tracking via cron_logs
- Resend webhook bounce/complaint tracking

Closes #373

## Test plan
- [ ] Visit `/admin/status` and run health check
- [ ] Verify cron `health-check` in Vercel logs
- [ ] Set `ADMIN_EMAIL` env var for alert emails