### PR TITLE
fix: [UX] /[slug] página pública: addressCountry e metadata hardcoded PT-BR/IE

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -407,7 +407,10 @@
     "cancelledPaymentTitle": "Payment cancelled",
     "cancelledPaymentDescription": "The payment was cancelled. Your booking has not been confirmed.",
     "cancelledRetryNote": "You can try again anytime.",
-    "tryAgainBooking": "Try again"
+    "tryAgainBooking": "Try again",
+    "pageNotFound": "Page not found",
+    "onlineBooking": "Online Booking",
+    "metaDescription": "Book {category} with {name} in {city}. {count, plural, one {# service available} other {# services available}}."
   },
   "whatsapp": {
     "usageTitle": "WhatsApp Usage (Today)",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -407,7 +407,10 @@
     "cancelledPaymentTitle": "Pago cancelado",
     "cancelledPaymentDescription": "El pago fue cancelado. Su reserva no ha sido confirmada.",
     "cancelledRetryNote": "Puede intentar de nuevo cuando quiera.",
-    "tryAgainBooking": "Intentar de nuevo"
+    "tryAgainBooking": "Intentar de nuevo",
+    "pageNotFound": "Página no encontrada",
+    "onlineBooking": "Reserva Online",
+    "metaDescription": "Reserva {category} con {name} en {city}. {count, plural, one {# servicio disponible} other {# servicios disponibles}}."
   },
   "whatsapp": {
     "usageTitle": "Uso de WhatsApp (Hoy)",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -407,7 +407,10 @@
     "cancelledPaymentTitle": "Pagamento cancelado",
     "cancelledPaymentDescription": "O pagamento foi cancelado. O seu agendamento não foi confirmado.",
     "cancelledRetryNote": "Pode tentar novamente quando quiser.",
-    "tryAgainBooking": "Tentar novamente"
+    "tryAgainBooking": "Tentar novamente",
+    "pageNotFound": "Página não encontrada",
+    "onlineBooking": "Agendamento Online",
+    "metaDescription": "Agende {category} com {name} em {city}. {count, plural, one {# serviço disponível} other {# serviços disponíveis}}."
   },
   "whatsapp": {
     "usageTitle": "Uso do WhatsApp (Hoje)",

--- a/src/app/[locale]/(public)/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
+import { getTranslations } from 'next-intl/server';
 import { BookingSection } from '@/components/booking/booking-section';
 import { TrialBanner } from '@/components/public-page/trial-banner';
 import { SectionRenderer } from '@/components/public-page/section-renderer';
@@ -75,17 +76,23 @@ async function getProfessional(slug: string) {
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
   const data = await getProfessional(slug);
+  const t = await getTranslations('public');
 
   if (!data) {
-    return { title: 'Página não encontrada' };
+    return { title: t('pageNotFound') };
   }
 
   const { professional, services } = data;
 
-  const title = `${professional.business_name} | Agendamento Online`;
+  const title = `${professional.business_name} | ${t('onlineBooking')}`;
   const description =
     professional.bio ||
-    `Agende ${professional.category || 'serviços'} com ${professional.business_name} em ${professional.city}. ${services.length} serviços disponíveis.`;
+    t('metaDescription', {
+      category: professional.category || t('services'),
+      name: professional.business_name,
+      city: professional.city || '',
+      count: services.length,
+    });
 
   const url = `https://booking.circlehood-tech.com/${professional.slug}`;
 
@@ -96,9 +103,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       professional.business_name,
       professional.category,
       professional.city,
-      'agendamento online',
+      t('onlineBooking'),
       'booking',
-      'dublin',
       ...services.slice(0, 5).map((s) => s.name),
     ].filter((k): k is string => Boolean(k)),
     openGraph: {
@@ -107,7 +113,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       type: 'website',
       url,
       siteName: 'CircleHood Booking',
-      locale: 'pt_BR',
       ...(professional.profile_image_url && {
         images: [
           {
@@ -289,8 +294,8 @@ export default async function PublicProfilePage({ params }: PageProps) {
     telephone: professional.phone || '',
     address: {
       '@type': 'PostalAddress',
-      addressLocality: professional.city || 'Dublin',
-      addressCountry: 'IE',
+      ...(professional.city && { addressLocality: professional.city }),
+      ...(professional.country && { addressCountry: professional.country }),
     },
     ...(professional.profile_image_url && {
       image: professional.profile_image_url,


### PR DESCRIPTION
Closes #425

## Summary
- `addressCountry: 'IE'` → `professional.country` (dynamic per professional)
- `addressLocality: professional.city || 'Dublin'` → only set if city exists (no Dublin fallback)
- Metadata title: `"... | Agendamento Online"` → `t('onlineBooking')` (locale-aware)
- Metadata description: hardcoded PT-BR → ICU plural `t('metaDescription', {...})` 
- Removed hardcoded `locale: 'pt_BR'` from OpenGraph and `'dublin'` from keywords
- 3 new i18n keys across all 3 locales

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] 101 test files, 1442 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)