### PR TITLE
fix: [UX] Correções menores — Booking success/cancel, Register e Dashboard (#394)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -107,6 +107,7 @@
     "signupFree": "Sign up free",
     "slugTaken": "This link is already taken.",
     "slugHint": "This will be your public page address. You can change it later in settings.",
+    "slugTooltip": "Unique link your clients use to book with you",
     "slugUnavailableError": "Choose an available link for your page.",
     "socialLoginError": "Error connecting with {provider}. Please try again.",
     "startCreatingAccount": "Start by creating your account",
@@ -409,6 +410,10 @@
     "cancelledPaymentDescription": "The payment was cancelled. Your booking has not been confirmed.",
     "cancelledRetryNote": "You can try again anytime.",
     "tryAgainBooking": "Try again",
+    "depositPayError": "Error processing payment.",
+    "depositPayNotConfirmed": "Payment not confirmed. Please try again.",
+    "depositInfo": "Booking deposit: {symbol}{amount}. Secure payment via Stripe.",
+    "depositPayButton": "Pay deposit {symbol}{amount}",
     "pageNotFound": "Page not found",
     "onlineBooking": "Online Booking",
     "metaDescription": "Book {category} with {name} in {city}. {count, plural, one {# service available} other {# services available}}."

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -107,6 +107,7 @@
     "signupFree": "Regístrate gratis",
     "slugTaken": "Este enlace ya está en uso.",
     "slugHint": "Esta será la dirección de tu página pública. Puedes cambiarla después en configuración.",
+    "slugTooltip": "Enlace único que tus clientes usan para reservar",
     "slugUnavailableError": "Elige un enlace disponible para tu página.",
     "socialLoginError": "Error al conectar con {provider}. Inténtalo de nuevo.",
     "startCreatingAccount": "Empieza creando tu cuenta",
@@ -409,6 +410,10 @@
     "cancelledPaymentDescription": "El pago fue cancelado. Su reserva no ha sido confirmada.",
     "cancelledRetryNote": "Puede intentar de nuevo cuando quiera.",
     "tryAgainBooking": "Intentar de nuevo",
+    "depositPayError": "Error al procesar el pago.",
+    "depositPayNotConfirmed": "Pago no confirmado. Inténtelo de nuevo.",
+    "depositInfo": "Señal de reserva: {symbol}{amount}. Pago seguro via Stripe.",
+    "depositPayButton": "Pagar señal {symbol}{amount}",
     "pageNotFound": "Página no encontrada",
     "onlineBooking": "Reserva Online",
     "metaDescription": "Reserva {category} con {name} en {city}. {count, plural, one {# servicio disponible} other {# servicios disponibles}}."

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -107,6 +107,7 @@
     "signupFree": "Cadastre-se grátis",
     "slugTaken": "Este link já está em uso.",
     "slugHint": "Este será o endereço da sua página pública. Pode alterá-lo depois nas configurações.",
+    "slugTooltip": "Link único que os seus clientes usam para agendar",
     "slugUnavailableError": "Escolha um link disponível para sua página.",
     "socialLoginError": "Erro ao conectar com {provider}. Tente novamente.",
     "startCreatingAccount": "Comece criando sua conta",
@@ -409,6 +410,10 @@
     "cancelledPaymentDescription": "O pagamento foi cancelado. O seu agendamento não foi confirmado.",
     "cancelledRetryNote": "Pode tentar novamente quando quiser.",
     "tryAgainBooking": "Tentar novamente",
+    "depositPayError": "Erro ao processar pagamento.",
+    "depositPayNotConfirmed": "Pagamento não confirmado. Tente novamente.",
+    "depositInfo": "Sinal de reserva: {symbol}{amount}. Pagamento seguro via Stripe.",
+    "depositPayButton": "Pagar sinal {symbol}{amount}",
     "pageNotFound": "Página não encontrada",
     "onlineBooking": "Agendamento Online",
     "metaDescription": "Agende {category} com {name} em {city}. {count, plural, one {# serviço disponível} other {# serviços disponíveis}}."

--- a/src/app/[locale]/(auth)/complete-profile/page.tsx
+++ b/src/app/[locale]/(auth)/complete-profile/page.tsx
@@ -23,7 +23,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Loader2, CheckCircle2, XCircle } from 'lucide-react';
+import { Loader2, CheckCircle2, XCircle, HelpCircle } from 'lucide-react';
 import { CircleHoodLogoFull } from '@/components/branding/logo';
 import { COUNTRY_CODES, CATEGORY_KEYS, CURRENCY_BY_COUNTRY } from '@/lib/auth-constants';
 
@@ -215,7 +215,15 @@ export default function CompleteProfilePage() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="slug">{t('pageLink')} *</Label>
+              <div className="flex items-center gap-1.5">
+                <Label htmlFor="slug">{t('pageLink')} *</Label>
+                <span className="relative group">
+                  <HelpCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
+                  <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-3 py-1.5 bg-popover text-popover-foreground text-xs rounded-md shadow-md border opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-50 pointer-events-none">
+                    {t('slugTooltip')}
+                  </span>
+                </span>
+              </div>
               <div className="flex items-center gap-2">
                 <span className="text-sm text-muted-foreground whitespace-nowrap">
                   booking.circlehood-tech.com/
