### PR TITLE
fix: [UX] Landing page: links sem locale awareness (/register em vez de /pt-BR/register)

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { Link } from '@/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { CircleHoodLogo } from '@/components/branding/logo';


### PR DESCRIPTION
## Summary
- Replaced `import Link from 'next/link'` with `import { Link } from '@/navigation'` on the landing page
- All links (/register, /login, /demo, /terms, /privacy) now automatically include the correct locale prefix via next-intl's locale-aware Link

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 1442 unit tests pass
- [ ] Landing page links include locale prefix for en-US/es-ES visitors

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)