### PR TITLE
fix: [UX] /settings/payment: dois componentes de pagamento na mesma página — confuso (#427)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -549,7 +549,11 @@
     "tabPayments": "Payments",
     "tabWhatsapp": "WhatsApp",
     "tabAssistant": "Virtual Assistant",
-    "tabNotifications": "Notifications"
+    "tabNotifications": "Notifications",
+    "paymentTitle": "Payments",
+    "paymentDescription": "Set up how to receive payments and when to charge",
+    "paymentStep1": "How do you want to get paid?",
+    "paymentStep2": "Charge an advance deposit?"
   },
   "schedule": {
     "title": "Schedule",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -549,7 +549,11 @@
     "tabPayments": "Pagos",
     "tabWhatsapp": "WhatsApp",
     "tabAssistant": "Asistente Virtual",
-    "tabNotifications": "Notificaciones"
+    "tabNotifications": "Notificaciones",
+    "paymentTitle": "Pagos",
+    "paymentDescription": "Configura cómo recibir pagos y cuándo cobrar",
+    "paymentStep1": "¿Cómo quieres cobrar?",
+    "paymentStep2": "¿Cobrar señal por adelantado?"
   },
   "schedule": {
     "title": "Horarios",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -549,7 +549,11 @@
     "tabPayments": "Pagamentos",
     "tabWhatsapp": "WhatsApp",
     "tabAssistant": "Assistente Virtual",
-    "tabNotifications": "Notificações"
+    "tabNotifications": "Notificações",
+    "paymentTitle": "Pagamentos",
+    "paymentDescription": "Configure como receber e quando cobrar",
+    "paymentStep1": "Como quer receber?",
+    "paymentStep2": "Quer cobrar sinal antecipado?"
   },
   "schedule": {
     "title": "Horários",

--- a/src/app/[locale]/(dashboard)/settings/unified-settings.tsx
+++ b/src/app/[locale]/(dashboard)/settings/unified-settings.tsx
@@ -9,6 +9,7 @@ import { WhatsAppConfigClient, AiAssistantSection } from '@/app/[locale]/(dashbo
 import { EmailNotificationsManager } from '@/components/dashboard/email-notifications-manager';
 import { SimplifiedPaymentSetup } from '@/components/settings/SimplifiedPaymentSetup';
 import { PaymentSettings } from '@/components/dashboard/payment-settings';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import type { PlanPrice } from '@/lib/pricing';
 import type { Professional } from '@/types/database';
 
@@ -124,20 +125,43 @@ export function UnifiedSettings({
         </TabsContent>
 
         <TabsContent value="pagamentos">
-          <div className="space-y-6 pt-2">
-            <SimplifiedPaymentSetup
-              currentMethod={professional.payment_method ?? null}
-              currentKey={professional.manual_payment_key ?? null}
-              currentCountry={professional.payment_country ?? null}
-            />
-            <PaymentSettings
-              requireDeposit={professional.require_deposit ?? false}
-              depositType={(professional.deposit_type as 'percentage' | 'fixed' | null) ?? null}
-              depositValue={professional.deposit_value ?? null}
-              currency={professional.currency ?? 'EUR'}
-              stripeConnected={stripeConnected}
-            />
-          </div>
+          <Card className="mt-2">
+            <CardHeader>
+              <CardTitle>{t('paymentTitle')}</CardTitle>
+              <CardDescription>{t('paymentDescription')}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-8">
+              {/* Step 1 — Payment method */}
+              <section>
+                <div className="flex items-center gap-2 mb-4">
+                  <span className="flex items-center justify-center h-6 w-6 rounded-full bg-primary text-primary-foreground text-xs font-bold">1</span>
+                  <h3 className="font-semibold text-sm">{t('paymentStep1')}</h3>
+                </div>
+                <SimplifiedPaymentSetup
+                  currentMethod={professional.payment_method ?? null}
+                  currentKey={professional.manual_payment_key ?? null}
+                  currentCountry={professional.payment_country ?? null}
+                />
+              </section>
+
+              <hr className="border-border" />
+
+              {/* Step 2 — Deposit */}
+              <section>
+                <div className="flex items-center gap-2 mb-4">
+                  <span className="flex items-center justify-center h-6 w-6 rounded-full bg-primary text-primary-foreground text-xs font-bold">2</span>
+                  <h3 className="font-semibold text-sm">{t('paymentStep2')}</h3>
+                </div>
+                <PaymentSettings
+                  requireDeposit={professional.require_deposit ?? false}
+                  depositType={(professional.deposit_type as 'percentage' | 'fixed' | null) ?? null}
+                  depositValue={professional.deposit_value ?? null}
+                  currency={professional.currency ?? 'EUR'}
+                  stripeConnected={stripeConnected}
+                />
+              </section>
+            </CardContent>
+          </Card>
         </TabsContent>
 
         <TabsContent value="whatsapp">

--- a/src/components/dashboard/payment-settings.tsx
+++ b/src/components/dashboard/payment-settings.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -89,12 +88,7 @@ export function PaymentSettings({
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{t('depositTitle')}</CardTitle>
-        <CardDescription>{t('depositDesc')}</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-5">
+    <div className="space-y-5">
         {!stripeConnected && (
           <div data-testid="stripe-required-warning" className="flex items-start gap-2 p-3 rounded-lg bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-900">
             <AlertTriangle className="h-4 w-4 text-yellow-500 mt-0.5 shrink-0" />
@@ -203,7 +197,6 @@ export function PaymentSettings({
           )}
           {saved ? t('saved') : t('save')}
         </Button>
-      </CardContent>
-    </Card>
+    </div>
   );
 }

--- a/src/components/settings/SimplifiedPaymentSetup.tsx
+++ b/src/components/settings/SimplifiedPaymentSetup.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -210,13 +209,7 @@ export function SimplifiedPaymentSetup({
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{t('setupTitle')}</CardTitle>
-        <CardDescription>{t('setupDescription')}</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-6">
-
+    <div className="space-y-6">
         {/* Status salvo anteriormente */}
         {savedMethod && status === 'idle' && (
           <div className="flex items-start gap-2 p-3 rounded-lg bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-900">
@@ -426,8 +419,6 @@ export function SimplifiedPaymentSetup({
             t('setupBtnAuto')
           )}
         </Button>
-
-      </CardContent>
-    </Card>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Unified two separate payment Card components into a single Card with numbered steps
- Step 1: "Como quer receber?" — payment method selection (Stripe / Manual)
- Step 2: "Quer cobrar sinal antecipado?" — deposit toggle and configuration
- Visual separator between steps for clear flow
- Removed individual Card wrappers from SimplifiedPaymentSetup and PaymentSettings

Closes #427

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1441 tests pass
- [ ] `/settings?tab=pagamentos` shows single card with 2 numbered steps
- [ ] Payment method selection works (Step 1)
- [ ] Deposit toggle and config works (Step 2)
- [ ] i18n: step labels correct in pt-BR, en-US, es-ES

🤖 Generated with [Claude Code](https://claude.com/claude-code)