### PR TITLE
fix: remove share URL card from dashboard — duplicate of my-page

### DIFF
--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -15,7 +15,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
-import { ShareLinkCard } from '@/components/dashboard/share-link-card';
+
 import { AlertsWidget } from './components/alerts-widget';
 
 export default async function DashboardPage() {
@@ -476,11 +476,6 @@ export default async function DashboardPage() {
         </CardContent>
       </Card>
 
-      {/* Share link with QR code */}
-      <ShareLinkCard
-        slug={professional.slug}
-        businessName={professional.business_name}
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Remove `ShareLinkCard` from `/dashboard` — the same sharing functionality already exists in `/my-page`

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)