### PR TITLE
fix: [UX] /dashboard: empty state sugere 'Add services' mesmo quando já tem serviços

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -225,6 +225,7 @@
     "noBookingsToday": "No bookings for today.",
     "sharePageHint": "Share your page to receive bookings!",
     "addServices": "Add services",
+    "shareYourLink": "Share your link",
     "manage": "Manage"
   },
   "services": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -225,6 +225,7 @@
     "noBookingsToday": "No hay reservas para hoy.",
     "sharePageHint": "¡Comparte tu página para recibir reservas!",
     "addServices": "Añadir servicios",
+    "shareYourLink": "Compartir tu enlace",
     "manage": "Gestionar"
   },
   "services": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -225,6 +225,7 @@
     "noBookingsToday": "Nenhum agendamento para hoje.",
     "sharePageHint": "Compartilhe sua página para receber agendamentos!",
     "addServices": "Adicionar serviços",
+    "shareYourLink": "Compartilhar seu link",
     "manage": "Gerenciar"
   },
   "services": {

--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -368,7 +368,7 @@ export default async function DashboardPage() {
                       <div>
                         <p className="text-xs text-muted-foreground">{t('statsTodayLabel')}</p>
                         <p className="text-2xl font-bold text-green-600 dark:text-green-400">
-                          {currencySymbol}{todayRevenueTotal.toFixed(0)}
+                          {currencySymbol}{todayRevenueTotal.toFixed(2)}
                         </p>
                       </div>
                     </div>
@@ -384,7 +384,7 @@ export default async function DashboardPage() {
                       <div>
                         <p className="text-xs text-muted-foreground">{t('statsWeekLabel')}</p>
                         <p className="text-2xl font-bold text-green-600 dark:text-green-400">
-                          {currencySymbol}{weekRevenueTotal.toFixed(0)}
+                          {currencySymbol}{weekRevenueTotal.toFixed(2)}
                         </p>
                       </div>
                     </div>
@@ -400,7 +400,7 @@ export default async function DashboardPage() {
                       <div>
                         <p className="text-xs text-muted-foreground">{t('statsMonthLabel')}</p>
                         <p className="text-2xl font-bold text-green-600 dark:text-green-400">
-                          {currencySymbol}{monthRevenueTotal.toFixed(0)}
+                          {currencySymbol}{monthRevenueTotal.toFixed(2)}
                         </p>
                       </div>
                     </div>
@@ -437,9 +437,22 @@ export default async function DashboardPage() {
               <CalendarDays className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
               <p className="text-muted-foreground">{t('noBookingsToday')}</p>
               <p className="text-sm text-muted-foreground mt-1">{t('sharePageHint')}</p>
-              <Button asChild variant="outline" className="mt-4" size="sm">
-                <Link href="/services">{t('addServices')}</Link>
-              </Button>
+              {(totalServices ?? 0) > 0 ? (
+                <Button asChild variant="outline" className="mt-4" size="sm">
+                  <a
+                    href={`/${professional.slug}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <ExternalLink className="h-4 w-4 mr-1.5" />
+                    {t('shareYourLink')}
+                  </a>
+                </Button>
+              ) : (
+                <Button asChild variant="outline" className="mt-4" size="sm">
+                  <Link href="/services">{t('addServices')}</Link>
+                </Button>
+              )}
             </div>
           ) : (
             <div className="space-y-3">


### PR DESCRIPTION
Closes #426

## Summary
- Empty state now context-aware: shows "Share your link" (opens public page) when services exist, or "Add services" when none configured
- Revenue values use `.toFixed(2)` — preserves cents (€9.50 instead of €9)
- Added `shareYourLink` i18n key across all 3 locales

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] 101 test files, 1442 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)