### PR TITLE
fix: standardize auth redirects to /onboarding (#430)

### DIFF
--- a/src/app/[locale]/(dashboard)/bookings/page.tsx
+++ b/src/app/[locale]/(dashboard)/bookings/page.tsx
@@ -16,7 +16,7 @@ export default async function BookingsPage() {
     .eq('user_id', user.id)
     .single();
 
-  if (!professional) redirect('/register');
+  if (!professional) redirect('/onboarding');
 
   const { data: bookings } = await supabase
     .from('bookings')

--- a/src/app/[locale]/(dashboard)/clients/page.tsx
+++ b/src/app/[locale]/(dashboard)/clients/page.tsx
@@ -16,7 +16,7 @@ export default async function ClientsPage() {
     .eq('user_id', user.id)
     .single();
 
-  if (!professional) redirect('/register');
+  if (!professional) redirect('/onboarding');
 
   return <ClientsPageClient professionalId={professional.id} />;
 }

--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -32,7 +32,7 @@ export default async function DashboardPage() {
     .eq('user_id', user.id)
     .single();
 
-  if (!professional) redirect('/register');
+  if (!professional) redirect('/onboarding');
 
   const t = await getTranslations('dashboard');
 

--- a/src/app/[locale]/(dashboard)/layout.tsx
+++ b/src/app/[locale]/(dashboard)/layout.tsx
@@ -34,7 +34,7 @@ export default async function DashboardLayout({
 
   // OAuth user without professional record → complete profile
   if (!professional) {
-    redirect('/complete-profile');
+    redirect('/onboarding');
   }
 
   // Block dashboard access if email not verified yet

--- a/src/app/[locale]/(dashboard)/marketing/page.tsx
+++ b/src/app/[locale]/(dashboard)/marketing/page.tsx
@@ -17,7 +17,7 @@ export default async function MarketingPage() {
     .eq('user_id', user.id)
     .single();
 
-  if (!professional) redirect('/register');
+  if (!professional) redirect('/onboarding');
 
   // Fetch saved QR codes
   const { data: savedQRCodes } = await supabase

--- a/src/app/[locale]/(dashboard)/notifications/page.tsx
+++ b/src/app/[locale]/(dashboard)/notifications/page.tsx
@@ -16,7 +16,7 @@ export default async function NotificationsPage() {
     .eq('user_id', user.id)
     .single();
 
-  if (!professional) redirect('/register');
+  if (!professional) redirect('/onboarding');
 
   // Últimas 100 notificações (email + whatsapp) nos últimos 30 dias
   const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();

--- a/src/app/[locale]/(dashboard)/schedule/page.tsx
+++ b/src/app/[locale]/(dashboard)/schedule/page.tsx
@@ -16,7 +16,7 @@ export default async function SchedulePage() {
     .eq('user_id', user.id)
     .single();
 
-  if (!professional) redirect('/register');
+  if (!professional) redirect('/onboarding');
 
   const { data: workingHours } = await supabase
     .from('working_hours')

--- a/src/app/[locale]/(dashboard)/services/page.tsx
+++ b/src/app/[locale]/(dashboard)/services/page.tsx
@@ -16,7 +16,7 @@ export default async function ServicesPage() {
     .eq('user_id', user.id)
     .single();
 
-  if (!professional) redirect('/register');
+  if (!professional) redirect('/onboarding');
 
   const { data: services } = await supabase
     .from('services')

--- a/src/app/[locale]/(dashboard)/settings/page.tsx
+++ b/src/app/[locale]/(dashboard)/settings/page.tsx
@@ -22,7 +22,7 @@ export default async function SettingsPage({ searchParams }: PageProps) {
     .eq('user_id', user.id)
     .single();
 
-  if (!professional) redirect('/register');
+  if (!professional) redirect('/onboarding');
 
   const trialDaysLeft = Math.max(
     0,

--- a/src/app/[locale]/(dashboard)/settings/payment/page.tsx
+++ b/src/app/[locale]/(dashboard)/settings/payment/page.tsx
@@ -20,7 +20,7 @@ export default async function PaymentSettingsPage() {
     .eq('user_id', user.id)
     .single();
 
-  if (!professional) redirect('/register');
+  if (!professional) redirect('/onboarding');
 
   // Check if Stripe Connect account is fully onboarded
   const { data: connectAccount } = await supabase

--- a/src/app/[locale]/(dashboard)/whatsapp-config/page.tsx
+++ b/src/app/[locale]/(dashboard)/whatsapp-config/page.tsx
@@ -16,7 +16,7 @@ export default async function WhatsAppConfigPage() {
     .eq('user_id', user.id)
     .single();
 
-  if (!professional) redirect('/register');
+  if (!professional) redirect('/onboarding');
 
   // Pre-fetch existing config to avoid client-side loading flash
   const [{ data: whatsappConfig }, { data: aiData }, { data: bcData }] = await Promise.all([


### PR DESCRIPTION
## Summary
- Standardized all dashboard page redirects when no professional record is found
- Changed 10 pages from `redirect('/register')` to `redirect('/onboarding')`
- Changed layout from `redirect('/complete-profile')` to `redirect('/onboarding')`
- Canonical flow is now: login → /onboarding (if incomplete) → /dashboard

## Files changed (11)
All `src/app/[locale]/(dashboard)/*/page.tsx` + `layout.tsx`

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)