### PR TITLE
fix: improve booking status tabs — full-width grid with counters

### DIFF
--- a/src/components/dashboard/bookings-manager.tsx
+++ b/src/components/dashboard/bookings-manager.tsx
@@ -304,11 +304,19 @@ export function BookingsManager({ bookings, currency }: BookingsManagerProps) {
       <h1 className="text-2xl font-bold">{t('title')}</h1>
 
       <Tabs value={tab} onValueChange={setTab}>
-        <TabsList>
-          <TabsTrigger value="all">{t('tabAll')}</TabsTrigger>
-          <TabsTrigger value="confirmed">{t('tabConfirmed')}</TabsTrigger>
-          <TabsTrigger value="cancelled">{t('tabCancelled')}</TabsTrigger>
-          <TabsTrigger value="completed">{t('tabCompleted')}</TabsTrigger>
+        <TabsList className="w-full grid grid-cols-4">
+          <TabsTrigger value="all">
+            {t('tabAll')} ({bookings.length})
+          </TabsTrigger>
+          <TabsTrigger value="confirmed">
+            {t('tabConfirmed')} ({bookings.filter(b => b.status === 'confirmed').length})
+          </TabsTrigger>
+          <TabsTrigger value="cancelled">
+            {t('tabCancelled')} ({bookings.filter(b => b.status === 'cancelled').length})
+          </TabsTrigger>
+          <TabsTrigger value="completed">
+            {t('tabCompleted')} ({bookings.filter(b => b.status === 'completed').length})
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value={tab} className="mt-4">


### PR DESCRIPTION
## Summary
- Tabs de status (Todos/Confirmados/Cancelados/Concluídos) agora ocupam 100% da largura com `grid-cols-4`
- Cada tab mostra contador de bookings naquele status

## Test plan
- [x] `npx tsc --noEmit` sem erros
- [ ] Visual: tabs full-width com contadores visíveis
- [ ] Mobile: tabs não overflow, texto legível

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)