### PR TITLE
fix: [UX] /register e /complete-profile: categorias e países hardcoded PT-BR

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -153,7 +153,42 @@
     "resetPasswordRequestNew": "Request New Link",
     "resetPasswordMinLength": "Password must be at least 6 characters.",
     "resetPasswordMismatch": "Passwords do not match.",
-    "resetPasswordError": "Error resetting password. Please try again."
+    "resetPasswordError": "Error resetting password. Please try again.",
+    "categories": {
+      "barber": "Barber",
+      "hairdresser": "Hairdresser",
+      "coach": "Coach / Consultant",
+      "cleaner": "Cleaner",
+      "dogGroomer": "Dog Groomer / Pet",
+      "esthetician": "Esthetician",
+      "physiotherapist": "Physiotherapist",
+      "photographer": "Photographer",
+      "yogaInstructor": "Yoga / Pilates Instructor",
+      "makeupArtist": "Makeup Artist",
+      "massageTherapist": "Massage Therapist",
+      "nailTech": "Nail Tech",
+      "nutritionist": "Nutritionist",
+      "personalTrainer": "Personal Trainer",
+      "teacher": "Teacher / Tutor",
+      "psychologist": "Psychologist / Therapist",
+      "other": "Other"
+    },
+    "countries": {
+      "IE": "Ireland",
+      "PT": "Portugal",
+      "BR": "Brazil",
+      "GB": "United Kingdom",
+      "US": "United States",
+      "ES": "Spain",
+      "FR": "France",
+      "DE": "Germany",
+      "IT": "Italy",
+      "AU": "Australia",
+      "CA": "Canada",
+      "MX": "Mexico",
+      "AR": "Argentina",
+      "CO": "Colombia"
+    }
   },
   "dashboard": {
     "welcome": "Welcome, {name}!",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -153,7 +153,42 @@
     "resetPasswordRequestNew": "Solicitar Nuevo Enlace",
     "resetPasswordMinLength": "La contraseña debe tener al menos 6 caracteres.",
     "resetPasswordMismatch": "Las contraseñas no coinciden.",
-    "resetPasswordError": "Error al restablecer la contraseña. Inténtalo de nuevo."
+    "resetPasswordError": "Error al restablecer la contraseña. Inténtalo de nuevo.",
+    "categories": {
+      "barber": "Barbero",
+      "hairdresser": "Peluquero(a)",
+      "coach": "Coach / Consultor",
+      "cleaner": "Limpieza",
+      "dogGroomer": "Peluquería Canina / Mascotas",
+      "esthetician": "Esteticista",
+      "physiotherapist": "Fisioterapeuta",
+      "photographer": "Fotógrafo",
+      "yogaInstructor": "Instructor de Yoga/Pilates",
+      "makeupArtist": "Maquillador(a)",
+      "massageTherapist": "Masajista",
+      "nailTech": "Nail Tech",
+      "nutritionist": "Nutricionista",
+      "personalTrainer": "Personal Trainer",
+      "teacher": "Profesor / Tutor",
+      "psychologist": "Psicólogo / Terapeuta",
+      "other": "Otro"
+    },
+    "countries": {
+      "IE": "Irlanda",
+      "PT": "Portugal",
+      "BR": "Brasil",
+      "GB": "Reino Unido",
+      "US": "Estados Unidos",
+      "ES": "España",
+      "FR": "Francia",
+      "DE": "Alemania",
+      "IT": "Italia",
+      "AU": "Australia",
+      "CA": "Canadá",
+      "MX": "México",
+      "AR": "Argentina",
+      "CO": "Colombia"
+    }
   },
   "dashboard": {
     "welcome": "¡Bienvenido, {name}!",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -153,7 +153,42 @@
     "resetPasswordRequestNew": "Solicitar Novo Link",
     "resetPasswordMinLength": "A senha deve ter no mínimo 6 caracteres.",
     "resetPasswordMismatch": "As senhas não coincidem.",
-    "resetPasswordError": "Erro ao redefinir senha. Tente novamente."
+    "resetPasswordError": "Erro ao redefinir senha. Tente novamente.",
+    "categories": {
+      "barber": "Barbeiro",
+      "hairdresser": "Cabeleireiro(a)",
+      "coach": "Coach / Consultor",
+      "cleaner": "Cleaner",
+      "dogGroomer": "Dog Groomer / Pet",
+      "esthetician": "Esteticista",
+      "physiotherapist": "Fisioterapeuta",
+      "photographer": "Fotógrafo",
+      "yogaInstructor": "Instrutor de Yoga/Pilates",
+      "makeupArtist": "Makeup Artist",
+      "massageTherapist": "Massagista",
+      "nailTech": "Nail Tech",
+      "nutritionist": "Nutricionista",
+      "personalTrainer": "Personal Trainer",
+      "teacher": "Professor / Tutor",
+      "psychologist": "Psicólogo / Terapeuta",
+      "other": "Outro"
+    },
+    "countries": {
+      "IE": "Irlanda",
+      "PT": "Portugal",
+      "BR": "Brasil",
+      "GB": "Reino Unido",
+      "US": "Estados Unidos",
+      "ES": "Espanha",
+      "FR": "França",
+      "DE": "Alemanha",
+      "IT": "Itália",
+      "AU": "Austrália",
+      "CA": "Canadá",
+      "MX": "México",
+      "AR": "Argentina",
+      "CO": "Colômbia"
+    }
   },
   "dashboard": {
     "welcome": "Bem-vindo, {name}!",

--- a/src/app/[locale]/(auth)/complete-profile/page.tsx
+++ b/src/app/[locale]/(auth)/complete-profile/page.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/components/ui/select';
 import { Loader2, CheckCircle2, XCircle } from 'lucide-react';
 import { CircleHoodLogoFull } from '@/components/branding/logo';
-import { COUNTRIES, CATEGORIES, CURRENCY_BY_COUNTRY } from '@/lib/auth-constants';
+import { COUNTRY_CODES, CATEGORY_KEYS, CURRENCY_BY_COUNTRY } from '@/lib/auth-constants';
 
 export default function CompleteProfilePage() {
   const router = useRouter();
@@ -259,9 +259,9 @@ export default function CompleteProfilePage() {
                   <SelectValue placeholder={t('selectCategory')} />
                 </SelectTrigger>
                 <SelectContent>
-                  {CATEGORIES.map((cat) => (
-                    <SelectItem key={cat} value={cat}>
-                      {cat}
+                  {CATEGORY_KEYS.map((key) => (
+                    <SelectItem key={key} value={key}>
+                      {t(`categories.${key}`)}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -281,9 +281,9 @@ export default function CompleteProfilePage() {
                   <SelectValue placeholder={t('selectCountry')} />
                 </SelectTrigger>
                 <SelectContent>
-                  {COUNTRIES.map((c) => (
-                    <SelectItem key={c.code} value={c.code}>
-                      {c.label}
+                  {COUNTRY_CODES.map((code) => (
+                    <SelectItem key={code} value={code}>
+                      {t(`countries.${code}`)}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/app/[locale]/(auth)/register/page.tsx
+++ b/src/app/[locale]/(auth)/register/page.tsx
@@ -25,7 +25,7 @@ import {
 import { Loader2, CheckCircle2, XCircle, Eye, EyeOff } from 'lucide-react';
 import { CircleHoodLogoFull } from '@/components/branding/logo';
 import { SocialLoginButtons } from '@/components/auth/social-login-buttons';
-import { COUNTRIES, CATEGORIES, CURRENCY_BY_COUNTRY } from '@/lib/auth-constants';
+import { COUNTRY_CODES, CATEGORY_KEYS, CURRENCY_BY_COUNTRY } from '@/lib/auth-constants';
 import { useTranslations } from 'next-intl';
 
 export default function RegisterPage() {
@@ -327,9 +327,9 @@ export default function RegisterPage() {
                     <SelectValue placeholder={t('selectCategory')} />
                   </SelectTrigger>
                   <SelectContent>
-                    {CATEGORIES.map((cat) => (
-                      <SelectItem key={cat} value={cat}>
-                        {cat}
+                    {CATEGORY_KEYS.map((key) => (
+                      <SelectItem key={key} value={key}>
+                        {t(`categories.${key}`)}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -349,9 +349,9 @@ export default function RegisterPage() {
                     <SelectValue placeholder={t('selectCountry')} />
                   </SelectTrigger>
                   <SelectContent>
-                    {COUNTRIES.map((c) => (
-                      <SelectItem key={c.code} value={c.code}>
-                        {c.label}
+                    {COUNTRY_CODES.map((code) => (
+                      <SelectItem key={code} value={code}>
+                        {t(`countries.${code}`)}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/lib/__tests__/auth-constants.test.ts
+++ b/src/lib/__tests__/auth-constants.test.ts
@@ -1,52 +1,61 @@
 import { describe, it, expect } from 'vitest';
-import { COUNTRIES, CATEGORIES, CURRENCY_BY_COUNTRY } from '@/lib/auth-constants';
+import { COUNTRY_CODES, CATEGORY_KEYS, CURRENCY_BY_COUNTRY, LEGACY_CATEGORY_MAP } from '@/lib/auth-constants';
 
-// ─── COUNTRIES ────────────────────────────────────────────────────────────────
+// ─── COUNTRY_CODES ──────────────────────────────────────────────────────────
 
-describe('COUNTRIES', () => {
+describe('COUNTRY_CODES', () => {
   it('é um array não-vazio', () => {
-    expect(COUNTRIES.length).toBeGreaterThan(0);
+    expect(COUNTRY_CODES.length).toBeGreaterThan(0);
   });
 
-  it('cada país tem code (2 chars) e label (string)', () => {
-    for (const c of COUNTRIES) {
-      expect(c.code).toMatch(/^[A-Z]{2}$/);
-      expect(c.label.length).toBeGreaterThan(0);
+  it('cada código tem 2 letras maiúsculas', () => {
+    for (const code of COUNTRY_CODES) {
+      expect(code).toMatch(/^[A-Z]{2}$/);
     }
   });
 
   it('não tem codes duplicados', () => {
-    const codes = COUNTRIES.map((c) => c.code);
-    expect(new Set(codes).size).toBe(codes.length);
+    expect(new Set(COUNTRY_CODES).size).toBe(COUNTRY_CODES.length);
   });
 
   it('contém os países principais (IE, PT, BR)', () => {
-    const codes = COUNTRIES.map((c) => c.code);
-    expect(codes).toContain('IE');
-    expect(codes).toContain('PT');
-    expect(codes).toContain('BR');
+    expect(COUNTRY_CODES).toContain('IE');
+    expect(COUNTRY_CODES).toContain('PT');
+    expect(COUNTRY_CODES).toContain('BR');
   });
 });
 
-// ─── CATEGORIES ───────────────────────────────────────────────────────────────
+// ─── CATEGORY_KEYS ──────────────────────────────────────────────────────────
 
-describe('CATEGORIES', () => {
+describe('CATEGORY_KEYS', () => {
   it('é um array não-vazio', () => {
-    expect(CATEGORIES.length).toBeGreaterThan(0);
+    expect(CATEGORY_KEYS.length).toBeGreaterThan(0);
   });
 
   it('não tem duplicados', () => {
-    expect(new Set(CATEGORIES).size).toBe(CATEGORIES.length);
+    expect(new Set(CATEGORY_KEYS).size).toBe(CATEGORY_KEYS.length);
   });
 
-  it('contém "Outro" como opção genérica', () => {
-    expect(CATEGORIES).toContain('Outro');
+  it('contém "other" como opção genérica', () => {
+    expect(CATEGORY_KEYS).toContain('other');
   });
 
-  it('todas são strings não-vazias', () => {
-    for (const cat of CATEGORIES) {
-      expect(typeof cat).toBe('string');
-      expect(cat.length).toBeGreaterThan(0);
+  it('todas são strings não-vazias em camelCase', () => {
+    for (const key of CATEGORY_KEYS) {
+      expect(typeof key).toBe('string');
+      expect(key.length).toBeGreaterThan(0);
+      expect(key).toMatch(/^[a-zA-Z]+$/);
+    }
+  });
+});
+
+// ─── LEGACY_CATEGORY_MAP ────────────────────────────────────────────────────
+
+describe('LEGACY_CATEGORY_MAP', () => {
+  it('mapeia cada CATEGORY_KEY de volta', () => {
+    const mappedKeys = new Set(Object.values(LEGACY_CATEGORY_MAP));
+    for (const key of CATEGORY_KEYS) {
+      expect(mappedKeys).toContain(key);
     }
   });
 });
@@ -54,10 +63,10 @@ describe('CATEGORIES', () => {
 // ─── CURRENCY_BY_COUNTRY ─────────────────────────────────────────────────────
 
 describe('CURRENCY_BY_COUNTRY', () => {
-  it('cada país em COUNTRIES tem uma moeda mapeada', () => {
-    for (const c of COUNTRIES) {
-      expect(CURRENCY_BY_COUNTRY[c.code]).toBeDefined();
-      expect(CURRENCY_BY_COUNTRY[c.code].length).toBe(3);
+  it('cada país em COUNTRY_CODES tem uma moeda mapeada', () => {
+    for (const code of COUNTRY_CODES) {
+      expect(CURRENCY_BY_COUNTRY[code]).toBeDefined();
+      expect(CURRENCY_BY_COUNTRY[code].length).toBe(3);
     }
   });
 

--- a/src/lib/auth-constants.ts
+++ b/src/lib/auth-constants.ts
@@ -1,19 +1,6 @@
-export const COUNTRIES: { code: string; label: string }[] = [
-  { code: 'IE', label: 'Irlanda' },
-  { code: 'PT', label: 'Portugal' },
-  { code: 'BR', label: 'Brasil' },
-  { code: 'GB', label: 'Reino Unido' },
-  { code: 'US', label: 'Estados Unidos' },
-  { code: 'ES', label: 'Espanha' },
-  { code: 'FR', label: 'França' },
-  { code: 'DE', label: 'Alemanha' },
-  { code: 'IT', label: 'Itália' },
-  { code: 'AU', label: 'Austrália' },
-  { code: 'CA', label: 'Canadá' },
-  { code: 'MX', label: 'México' },
-  { code: 'AR', label: 'Argentina' },
-  { code: 'CO', label: 'Colômbia' },
-];
+export const COUNTRY_CODES = [
+  'IE', 'PT', 'BR', 'GB', 'US', 'ES', 'FR', 'DE', 'IT', 'AU', 'CA', 'MX', 'AR', 'CO',
+] as const;
 
 export const CURRENCY_BY_COUNTRY: Record<string, string> = {
   IE: 'eur', PT: 'eur', ES: 'eur', FR: 'eur', DE: 'eur', IT: 'eur',
@@ -21,22 +8,49 @@ export const CURRENCY_BY_COUNTRY: Record<string, string> = {
   AR: 'ars', CO: 'cop',
 };
 
-export const CATEGORIES = [
-  'Barbeiro',
-  'Cabeleireiro(a)',
-  'Coach / Consultor',
-  'Cleaner',
-  'Dog Groomer / Pet',
-  'Esteticista',
-  'Fisioterapeuta',
-  'Fotógrafo',
-  'Instrutor de Yoga/Pilates',
-  'Makeup Artist',
-  'Massagista',
-  'Nail Tech',
-  'Nutricionista',
-  'Personal Trainer',
-  'Professor / Tutor',
-  'Psicólogo / Terapeuta',
-  'Outro',
-];
+export const CATEGORY_KEYS = [
+  'barber',
+  'hairdresser',
+  'coach',
+  'cleaner',
+  'dogGroomer',
+  'esthetician',
+  'physiotherapist',
+  'photographer',
+  'yogaInstructor',
+  'makeupArtist',
+  'massageTherapist',
+  'nailTech',
+  'nutritionist',
+  'personalTrainer',
+  'teacher',
+  'psychologist',
+  'other',
+] as const;
+
+// Backward compatibility — map old PT-BR DB values to new keys
+export const LEGACY_CATEGORY_MAP: Record<string, string> = {
+  'Barbeiro': 'barber',
+  'Cabeleireiro(a)': 'hairdresser',
+  'Coach / Consultor': 'coach',
+  'Cleaner': 'cleaner',
+  'Dog Groomer / Pet': 'dogGroomer',
+  'Esteticista': 'esthetician',
+  'Fisioterapeuta': 'physiotherapist',
+  'Fotógrafo': 'photographer',
+  'Instrutor de Yoga/Pilates': 'yogaInstructor',
+  'Makeup Artist': 'makeupArtist',
+  'Massagista': 'massageTherapist',
+  'Nail Tech': 'nailTech',
+  'Nutricionista': 'nutritionist',
+  'Personal Trainer': 'personalTrainer',
+  'Professor / Tutor': 'teacher',
+  'Psicólogo / Terapeuta': 'psychologist',
+  'Outro': 'other',
+};
+
+/** @deprecated Use COUNTRY_CODES + i18n instead */
+export const COUNTRIES = COUNTRY_CODES.map((code) => ({ code, label: code }));
+
+/** @deprecated Use CATEGORY_KEYS + i18n instead */
+export const CATEGORIES = CATEGORY_KEYS as unknown as string[];


### PR DESCRIPTION
Closes #424

## Summary
- **CATEGORIES**: Replaced hardcoded PT-BR array with `CATEGORY_KEYS` (locale-independent keys like `barber`, `hairdresser`) + i18n translations via `t('categories.barber')`
- **COUNTRIES**: Replaced hardcoded PT-BR labels with `COUNTRY_CODES` + i18n translations via `t('countries.IE')`
- New records store locale-independent keys in DB (e.g., `barber` instead of `Barbeiro`)
- Added `LEGACY_CATEGORY_MAP` for backward compatibility with existing Portuguese DB values
- 31 new i18n keys per locale (17 categories + 14 countries) across pt-BR, en-US, es-ES
- Updated unit tests for new exports

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] 101 test files, 1442 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)