### PR TITLE
fix: i18n booking success/cancel, slug hint, hide empty stats (#394)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -106,6 +106,7 @@
     "signupError": "Error creating account.",
     "signupFree": "Sign up free",
     "slugTaken": "This link is already taken.",
+    "slugHint": "This will be your public page address. You can change it later in settings.",
     "slugUnavailableError": "Choose an available link for your page.",
     "socialLoginError": "Error connecting with {provider}. Please try again.",
     "startCreatingAccount": "Start by creating your account",
@@ -347,7 +348,15 @@
     "demoService2": "Spa Pedicure",
     "demoService2Desc": "Relaxing pedicure with exfoliation, deep moisturizing and polish",
     "demoService3": "Gel Nails with Design",
-    "demoService3Desc": "Gel nail extensions with custom decoration and nail art"
+    "demoService3Desc": "Gel nail extensions with custom decoration and nail art",
+    "successTitle": "Booking confirmed!",
+    "successDescription": "Your payment was processed successfully and the booking has been confirmed.",
+    "successConfirmationNote": "You will receive a confirmation shortly via email and/or WhatsApp.",
+    "backToProfessional": "Back to professional's page",
+    "cancelledPaymentTitle": "Payment cancelled",
+    "cancelledPaymentDescription": "The payment was cancelled. Your booking has not been confirmed.",
+    "cancelledRetryNote": "You can try again anytime.",
+    "tryAgainBooking": "Try again"
   },
   "whatsapp": {
     "usageTitle": "WhatsApp Usage (Today)",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -106,6 +106,7 @@
     "signupError": "Error al crear la cuenta.",
     "signupFree": "Regístrate gratis",
     "slugTaken": "Este enlace ya está en uso.",
+    "slugHint": "Esta será la dirección de tu página pública. Puedes cambiarla después en configuración.",
     "slugUnavailableError": "Elige un enlace disponible para tu página.",
     "socialLoginError": "Error al conectar con {provider}. Inténtalo de nuevo.",
     "startCreatingAccount": "Empieza creando tu cuenta",
@@ -347,7 +348,15 @@
     "demoService2": "Pedicura Spa",
     "demoService2Desc": "Pedicura relajante con exfoliación, hidratación profunda y esmaltado",
     "demoService3": "Uñas de Gel con Diseño",
-    "demoService3Desc": "Extensiones de gel con decoración personalizada y nail art"
+    "demoService3Desc": "Extensiones de gel con decoración personalizada y nail art",
+    "successTitle": "¡Reserva confirmada!",
+    "successDescription": "Su pago fue procesado con éxito y la reserva ha sido confirmada.",
+    "successConfirmationNote": "Recibirá una confirmación en breve por email y/o WhatsApp.",
+    "backToProfessional": "Volver a la página del profesional",
+    "cancelledPaymentTitle": "Pago cancelado",
+    "cancelledPaymentDescription": "El pago fue cancelado. Su reserva no ha sido confirmada.",
+    "cancelledRetryNote": "Puede intentar de nuevo cuando quiera.",
+    "tryAgainBooking": "Intentar de nuevo"
   },
   "whatsapp": {
     "usageTitle": "Uso de WhatsApp (Hoy)",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -106,6 +106,7 @@
     "signupError": "Erro ao criar conta.",
     "signupFree": "Cadastre-se grátis",
     "slugTaken": "Este link já está em uso.",
+    "slugHint": "Este será o endereço da sua página pública. Pode alterá-lo depois nas configurações.",
     "slugUnavailableError": "Escolha um link disponível para sua página.",
     "socialLoginError": "Erro ao conectar com {provider}. Tente novamente.",
     "startCreatingAccount": "Comece criando sua conta",
@@ -347,7 +348,15 @@
     "demoService2": "Pedicure Spa",
     "demoService2Desc": "Pedicure relaxante com esfoliação, hidratação profunda e esmaltação",
     "demoService3": "Unhas em Gel com Design",
-    "demoService3Desc": "Alongamento em gel com decoração personalizada e nail art"
+    "demoService3Desc": "Alongamento em gel com decoração personalizada e nail art",
+    "successTitle": "Agendamento confirmado!",
+    "successDescription": "O seu pagamento foi processado com sucesso e o agendamento foi confirmado.",
+    "successConfirmationNote": "Receberá uma confirmação em breve por email e/ou WhatsApp.",
+    "backToProfessional": "Voltar à página do profissional",
+    "cancelledPaymentTitle": "Pagamento cancelado",
+    "cancelledPaymentDescription": "O pagamento foi cancelado. O seu agendamento não foi confirmado.",
+    "cancelledRetryNote": "Pode tentar novamente quando quiser.",
+    "tryAgainBooking": "Tentar novamente"
   },
   "whatsapp": {
     "usageTitle": "Uso do WhatsApp (Hoje)",

--- a/src/app/[locale]/(auth)/register/page.tsx
+++ b/src/app/[locale]/(auth)/register/page.tsx
@@ -306,6 +306,7 @@ export default function RegisterPage() {
                 {slugAvailable === false && (
                   <p data-testid="slug-error" className="text-xs text-destructive">{t('slugTaken')}</p>
                 )}
+                <p className="text-xs text-muted-foreground">{t('slugHint')}</p>
               </div>
 
               <div className="space-y-2">

--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -291,122 +291,126 @@ export default async function DashboardPage() {
       {/* CRM Alerts */}
       <AlertsWidget />
 
-      {/* Stats */}
-      <div className="space-y-4">
-        <div>
-          <h2 className="text-sm font-medium text-muted-foreground mb-3">{t('statsSectionBookings')}</h2>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            <Card>
-              <CardContent className="p-4 sm:p-6">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-primary/10">
-                    <CalendarDays className="h-5 w-5 text-primary" />
+      {/* Stats — only show when there's data */}
+      {((todayBookings ?? 0) > 0 || (weekBookings ?? 0) > 0 || (monthBookings ?? 0) > 0 || (totalServices ?? 0) > 0) && (
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-sm font-medium text-muted-foreground mb-3">{t('statsSectionBookings')}</h2>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+              <Card>
+                <CardContent className="p-4 sm:p-6">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 rounded-lg bg-primary/10">
+                      <CalendarDays className="h-5 w-5 text-primary" />
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground">{t('statsTodayLabel')}</p>
+                      <p className="text-2xl font-bold">{todayBookings || 0}</p>
+                    </div>
                   </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">{t('statsTodayLabel')}</p>
-                    <p className="text-2xl font-bold">{todayBookings || 0}</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
 
-            <Card>
-              <CardContent className="p-4 sm:p-6">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-primary/10">
-                    <CalendarRange className="h-5 w-5 text-primary" />
+              <Card>
+                <CardContent className="p-4 sm:p-6">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 rounded-lg bg-primary/10">
+                      <CalendarRange className="h-5 w-5 text-primary" />
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground">{t('statsWeekLabel')}</p>
+                      <p className="text-2xl font-bold">{weekBookings || 0}</p>
+                    </div>
                   </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">{t('statsWeekLabel')}</p>
-                    <p className="text-2xl font-bold">{weekBookings || 0}</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
 
-            <Card>
-              <CardContent className="p-4 sm:p-6">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-primary/10">
-                    <TrendingUp className="h-5 w-5 text-primary" />
+              <Card>
+                <CardContent className="p-4 sm:p-6">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 rounded-lg bg-primary/10">
+                      <TrendingUp className="h-5 w-5 text-primary" />
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground">{t('statsMonthLabel')}</p>
+                      <p className="text-2xl font-bold">{monthBookings || 0}</p>
+                    </div>
                   </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">{t('statsMonthLabel')}</p>
-                    <p className="text-2xl font-bold">{monthBookings || 0}</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
 
-            <Card>
-              <CardContent className="p-4 sm:p-6">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-primary/10">
-                    <Users className="h-5 w-5 text-primary" />
+              <Card>
+                <CardContent className="p-4 sm:p-6">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 rounded-lg bg-primary/10">
+                      <Users className="h-5 w-5 text-primary" />
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground">{t('statsServicesLabel')}</p>
+                      <p className="text-2xl font-bold">{totalServices || 0}</p>
+                    </div>
                   </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">{t('statsServicesLabel')}</p>
-                    <p className="text-2xl font-bold">{totalServices || 0}</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+            </div>
           </div>
+
+          {(todayRevenueTotal > 0 || weekRevenueTotal > 0 || monthRevenueTotal > 0) && (
+            <div>
+              <h2 className="text-sm font-medium text-muted-foreground mb-3">{t('statsSectionRevenue')}</h2>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <Card>
+                  <CardContent className="p-4 sm:p-6">
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/20">
+                        <TrendingUp className="h-5 w-5 text-green-600 dark:text-green-400" />
+                      </div>
+                      <div>
+                        <p className="text-xs text-muted-foreground">{t('statsTodayLabel')}</p>
+                        <p className="text-2xl font-bold text-green-600 dark:text-green-400">
+                          {currencySymbol}{todayRevenueTotal.toFixed(0)}
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardContent className="p-4 sm:p-6">
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/20">
+                        <TrendingUp className="h-5 w-5 text-green-600 dark:text-green-400" />
+                      </div>
+                      <div>
+                        <p className="text-xs text-muted-foreground">{t('statsWeekLabel')}</p>
+                        <p className="text-2xl font-bold text-green-600 dark:text-green-400">
+                          {currencySymbol}{weekRevenueTotal.toFixed(0)}
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardContent className="p-4 sm:p-6">
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/20">
+                        <TrendingUp className="h-5 w-5 text-green-600 dark:text-green-400" />
+                      </div>
+                      <div>
+                        <p className="text-xs text-muted-foreground">{t('statsMonthLabel')}</p>
+                        <p className="text-2xl font-bold text-green-600 dark:text-green-400">
+                          {currencySymbol}{monthRevenueTotal.toFixed(0)}
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          )}
         </div>
-
-        <div>
-          <h2 className="text-sm font-medium text-muted-foreground mb-3">{t('statsSectionRevenue')}</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            <Card>
-              <CardContent className="p-4 sm:p-6">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/20">
-                    <TrendingUp className="h-5 w-5 text-green-600 dark:text-green-400" />
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">{t('statsTodayLabel')}</p>
-                    <p className="text-2xl font-bold text-green-600 dark:text-green-400">
-                      {currencySymbol}{todayRevenueTotal.toFixed(0)}
-                    </p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardContent className="p-4 sm:p-6">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/20">
-                    <TrendingUp className="h-5 w-5 text-green-600 dark:text-green-400" />
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">{t('statsWeekLabel')}</p>
-                    <p className="text-2xl font-bold text-green-600 dark:text-green-400">
-                      {currencySymbol}{weekRevenueTotal.toFixed(0)}
-                    </p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardContent className="p-4 sm:p-6">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/20">
-                    <TrendingUp className="h-5 w-5 text-green-600 dark:text-green-400" />
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">{t('statsMonthLabel')}</p>
-                    <p className="text-2xl font-bold text-green-600 dark:text-green-400">
-                      {currencySymbol}{monthRevenueTotal.toFixed(0)}
-                    </p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </div>
+      )}
 
       {/* Subscription status badge */}
       <Card>

--- a/src/app/[locale]/(public)/booking/cancel/page.tsx
+++ b/src/app/[locale]/(public)/booking/cancel/page.tsx
@@ -2,22 +2,31 @@ import { XCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
 
-export default function BookingCancelPage() {
+interface Props {
+  searchParams: Promise<{ slug?: string }>;
+}
+
+export default async function BookingCancelPage({ searchParams }: Props) {
+  const t = await getTranslations('public');
+  const params = await searchParams;
+  const backHref = params.slug ? `/${params.slug}` : '/';
+
   return (
     <div className="min-h-screen bg-background flex items-center justify-center px-4">
       <Card className="max-w-md w-full">
         <CardContent className="p-8 text-center space-y-4">
           <XCircle className="h-16 w-16 text-red-400 mx-auto" />
-          <h1 className="text-2xl font-bold">Pagamento cancelado</h1>
+          <h1 className="text-2xl font-bold">{t('cancelledPaymentTitle')}</h1>
           <p className="text-muted-foreground">
-            O pagamento foi cancelado. O seu agendamento não foi confirmado.
+            {t('cancelledPaymentDescription')}
           </p>
           <p className="text-sm text-muted-foreground">
-            Pode tentar novamente quando quiser.
+            {t('cancelledRetryNote')}
           </p>
           <Button asChild className="w-full">
-            <Link href="/">Tentar novamente</Link>
+            <Link href={backHref}>{t('tryAgainBooking')}</Link>
           </Button>
         </CardContent>
       </Card>

--- a/src/app/[locale]/(public)/booking/success/page.tsx
+++ b/src/app/[locale]/(public)/booking/success/page.tsx
@@ -2,22 +2,31 @@ import { CheckCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
 
-export default function BookingSuccessPage() {
+interface Props {
+  searchParams: Promise<{ slug?: string }>;
+}
+
+export default async function BookingSuccessPage({ searchParams }: Props) {
+  const t = await getTranslations('public');
+  const params = await searchParams;
+  const backHref = params.slug ? `/${params.slug}` : '/';
+
   return (
     <div className="min-h-screen bg-background flex items-center justify-center px-4">
       <Card className="max-w-md w-full">
         <CardContent className="p-8 text-center space-y-4">
           <CheckCircle className="h-16 w-16 text-green-500 mx-auto" />
-          <h1 data-testid="success-message" className="text-2xl font-bold">Agendamento confirmado!</h1>
+          <h1 data-testid="success-message" className="text-2xl font-bold">{t('successTitle')}</h1>
           <p data-testid="payment-confirmed" className="text-muted-foreground">
-            O seu pagamento foi processado com sucesso e o agendamento foi confirmado.
+            {t('successDescription')}
           </p>
           <p className="text-sm text-muted-foreground">
-            Receberá uma confirmação em breve por email e/ou WhatsApp.
+            {t('successConfirmationNote')}
           </p>
           <Button asChild variant="outline" className="w-full">
-            <Link href="/">Voltar ao início</Link>
+            <Link href={backHref}>{t('backToProfessional')}</Link>
           </Button>
         </CardContent>
       </Card>

--- a/src/app/api/bookings/checkout/route.ts
+++ b/src/app/api/bookings/checkout/route.ts
@@ -55,7 +55,7 @@ export async function POST(request: NextRequest) {
   const { data: prof } = await supabase
     .from('professionals')
     .select(
-      'subscription_status, trial_ends_at, stripe_account_id, currency, require_deposit, deposit_type, deposit_value'
+      'subscription_status, trial_ends_at, stripe_account_id, currency, require_deposit, deposit_type, deposit_value, slug'
     )
     .eq('id', professional_id)
     .single();
@@ -248,8 +248,8 @@ export async function POST(request: NextRequest) {
           type: 'deposit',
         },
         customer_email: client_email,
-        success_url: `${BASE_URL}/booking/success?session_id={CHECKOUT_SESSION_ID}`,
-        cancel_url: `${BASE_URL}/booking/cancel`,
+        success_url: `${BASE_URL}/booking/success?session_id={CHECKOUT_SESSION_ID}&slug=${encodeURIComponent(prof.slug as string || '')}`,
+        cancel_url: `${BASE_URL}/booking/cancel?slug=${encodeURIComponent(prof.slug as string || '')}`,
       },
       { idempotencyKey }
     );


### PR DESCRIPTION
## Summary
- Booking success/cancel pages: replaced hardcoded PT-BR with i18n via `getTranslations('public')`
- "Back" button now links to the professional's page (`/{slug}`) instead of `/`
- Checkout API passes `slug` in success_url and cancel_url query params
- Register page: added `slugHint` tooltip below the slug input field
- Dashboard: stats sections hidden when all bookings/revenue values are zero

## Test plan
- [ ] Visit `/booking/success?slug=test` — texts translated, back button goes to `/test`
- [ ] Visit `/booking/cancel?slug=test` — texts translated, retry button goes to `/test`
- [ ] Visit `/register` — slug field shows hint text below input
- [ ] Dashboard with no bookings — stats section not visible
- [ ] Dashboard with bookings — stats section visible
- [ ] Test in pt-BR, en-US, es-ES locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)