### PR TITLE
fix: [UX] Sidebar com 15 itens sem agrupamento — profissional novo não sabe por onde começar (#417)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -24,6 +24,9 @@
   },
   "nav": {
     "groupMain": "Main",
+    "groupDaily": "Daily",
+    "groupBusiness": "My Business",
+    "groupTools": "Tools",
     "groupPage": "My Page",
     "groupCommunication": "Communication",
     "groupGrowth": "Growth",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -24,6 +24,9 @@
   },
   "nav": {
     "groupMain": "Principal",
+    "groupDaily": "Operacional",
+    "groupBusiness": "Mi Negocio",
+    "groupTools": "Herramientas",
     "groupPage": "Mi Página",
     "groupCommunication": "Comunicación",
     "groupGrowth": "Crecimiento",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -24,6 +24,9 @@
   },
   "nav": {
     "groupMain": "Principal",
+    "groupDaily": "Operacional",
+    "groupBusiness": "Meu Negócio",
+    "groupTools": "Ferramentas",
     "groupPage": "Minha Página",
     "groupCommunication": "Comunicação",
     "groupGrowth": "Crescimento",

--- a/src/components/dashboard/mobile-nav.tsx
+++ b/src/components/dashboard/mobile-nav.tsx
@@ -13,7 +13,6 @@ import {
   UserCheck,
   QrCode,
   BarChart3,
-  ImageIcon,
   MessageSquare,
   Settings,
   LogOut,
@@ -47,19 +46,34 @@ export function MobileNav({ professionalSlug, failedNotificationsCount = 0 }: Mo
   const MAIN_ITEMS = [
     { href: '/dashboard' as const, label: t('dashboard'), icon: LayoutDashboard },
     { href: '/bookings' as const, label: t('bookings'), icon: CalendarDays },
-    { href: '/my-page-editor' as const, label: t('myPage'), icon: Palette },
+    { href: '/clients' as const, label: t('clients'), icon: UserCheck },
     { href: '/services' as const, label: t('services'), icon: Scissors },
   ];
 
-  const MENU_ITEMS = [
-    { href: '/schedule' as const, label: t('schedule'), icon: Clock },
-    { href: '/clients' as const, label: t('clients'), icon: UserCheck },
-    { href: '/marketing' as const, label: t('marketing'), icon: QrCode },
-    { href: '/analytics' as const, label: t('analytics'), icon: BarChart3 },
-    { href: '/gallery' as const, label: t('gallery'), icon: ImageIcon },
-    { href: '/testimonials' as const, label: t('testimonials'), icon: MessageSquare },
-    { href: '/settings' as const, label: t('settings'), icon: Settings },
-    { href: '/support' as const, label: t('support'), icon: LifeBuoy },
+  const MENU_GROUPS = [
+    {
+      label: t('groupBusiness'),
+      items: [
+        { href: '/schedule' as const, label: t('schedule'), icon: Clock },
+        { href: '/clients' as const, label: t('clients'), icon: UserCheck },
+        { href: '/my-page-editor' as const, label: t('myPage'), icon: Palette },
+      ],
+    },
+    {
+      label: t('groupTools'),
+      items: [
+        { href: '/settings?tab=whatsapp' as const, label: t('whatsapp'), icon: MessageSquare },
+        { href: '/marketing' as const, label: t('marketing'), icon: QrCode },
+        { href: '/analytics' as const, label: t('analytics'), icon: BarChart3 },
+      ],
+    },
+    {
+      label: t('groupAccount'),
+      items: [
+        { href: '/settings' as const, label: t('settings'), icon: Settings },
+        { href: '/support' as const, label: t('support'), icon: LifeBuoy },
+      ],
+    },
   ];
 
   return (
@@ -97,23 +111,32 @@ export function MobileNav({ professionalSlug, failedNotificationsCount = 0 }: Mo
             <SheetHeader className="shrink-0">
               <SheetTitle>Menu</SheetTitle>
             </SheetHeader>
-            {/* Scrollable menu items */}
-            <div className="flex-1 overflow-y-auto py-2 space-y-1">
-              {MENU_ITEMS.map((item) => (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  onClick={() => setOpen(false)}
-                  className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-accent transition-colors"
-                >
-                  <item.icon className="h-5 w-5" />
-                  <span className="text-sm">{item.label}</span>
-                  {item.href === '/settings' && failedNotificationsCount > 0 && (
-                    <span className="ml-auto text-[10px] font-bold bg-destructive text-destructive-foreground rounded-full px-1.5 py-0.5 min-w-[18px] text-center leading-none">
-                      {failedNotificationsCount > 99 ? '99+' : failedNotificationsCount}
-                    </span>
-                  )}
-                </Link>
+            {/* Scrollable grouped menu items */}
+            <div className="flex-1 overflow-y-auto py-2 space-y-3">
+              {MENU_GROUPS.map((group) => (
+                <div key={group.label}>
+                  <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+                    {group.label}
+                  </p>
+                  <div className="space-y-0.5">
+                    {group.items.map((item) => (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        onClick={() => setOpen(false)}
+                        className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-accent transition-colors"
+                      >
+                        <item.icon className="h-5 w-5" />
+                        <span className="text-sm">{item.label}</span>
+                        {item.href === '/settings' && failedNotificationsCount > 0 && (
+                          <span className="ml-auto text-[10px] font-bold bg-destructive text-destructive-foreground rounded-full px-1.5 py-0.5 min-w-[18px] text-center leading-none">
+                            {failedNotificationsCount > 99 ? '99+' : failedNotificationsCount}
+                          </span>
+                        )}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
               ))}
             </div>
             {/* Fixed bottom: public page + logout — always visible */}

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -14,7 +14,6 @@ import {
   QrCode,
   BarChart3,
   Palette,
-  ImageIcon,
   MessageSquare,
   Settings,
   LifeBuoy,
@@ -31,26 +30,25 @@ const TOUR_IDS: Partial<Record<string, string>> = {
 
 const NAV_GROUPS = [
   {
-    tKey: 'groupMain' as const,
+    tKey: 'groupDaily' as const,
     items: [
       { href: '/dashboard', tKey: 'dashboard' as const, icon: LayoutDashboard },
       { href: '/bookings', tKey: 'bookings' as const, icon: CalendarDays },
-      { href: '/services', tKey: 'services' as const, icon: Scissors },
-      { href: '/schedule', tKey: 'schedule' as const, icon: Clock },
       { href: '/clients', tKey: 'clients' as const, icon: Users },
     ],
   },
   {
-    tKey: 'groupPage' as const,
+    tKey: 'groupBusiness' as const,
     items: [
+      { href: '/services', tKey: 'services' as const, icon: Scissors },
+      { href: '/schedule', tKey: 'schedule' as const, icon: Clock },
       { href: '/my-page-editor', tKey: 'myPage' as const, icon: Palette },
-      { href: '/gallery', tKey: 'gallery' as const, icon: ImageIcon },
-      { href: '/testimonials', tKey: 'testimonials' as const, icon: MessageSquare },
     ],
   },
   {
-    tKey: 'groupGrowth' as const,
+    tKey: 'groupTools' as const,
     items: [
+      { href: '/settings?tab=whatsapp', tKey: 'whatsapp' as const, icon: MessageSquare },
       { href: '/marketing', tKey: 'marketing' as const, icon: QrCode },
       { href: '/analytics', tKey: 'analytics' as const, icon: BarChart3 },
     ],


### PR DESCRIPTION
## Summary
- Reorganize sidebar from 4 generic groups into 4 semantic groups matching user mental model:
  - **Operacional** (daily use): Dashboard, Agendamentos, Clientes
  - **Meu Negócio** (configure once): Serviços, Horários, Minha Página
  - **Ferramentas**: WhatsApp, Marketing, Analytics
  - **Conta**: Configurações, Suporte
- Remove gallery/testimonials as standalone sidebar items (accessible via Minha Página editor)
- Mobile bottom bar: Dashboard, Bookings, Clients, Services (most used daily)
- Mobile menu sheet: grouped with section headers matching sidebar

Closes #417

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1441 tests pass
- [ ] Sidebar shows 4 semantic groups with correct labels
- [ ] Mobile bottom bar shows 4 daily-use items
- [ ] Mobile menu sheet shows grouped items with headers
- [ ] All existing sidebar links still work
- [ ] i18n: group labels correct in pt-BR, en-US, es-ES

🤖 Generated with [Claude Code](https://claude.com/claude-code)