### PR TITLE
feat: add quick setup buttons to schedule page (#429)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -589,7 +589,10 @@
     "day5": "Friday",
     "day6": "Saturday",
     "removeBlockedDate": "Remove blocked date",
-    "removeBlockedPeriod": "Remove blocked period"
+    "removeBlockedPeriod": "Remove blocked period",
+    "quickSetupTitle": "Quick setup",
+    "quickMonFri": "Mon–Fri, 9am–6pm",
+    "quickMonSat": "Mon–Sat, 9am–6pm"
   },
   "support": {
     "title": "Support Center",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -589,7 +589,10 @@
     "day5": "Viernes",
     "day6": "Sábado",
     "removeBlockedDate": "Eliminar fecha bloqueada",
-    "removeBlockedPeriod": "Eliminar período bloqueado"
+    "removeBlockedPeriod": "Eliminar período bloqueado",
+    "quickSetupTitle": "Configuración rápida",
+    "quickMonFri": "Lun–Vie, 9h–18h",
+    "quickMonSat": "Lun–Sáb, 9h–18h"
   },
   "support": {
     "title": "Centro de Soporte",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -589,7 +589,10 @@
     "day5": "Sexta",
     "day6": "Sábado",
     "removeBlockedDate": "Remover data bloqueada",
-    "removeBlockedPeriod": "Remover período bloqueado"
+    "removeBlockedPeriod": "Remover período bloqueado",
+    "quickSetupTitle": "Configuração rápida",
+    "quickMonFri": "Seg–Sex, 9h–18h",
+    "quickMonSat": "Seg–Sáb, 9h–18h"
   },
   "support": {
     "title": "Central de Suporte",

--- a/src/components/dashboard/schedule-manager.tsx
+++ b/src/components/dashboard/schedule-manager.tsx
@@ -10,7 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Calendar } from '@/components/ui/calendar';
-import { Loader2, Trash2 } from 'lucide-react';
+import { Loader2, Trash2, Zap } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import type { WorkingHours, BlockedDate, BlockedPeriod } from '@/types/database';
 
@@ -71,6 +71,18 @@ export function ScheduleManager({
       prev.map((d, i) => (i === index ? { ...d, ...updates } : d))
     );
   }
+
+  function applyQuickSetup(activeDays: number[], start: string, end: string) {
+    setDays((prev) =>
+      prev.map((d, i) => ({
+        isAvailable: activeDays.includes(i),
+        startTime: activeDays.includes(i) ? start : d.startTime,
+        endTime: activeDays.includes(i) ? end : d.endTime,
+      }))
+    );
+  }
+
+  const hasAnyActive = days.some((d) => d.isAvailable);
 
   async function saveWorkingHours() {
     setSavingHours(true);
@@ -174,6 +186,30 @@ export function ScheduleManager({
         </TabsList>
 
         <TabsContent value="hours" className="mt-4">
+          {!hasAnyActive && (
+            <div className="mb-4 p-4 rounded-lg border border-dashed border-primary/40 bg-primary/5">
+              <div className="flex items-center gap-2 mb-3">
+                <Zap className="h-4 w-4 text-primary" />
+                <p className="text-sm font-medium">{t('quickSetupTitle')}</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => applyQuickSetup([1, 2, 3, 4, 5], '09:00', '18:00')}
+                >
+                  {t('quickMonFri')}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => applyQuickSetup([1, 2, 3, 4, 5, 6], '09:00', '18:00')}
+                >
+                  {t('quickMonSat')}
+                </Button>
+              </div>
+            </div>
+          )}
           <Card>
             <CardContent className="p-4 space-y-4">
               {days.map((day, i) => (


### PR DESCRIPTION
## Summary
- Adds a "Quick setup" panel at the top of the schedule hours tab when no days are active
- Two presets: **Mon–Fri 9h–18h** and **Mon–Sat 9h–18h**
- Clicking a preset pre-fills all selected days with `isAvailable=true` and the corresponding times
- Panel auto-hides once any day is active (user has already configured)
- i18n keys added in pt-BR, en-US, es-ES

Closes #429

## Test plan
- [ ] New user sees quick setup panel on `/schedule`
- [ ] Clicking "Seg–Sex, 9h–18h" activates Mon–Fri with 09:00–18:00
- [ ] Clicking "Seg–Sáb, 9h–18h" activates Mon–Sat with 09:00–18:00
- [ ] Panel disappears after clicking a preset (days are now active)
- [ ] Existing users with configured hours don't see the panel
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes (1441 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)