### PR TITLE
fix: consolidate my-page and my-page-editor into single entry (#388)

### DIFF
--- a/e2e/dashboard/06-presence.spec.ts
+++ b/e2e/dashboard/06-presence.spec.ts
@@ -6,21 +6,18 @@ import { TEST } from '../helpers/config';
 
 const BASE = TEST.BASE_URL;
 
-test.describe('Dashboard — Editor de Página', () => {
-  test('my-page carrega sem erro', async ({ page }) => {
+test.describe('Dashboard — Minha Página Pública', () => {
+  test('my-page redireciona para my-page-editor', async ({ page }) => {
     await page.goto(`${BASE}/my-page`);
+    await page.waitForURL(/my-page-editor/, { timeout: 15_000 });
     await expect(page.locator('body')).not.toContainText(/erro interno|500/i, { timeout: 15_000 });
-    await expect(page.locator('h1, h2').first()).toBeVisible({ timeout: 15_000 });
   });
 
   test('my-page-editor carrega heading correto', async ({ page }) => {
     await page.goto(`${BASE}/my-page-editor`);
     await expect(
-      page.getByRole('heading', { name: /editor de página/i })
+      page.getByRole('heading', { name: /minha página pública|my public page|mi página pública/i })
     ).toBeVisible({ timeout: 15_000 });
-    await expect(
-      page.getByRole('link', { name: /ver página pública/i })
-    ).toBeVisible();
   });
 });
 

--- a/e2e/navigation/01-consistency.spec.ts
+++ b/e2e/navigation/01-consistency.spec.ts
@@ -37,7 +37,7 @@ test.describe('Sidebar — Desktop', () => {
       { href: '/schedule',       heading: 'Horários'                    },
       { href: '/settings',       heading: 'Configurações'               },
       { href: '/whatsapp-config',heading: /Configuração WhatsApp/i      },
-      { href: '/my-page',        heading: 'Página Pública'              },
+      { href: '/my-page-editor',  heading: /Minha Página Pública/i       },
     ];
 
     for (const route of routes) {
@@ -82,7 +82,7 @@ test.describe('Deep Links — Acesso Direto', () => {
       { url: '/services',  heading: 'Serviços'      },
       { url: '/settings',  heading: 'Configurações' },
       { url: '/schedule',  heading: 'Horários'      },
-      { url: '/my-page',   heading: 'Página Pública' },
+      { url: '/my-page-editor', heading: /Minha Página Pública/i },
     ];
 
     for (const link of deepLinks) {

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1092,6 +1092,8 @@
     "waitlistBadge": "Notify"
   },
   "pageEditor": {
+    "pageTitle": "My Public Page",
+    "pageDescription": "Customize your public page and preview in real time",
     "pageSections": "Page Sections",
     "saving": "Saving...",
     "saveOrder": "Save Order",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -1092,6 +1092,8 @@
     "waitlistBadge": "Notificar"
   },
   "pageEditor": {
+    "pageTitle": "Mi Página Pública",
+    "pageDescription": "Personaliza tu página pública y previsualiza en tiempo real",
     "pageSections": "Secciones de la Página",
     "saving": "Guardando...",
     "saveOrder": "Guardar Orden",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1092,6 +1092,8 @@
     "waitlistBadge": "Notificar"
   },
   "pageEditor": {
+    "pageTitle": "Minha Página Pública",
+    "pageDescription": "Personalize sua página pública e veja em tempo real",
     "pageSections": "Seções da Página",
     "saving": "Salvando...",
     "saveOrder": "Salvar Ordem",

--- a/src/__tests__/i18n/dashboard-i18n-completeness.test.ts
+++ b/src/__tests__/i18n/dashboard-i18n-completeness.test.ts
@@ -91,6 +91,7 @@ describe('i18n: pageEditor namespace — section-configurator keys', () => {
 
 describe('i18n: pageEditor namespace — my-page-editor keys', () => {
   const EXPECTED_KEYS = [
+    'pageTitle', 'pageDescription',
     'publicPage', 'viewLive', 'pageInfo',
     'images', 'profilePhoto', 'coverImage', 'changeCover',
     'bio', 'generateWithAI', 'bioPlaceholder',

--- a/src/app/[locale]/(dashboard)/layout.tsx
+++ b/src/app/[locale]/(dashboard)/layout.tsx
@@ -19,7 +19,6 @@ import {
   Users,
   QrCode,
   BarChart3,
-  FileEdit,
   ImageIcon,
   MessageSquare,
   Phone,
@@ -32,7 +31,7 @@ const TOUR_IDS: Partial<Record<string, string>> = {
   '/services': 'services',
   '/schedule': 'schedule',
   '/whatsapp-config': 'whatsapp',
-  '/my-page': 'my-page',
+  '/my-page-editor': 'my-page',
 };
 
 // Nav item definitions — labels injected at render time via t()
@@ -46,10 +45,9 @@ const NAV_ITEM_DEFS = [
   { href: '/analytics', tKey: 'analytics', icon: BarChart3 },
   { href: '/notifications', tKey: 'notifications', icon: Bell },
   { href: '/whatsapp-config', tKey: 'whatsapp', icon: Phone },
-  { href: '/my-page-editor', tKey: 'pageEditor', icon: FileEdit },
+  { href: '/my-page-editor', tKey: 'myPage', icon: Palette },
   { href: '/gallery', tKey: 'gallery', icon: ImageIcon },
   { href: '/testimonials', tKey: 'testimonials', icon: MessageSquare },
-  { href: '/my-page', tKey: 'myPage', icon: Palette },
   { href: '/settings', tKey: 'settings', icon: Settings },
   { href: '/support', tKey: 'support', icon: LifeBuoy },
 ] as const;

--- a/src/app/[locale]/(dashboard)/my-page-editor/page.tsx
+++ b/src/app/[locale]/(dashboard)/my-page-editor/page.tsx
@@ -1,14 +1,20 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
 import { PageEditor } from './page-editor';
+import { QrCodeDownload } from '@/components/dashboard/qr-code-download';
 
-export const metadata = {
-  title: 'Editor de Página | CircleHood Booking',
-  description: 'Personalize sua página pública',
-};
+export async function generateMetadata() {
+  const t = await getTranslations('pageEditor');
+  return {
+    title: `${t('pageTitle')} | CircleHood Booking`,
+    description: t('pageDescription'),
+  };
+}
 
 export default async function MyPageEditorPage() {
   const supabase = await createClient();
+  const t = await getTranslations('pageEditor');
 
   // Auth check
   const {
@@ -40,9 +46,9 @@ export default async function MyPageEditorPage() {
   return (
     <div className="container mx-auto py-6 px-4 lg:px-8">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold tracking-tight">Editor de Página</h1>
+        <h1 className="text-3xl font-bold tracking-tight">{t('pageTitle')}</h1>
         <p className="text-muted-foreground mt-2">
-          Personalize sua página pública e veja em tempo real
+          {t('pageDescription')}
         </p>
         <a
           href={`/${professional.slug}`}
@@ -50,9 +56,11 @@ export default async function MyPageEditorPage() {
           rel="noopener noreferrer"
           className="text-sm text-blue-600 hover:underline mt-2 inline-block"
         >
-          Ver página pública →
+          {t('viewPage')} →
         </a>
       </div>
+
+      <QrCodeDownload slug={professional.slug} businessName={professional.business_name} />
 
       <PageEditor
         professionalId={professional.id}

--- a/src/app/[locale]/(dashboard)/my-page/page.tsx
+++ b/src/app/[locale]/(dashboard)/my-page/page.tsx
@@ -1,37 +1,9 @@
-import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
-import { MyPageEditor } from '@/components/dashboard/my-page-editor';
-import { QrCodeDownload } from '@/components/dashboard/qr-code-download';
 
-export default async function MyPageEditorPage() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) redirect('/login');
-
-  const { data: professional } = await supabase
-    .from('professionals')
-    .select('*')
-    .eq('user_id', user.id)
-    .single();
-
-  if (!professional) redirect('/register');
-
-  const { data: services } = await supabase
-    .from('services')
-    .select('*')
-    .eq('professional_id', professional.id)
-    .order('sort_order', { ascending: true });
-
-  return (
-    <div>
-      <QrCodeDownload slug={professional.slug} businessName={professional.business_name} />
-      <MyPageEditor
-        professional={professional}
-        services={services || []}
-      />
-    </div>
-  );
+/**
+ * Legacy /my-page route — redirects to the consolidated /my-page-editor.
+ * Kept so bookmarks / old links still work.
+ */
+export default function MyPageRedirect() {
+  redirect('/my-page-editor');
 }

--- a/src/components/dashboard/mobile-nav.tsx
+++ b/src/components/dashboard/mobile-nav.tsx
@@ -13,7 +13,6 @@ import {
   UserCheck,
   QrCode,
   BarChart3,
-  FileEdit,
   ImageIcon,
   MessageSquare,
   Settings,
@@ -38,7 +37,7 @@ interface MobileNavProps {
 
 // data-tour-id values for guided tour — only items visible in the bottom bar
 const TOUR_IDS: Partial<Record<string, string>> = {
-  '/my-page': 'my-page',
+  '/my-page-editor': 'my-page',
   '/services': 'services',
 };
 
@@ -50,7 +49,7 @@ export function MobileNav({ professionalSlug, failedNotificationsCount = 0 }: Mo
   const MAIN_ITEMS = [
     { href: '/dashboard' as const, label: t('dashboard'), icon: LayoutDashboard },
     { href: '/bookings' as const, label: t('bookings'), icon: CalendarDays },
-    { href: '/my-page' as const, label: t('myPage'), icon: Palette },
+    { href: '/my-page-editor' as const, label: t('myPage'), icon: Palette },
     { href: '/services' as const, label: t('services'), icon: Scissors },
   ];
 
@@ -59,7 +58,6 @@ export function MobileNav({ professionalSlug, failedNotificationsCount = 0 }: Mo
     { href: '/clients' as const, label: t('clients'), icon: UserCheck },
     { href: '/marketing' as const, label: t('marketing'), icon: QrCode },
     { href: '/analytics' as const, label: t('analytics'), icon: BarChart3 },
-    { href: '/my-page-editor' as const, label: t('pageEditor'), icon: FileEdit },
     { href: '/gallery' as const, label: t('gallery'), icon: ImageIcon },
     { href: '/testimonials' as const, label: t('testimonials'), icon: MessageSquare },
     { href: '/notifications' as const, label: t('notifications'), icon: Bell },


### PR DESCRIPTION
## Summary
- `/my-page` now redirects to `/my-page-editor` (old bookmarks still work)
- Removed duplicate nav entry — single "Minha Página Pública" link in sidebar and mobile nav
- Moved `QrCodeDownload` component into the page editor page
- i18n'd hardcoded PT-BR strings in page editor (`pageTitle`, `pageDescription`)
- Updated tour IDs, E2E tests, and i18n completeness test

## Test plan
- [ ] Navigating to `/my-page` redirects to `/my-page-editor`
- [ ] Only one nav entry visible in sidebar (no more "Editor de Página" + "Página Pública")
- [ ] QR Code download banner appears on the editor page
- [ ] Page heading shows "Minha Página Pública" (pt-BR) / "My Public Page" (en-US) / "Mi Página Pública" (es-ES)
- [ ] Mobile bottom nav shows single entry pointing to `/my-page-editor`

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)