@@ -239,6 +247,7 @@ export default function CompleteProfilePage() {
               {slugAvailable === false && (
                 <p className="text-xs text-destructive">{t('slugTaken')}</p>
               )}
+              <p className="text-xs text-muted-foreground">{t('slugHint')}</p>
             </div>
 
             <div className="space-y-2">

--- a/src/app/[locale]/(auth)/register/page.tsx
+++ b/src/app/[locale]/(auth)/register/page.tsx
@@ -22,7 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Loader2, CheckCircle2, XCircle, Eye, EyeOff } from 'lucide-react';
+import { Loader2, CheckCircle2, XCircle, Eye, EyeOff, HelpCircle } from 'lucide-react';
 import { CircleHoodLogoFull } from '@/components/branding/logo';
 import { SocialLoginButtons } from '@/components/auth/social-login-buttons';
 import { COUNTRY_CODES, CATEGORY_KEYS, CURRENCY_BY_COUNTRY } from '@/lib/auth-constants';
@@ -282,7 +282,15 @@ export default function RegisterPage() {
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="slug">{t('pageLink')} *</Label>
+                <div className="flex items-center gap-1.5">
+                  <Label htmlFor="slug">{t('pageLink')} *</Label>
+                  <span className="relative group">
+                    <HelpCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
+                    <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-3 py-1.5 bg-popover text-popover-foreground text-xs rounded-md shadow-md border opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-50 pointer-events-none">
+                      {t('slugTooltip')}
+                    </span>
+                  </span>
+                </div>
                 <div className="flex items-center gap-2">
                   <span className="text-sm text-muted-foreground whitespace-nowrap">
                     booking.circlehood-tech.com/

--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -292,7 +292,7 @@ export default async function DashboardPage() {
       <AlertsWidget />
 
       {/* Stats — only show when there's data */}
-      {((todayBookings ?? 0) > 0 || (weekBookings ?? 0) > 0 || (monthBookings ?? 0) > 0 || (totalServices ?? 0) > 0) && (
+      {((todayBookings ?? 0) > 0 || (weekBookings ?? 0) > 0 || (monthBookings ?? 0) > 0) && (
         <div className="space-y-4">
           <div>
             <h2 className="text-sm font-medium text-muted-foreground mb-3">{t('statsSectionBookings')}</h2>

--- a/src/components/checkout/payment-form.tsx
+++ b/src/components/checkout/payment-form.tsx
@@ -10,6 +10,7 @@ import {
 import { getStripe } from '@/lib/stripe/client';
 import { Button } from '@/components/ui/button';
 import { Loader2, ShieldCheck } from 'lucide-react';
+import { useTranslations, useLocale } from 'next-intl';
 
 interface InnerFormProps {
   amount: number;
@@ -29,6 +30,7 @@ function InnerForm({ amount, currency, onSuccess, onError }: InnerFormProps) {
   const stripe = useStripe();
   const elements = useElements();
   const [loading, setLoading] = useState(false);
+  const t = useTranslations('public');
 
   const sym = currencySymbols[currency?.toUpperCase()] ?? currency;
 
@@ -49,14 +51,14 @@ function InnerForm({ amount, currency, onSuccess, onError }: InnerFormProps) {
     setLoading(false);
 
     if (result.error) {
-      onError(result.error.message ?? 'Erro ao processar pagamento.');
+      onError(result.error.message ?? t('depositPayError'));
       return;
     }
 
     if (result.paymentIntent?.status === 'succeeded') {
       onSuccess(result.paymentIntent.id);
     } else {
-      onError('Pagamento não confirmado. Tente novamente.');
+      onError(t('depositPayNotConfirmed'));
     }
   }
 
@@ -65,7 +67,7 @@ function InnerForm({ amount, currency, onSuccess, onError }: InnerFormProps) {
       <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-900 flex items-start gap-2">
         <ShieldCheck className="h-4 w-4 text-blue-600 mt-0.5 shrink-0" />
         <p className="text-sm text-blue-800 dark:text-blue-300">
-          Sinal de reserva: <strong>{sym}{amount.toFixed(2)}</strong>. Pagamento seguro via Stripe.
+          {t('depositInfo', { symbol: sym, amount: amount.toFixed(2) })}
         </p>
       </div>
 
@@ -73,7 +75,7 @@ function InnerForm({ amount, currency, onSuccess, onError }: InnerFormProps) {
 
       <Button type="submit" className="w-full" disabled={loading || !stripe}>
         {loading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
-        Pagar sinal {sym}{amount.toFixed(2)}
+        {t('depositPayButton', { symbol: sym, amount: amount.toFixed(2) })}
       </Button>
     </form>
   );
@@ -96,6 +98,8 @@ export function PaymentForm({
   onError,
 }: PaymentFormProps) {
   const stripePromise = getStripe();
+  const locale = useLocale();
+  const stripeLocale = locale === 'pt-BR' ? 'pt-BR' : locale === 'es-ES' ? 'es' : 'en';
 
   return (
     <Elements
@@ -103,7 +107,7 @@ export function PaymentForm({
       options={{
         clientSecret,
         appearance: { theme: 'stripe' },
-        locale: 'pt-BR',
+        locale: stripeLocale as 'pt-BR' | 'es' | 'en',
       }}
     >
       <InnerForm


### PR DESCRIPTION
## Summary
- **Payment form i18n**: Replace 4 hardcoded PT-BR strings in `payment-form.tsx` with `useTranslations('public')`. Stripe Elements locale now dynamic based on user locale.
- **Slug tooltip**: Add HelpCircle icon with hover tooltip on slug field in register and complete-profile pages, explaining what the link is for.
- **Dashboard stats**: Hide booking stats section until user has actual bookings (removed `totalServices` from visibility condition so new users don't see confusing "0 agendamentos").
- **Booking back button**: Already working correctly — uses `?slug=` param from checkout route.

Closes #394

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1441 tests pass
- [ ] `/booking/success?slug=test` shows localized text and "Back" links to `/test`
- [ ] Payment form shows deposit info in correct locale
- [ ] Register page slug field shows tooltip on hover
- [ ] New user dashboard hides stats section (no bookings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)