### PR TITLE
fix: [UX] Duas páginas de edição de página pública usando sistemas diferentes (#414)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1244,7 +1244,13 @@
     "sectionTypeGallery": "Gallery",
     "sectionTypeTestimonials": "Testimonials",
     "sectionTypeFaq": "Frequently Asked Questions",
-    "sectionTypeContact": "Contact"
+    "sectionTypeContact": "Contact",
+    "hideSection": "Hide",
+    "showSection": "Show",
+    "editSection": "Edit",
+    "translating": "Translating...",
+    "translated": "Translated!",
+    "translateAuto": "Auto Translate"
   },
   "nextSteps": {
     "title": "Congratulations! You're ready to receive clients!",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -1244,7 +1244,13 @@
     "sectionTypeGallery": "Galería",
     "sectionTypeTestimonials": "Testimonios",
     "sectionTypeFaq": "Preguntas Frecuentes",
-    "sectionTypeContact": "Contacto"
+    "sectionTypeContact": "Contacto",
+    "hideSection": "Ocultar",
+    "showSection": "Mostrar",
+    "editSection": "Editar",
+    "translating": "Traduciendo...",
+    "translated": "¡Traducido!",
+    "translateAuto": "Traducir Automáticamente"
   },
   "nextSteps": {
     "title": "¡Felicitaciones! ¡Estás listo para recibir clientes!",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1244,7 +1244,13 @@
     "sectionTypeGallery": "Galeria",
     "sectionTypeTestimonials": "Depoimentos",
     "sectionTypeFaq": "Perguntas Frequentes",
-    "sectionTypeContact": "Contato"
+    "sectionTypeContact": "Contato",
+    "hideSection": "Ocultar",
+    "showSection": "Mostrar",
+    "editSection": "Editar",
+    "translating": "Traduzindo...",
+    "translated": "Traduzido!",
+    "translateAuto": "Traduzir Automaticamente"
   },
   "nextSteps": {
     "title": "Parabéns! Você está pronto para receber clientes!",

--- a/src/components/page-editor/auto-translate-button.tsx
+++ b/src/components/page-editor/auto-translate-button.tsx
@@ -2,6 +2,7 @@
 import { logger } from '@/lib/logger';
 
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Loader2, Sparkles } from 'lucide-react';
 
@@ -16,6 +17,7 @@ export function AutoTranslateButton({
   fromLanguage = 'pt',
   onTranslated,
 }: AutoTranslateButtonProps) {
+  const t = useTranslations('pageEditor');
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
 
@@ -62,17 +64,17 @@ export function AutoTranslateButton({
       {loading ? (
         <>
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          Traduzindo...
+          {t('translating')}
         </>
       ) : done ? (
         <>
           <Sparkles className="h-3.5 w-3.5 text-green-500" />
-          Traduzido!
+          {t('translated')}
         </>
       ) : (
         <>
           <Sparkles className="h-3.5 w-3.5" />
-          Traduzir Automaticamente
+          {t('translateAuto')}
         </>
       )}
     </Button>

--- a/src/components/page-editor/sortable-section-item.tsx
+++ b/src/components/page-editor/sortable-section-item.tsx
@@ -2,6 +2,7 @@
 
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { useTranslations } from 'next-intl';
 import { GripVertical, Eye, EyeOff, Settings } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -14,6 +15,7 @@ interface SortableSectionItemProps {
 }
 
 export function SortableSectionItem({ section, label, onToggle, onEdit }: SortableSectionItemProps) {
+  const t = useTranslations('pageEditor');
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: section.id,
   });
@@ -49,11 +51,11 @@ export function SortableSectionItem({ section, label, onToggle, onEdit }: Sortab
             size="sm"
             variant="ghost"
             onClick={() => onToggle(section.id)}
-            title={section.is_visible ? 'Ocultar' : 'Mostrar'}
+            title={section.is_visible ? t('hideSection') : t('showSection')}
           >
             {section.is_visible ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
           </Button>
-          <Button size="sm" variant="ghost" onClick={onEdit} title="Editar">
+          <Button size="sm" variant="ghost" onClick={onEdit} title={t('editSection')}>
             <Settings className="w-4 h-4" />
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- **Canonical system**: `/my-page-editor` with `page_sections` table (already established in #388)
- **Redirect**: `/my-page` → `/my-page-editor` (already done in #388)
- **Sidebar**: single "Minha Página" link to `/my-page-editor` (already done in #389)
- **i18n fix**: `sortable-section-item.tsx` — hardcoded PT-BR titles ("Ocultar"/"Mostrar"/"Editar") replaced with `useTranslations('pageEditor')`
- **i18n fix**: `auto-translate-button.tsx` — hardcoded PT-BR ("Traduzindo..."/"Traduzido!"/"Traduzir Automaticamente") replaced with `useTranslations('pageEditor')`
- Added 6 new `pageEditor` keys across pt-BR, en-US, es-ES

Closes #414

## Test plan
- [ ] Open `/my-page-editor` — section items show translated hide/show/edit titles
- [ ] Click translate button — shows translated loading/done states
- [ ] Switch locale to en-US / es-ES — all strings translated
- [ ] Visit `/my-page` — redirects to `/my-page-editor`
- [ ] Sidebar has only one "Minha Página" entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)