### PR TITLE
fix: [UX] Sidebar com 15 itens sem agrupamento — overwhelm para usuário novo (#389)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -23,6 +23,11 @@
     "backToLogin": "Back to login"
   },
   "nav": {
+    "groupMain": "Main",
+    "groupPage": "My Page",
+    "groupCommunication": "Communication",
+    "groupGrowth": "Growth",
+    "groupAccount": "Account",
     "dashboard": "Dashboard",
     "services": "Services",
     "bookings": "Bookings",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -23,6 +23,11 @@
     "backToLogin": "Volver al inicio de sesión"
   },
   "nav": {
+    "groupMain": "Principal",
+    "groupPage": "Mi Página",
+    "groupCommunication": "Comunicación",
+    "groupGrowth": "Crecimiento",
+    "groupAccount": "Cuenta",
     "dashboard": "Panel",
     "services": "Servicios",
     "bookings": "Reservas",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -23,6 +23,11 @@
     "backToLogin": "Voltar ao login"
   },
   "nav": {
+    "groupMain": "Principal",
+    "groupPage": "Minha Página",
+    "groupCommunication": "Comunicação",
+    "groupGrowth": "Crescimento",
+    "groupAccount": "Conta",
     "dashboard": "Painel",
     "services": "Serviços",
     "bookings": "Agendamentos",

--- a/src/app/[locale]/(dashboard)/layout.tsx
+++ b/src/app/[locale]/(dashboard)/layout.tsx
@@ -2,57 +2,13 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import Link from 'next/link';
 import { MobileNav } from '@/components/dashboard/mobile-nav';
+import { Sidebar } from '@/components/dashboard/sidebar';
 import { CircleHoodLogoCompact } from '@/components/branding/logo';
 import { GuidedTour } from '@/components/onboarding/guided-tour';
 import { EmailVerificationBanner } from '@/components/dashboard/email-verification-banner';
 import { TrialExpirationBanner } from '@/components/dashboard/trial-expiration-banner';
 import { getTrialStatus } from '@/lib/trial-helpers';
 import { getTranslations } from 'next-intl/server';
-import {
-  LayoutDashboard,
-  Scissors,
-  CalendarDays,
-  Clock,
-  Palette,
-  Settings,
-  LogOut,
-  Users,
-  QrCode,
-  BarChart3,
-  ImageIcon,
-  MessageSquare,
-  Phone,
-  Bell,
-  LifeBuoy,
-} from 'lucide-react';
-
-// data-tour-id values for guided tour — keyed by nav href
-const TOUR_IDS: Partial<Record<string, string>> = {
-  '/services': 'services',
-  '/schedule': 'schedule',
-  '/whatsapp-config': 'whatsapp',
-  '/my-page-editor': 'my-page',
-};
-
-// Nav item definitions — labels injected at render time via t()
-const NAV_ITEM_DEFS = [
-  { href: '/dashboard', tKey: 'dashboard', icon: LayoutDashboard },
-  { href: '/services', tKey: 'services', icon: Scissors },
-  { href: '/bookings', tKey: 'bookings', icon: CalendarDays },
-  { href: '/schedule', tKey: 'schedule', icon: Clock },
-  { href: '/clients', tKey: 'clients', icon: Users },
-  { href: '/marketing', tKey: 'marketing', icon: QrCode },
-  { href: '/analytics', tKey: 'analytics', icon: BarChart3 },
-  { href: '/notifications', tKey: 'notifications', icon: Bell },
-  { href: '/whatsapp-config', tKey: 'whatsapp', icon: Phone },
-  { href: '/my-page-editor', tKey: 'myPage', icon: Palette },
-  { href: '/gallery', tKey: 'gallery', icon: ImageIcon },
-  { href: '/testimonials', tKey: 'testimonials', icon: MessageSquare },
-  { href: '/settings', tKey: 'settings', icon: Settings },
-  { href: '/support', tKey: 'support', icon: LifeBuoy },
-] as const;
-
-// Automações removida do nav intencionalmente (rota ainda existe)
 
 export default async function DashboardLayout({
   children,
@@ -117,70 +73,12 @@ export default async function DashboardLayout({
   return (
     <div className="min-h-screen flex">
       {/* Sidebar */}
-      <aside className="hidden md:flex w-64 flex-col border-r bg-muted/30 h-screen sticky top-0">
-        <div className="p-4 pb-3 shrink-0">
-          <Link href="/dashboard" className="flex items-center gap-2">
-            <CircleHoodLogoCompact size="sm" />
-            <span className="text-sm font-bold leading-tight">CircleHood<br /><span className="text-xs font-normal text-muted-foreground">Booking</span></span>
-          </Link>
-          {professional && (
-            <p className="text-xs text-muted-foreground mt-2 truncate pl-1">
-              {professional.business_name}
-            </p>
-          )}
-        </div>
-
-        <nav className="flex-1 overflow-y-auto px-3 space-y-1 py-1">
-          {NAV_ITEM_DEFS.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              data-tour-id={TOUR_IDS[item.href]}
-              className="flex items-center gap-3 px-3 py-2 text-sm rounded-md hover:bg-accent transition-colors"
-            >
-              <item.icon className="h-4 w-4" />
-              {t(item.tKey)}
-              {item.href === '/notifications' && failedCount > 0 && (
-                <span className="ml-auto text-[10px] font-bold bg-destructive text-destructive-foreground rounded-full px-1.5 py-0.5 min-w-[18px] text-center leading-none">
-                  {failedCount > 99 ? '99+' : failedCount}
-                </span>
-              )}
-            </Link>
-          ))}
-        </nav>
-
-        <div className="shrink-0 p-3 border-t">
-          {professional && (
-            <a
-              href={`/${professional.slug}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block px-3 py-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              {t('viewPublicPage')} &rarr;
-            </a>
-          )}
-          {user.email && (
-            <p className="px-3 py-1 text-[11px] text-muted-foreground truncate" title={user.email}>
-              {user.email}
-            </p>
-          )}
-          <form action="/api/auth/signout" method="POST">
-            <button
-              type="submit"
-              className="flex items-center gap-3 px-3 py-2 text-sm text-muted-foreground hover:text-foreground w-full rounded-md hover:bg-accent transition-colors"
-            >
-              <LogOut className="h-4 w-4" />
-              {t('logout')}
-            </button>
-          </form>
-          <div className="px-3 pt-2">
-            <p className="text-[10px] text-muted-foreground/50">
-              by CircleHood Tech
-            </p>
-          </div>
-        </div>
-      </aside>
+      <Sidebar
+        professionalSlug={professional?.slug}
+        businessName={professional?.business_name}
+        userEmail={user.email}
+        failedNotificationsCount={failedCount}
+      />
 
       {/* Mobile header */}
       <div className="flex-1 flex flex-col">

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import { CircleHoodLogoCompact } from '@/components/branding/logo';
+import {
+  LayoutDashboard,
+  Scissors,
+  CalendarDays,
+  Clock,
+  Users,
+  QrCode,
+  BarChart3,
+  Bell,
+  Phone,
+  Palette,
+  ImageIcon,
+  MessageSquare,
+  Settings,
+  LifeBuoy,
+  LogOut,
+} from 'lucide-react';
+
+// Tour IDs for guided tour — keyed by nav href
+const TOUR_IDS: Partial<Record<string, string>> = {
+  '/services': 'services',
+  '/schedule': 'schedule',
+  '/whatsapp-config': 'whatsapp',
+  '/my-page-editor': 'my-page',
+};
+
+const NAV_GROUPS = [
+  {
+    tKey: 'groupMain' as const,
+    items: [
+      { href: '/dashboard', tKey: 'dashboard' as const, icon: LayoutDashboard },
+      { href: '/bookings', tKey: 'bookings' as const, icon: CalendarDays },
+      { href: '/services', tKey: 'services' as const, icon: Scissors },
+      { href: '/schedule', tKey: 'schedule' as const, icon: Clock },
+      { href: '/clients', tKey: 'clients' as const, icon: Users },
+    ],
+  },
+  {
+    tKey: 'groupPage' as const,
+    items: [
+      { href: '/my-page-editor', tKey: 'myPage' as const, icon: Palette },
+      { href: '/gallery', tKey: 'gallery' as const, icon: ImageIcon },
+      { href: '/testimonials', tKey: 'testimonials' as const, icon: MessageSquare },
+    ],
+  },
+  {
+    tKey: 'groupCommunication' as const,
+    items: [
+      { href: '/whatsapp-config', tKey: 'whatsapp' as const, icon: Phone },
+      { href: '/notifications', tKey: 'notifications' as const, icon: Bell },
+    ],
+  },
+  {
+    tKey: 'groupGrowth' as const,
+    items: [
+      { href: '/marketing', tKey: 'marketing' as const, icon: QrCode },
+      { href: '/analytics', tKey: 'analytics' as const, icon: BarChart3 },
+    ],
+  },
+  {
+    tKey: 'groupAccount' as const,
+    items: [
+      { href: '/settings', tKey: 'settings' as const, icon: Settings },
+      { href: '/support', tKey: 'support' as const, icon: LifeBuoy },
+    ],
+  },
+];
+
+interface SidebarProps {
+  professionalSlug?: string;
+  businessName?: string;
+  userEmail?: string;
+  failedNotificationsCount: number;
+}
+
+export function Sidebar({
+  professionalSlug,
+  businessName,
+  userEmail,
+  failedNotificationsCount,
+}: SidebarProps) {
+  const pathname = usePathname();
+  const t = useTranslations('nav');
+
+  function isActive(href: string) {
+    // Strip locale prefix if present (e.g. /pt-BR/dashboard → /dashboard)
+    const clean = pathname.replace(/^\/[a-z]{2}-[A-Z]{2}/, '');
+    return clean === href || clean.startsWith(href + '/');
+  }
+
+  return (
+    <aside className="hidden md:flex w-64 flex-col border-r bg-muted/30 h-screen sticky top-0">
+      <div className="p-4 pb-3 shrink-0">
+        <Link href="/dashboard" className="flex items-center gap-2">
+          <CircleHoodLogoCompact size="sm" />
+          <span className="text-sm font-bold leading-tight">
+            CircleHood<br />
+            <span className="text-xs font-normal text-muted-foreground">Booking</span>
+          </span>
+        </Link>
+        {businessName && (
+          <p className="text-xs text-muted-foreground mt-2 truncate pl-1">
+            {businessName}
+          </p>
+        )}
+      </div>
+
+      <nav className="flex-1 overflow-y-auto px-3 py-1">
+        {NAV_GROUPS.map((group) => (
+          <div key={group.tKey} className="mb-3">
+            <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+              {t(group.tKey)}
+            </p>
+            <div className="space-y-0.5">
+              {group.items.map((item) => {
+                const active = isActive(item.href);
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    data-tour-id={TOUR_IDS[item.href]}
+                    className={cn(
+                      'flex items-center gap-3 px-3 py-2 text-sm rounded-md transition-colors',
+                      active
+                        ? 'bg-primary/10 text-primary font-medium'
+                        : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+                    )}
+                  >
+                    <item.icon className={cn('h-4 w-4', active && 'text-primary')} />
+                    {t(item.tKey)}
+                    {item.href === '/notifications' && failedNotificationsCount > 0 && (
+                      <span className="ml-auto text-[10px] font-bold bg-destructive text-destructive-foreground rounded-full px-1.5 py-0.5 min-w-[18px] text-center leading-none">
+                        {failedNotificationsCount > 99 ? '99+' : failedNotificationsCount}
+                      </span>
+                    )}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </nav>
+
+      <div className="shrink-0 p-3 border-t">
+        {professionalSlug && (
+          <a
+            href={`/${professionalSlug}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block px-3 py-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {t('viewPublicPage')} &rarr;
+          </a>
+        )}
+        {userEmail && (
+          <p className="px-3 py-1 text-[11px] text-muted-foreground truncate" title={userEmail}>
+            {userEmail}
+          </p>
+        )}
+        <form action="/api/auth/signout" method="POST">
+          <button
+            type="submit"
+            className="flex items-center gap-3 px-3 py-2 text-sm text-muted-foreground hover:text-foreground w-full rounded-md hover:bg-accent transition-colors"
+          >
+            <LogOut className="h-4 w-4" />
+            {t('logout')}
+          </button>
+        </form>
+        <div className="px-3 pt-2">
+          <p className="text-[10px] text-muted-foreground/50">
+            by CircleHood Tech
+          </p>
+        </div>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- **Grouped navigation**: 14 items organized into 5 categories (Principal, Minha Página, Comunicação, Crescimento, Conta)
- **Active state highlight**: Current page gets `bg-primary/10 + text-primary` styling via `usePathname()`
- **Extracted Sidebar component**: Server layout now delegates to `<Sidebar />` client component for interactivity
- **Group labels**: Uppercase 10px semibold text for visual hierarchy between sections
- **i18n**: Added 5 `group*` keys to all 3 locales (pt-BR, en-US, es-ES)

## Test plan
- [ ] Sidebar shows grouped items with section labels
- [ ] Active page is highlighted with primary color
- [ ] Navigation between pages updates the active state
- [ ] Tour IDs still work (guided tour targets unchanged)
- [ ] `aside nav a[href$="..."]` selector still works for E2E tests
- [ ] Notification badge still appears on Notifications link
- [ ] Mobile nav unchanged (bottom bar + menu sheet)
- [ ] All 3 locales display correct group labels

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)