### PR TITLE
fix: UX polish — automations, notifications, my-page-editor, support (#432)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -597,6 +597,7 @@
   "support": {
     "title": "Support Center",
     "subtitle": "Open tickets and track responses from our team",
+    "slaHint": "We respond within 24 business hours.",
     "newTicket": "New ticket",
     "loading": "Loading tickets...",
     "noTickets": "No open tickets yet.",
@@ -1415,7 +1416,8 @@
     "todayAt2": "Today at 02:00",
     "cronHistory": "Cron Job History",
     "processed": "{count} processed",
-    "notificationsHistory": "Notification History"
+    "notificationsHistory": "Notification History",
+    "noNotifications": "No notifications sent yet"
   },
   "notificationsPage": {
     "title": "Notifications",
@@ -1430,6 +1432,7 @@
     "feedFailed": "{type} not delivered to {recipient} ({channel})",
     "feedErrorReason": "{reason}",
     "noLogs": "No notifications in the last 30 days",
+    "noLogsHint": "When your clients receive confirmations or reminders, they will appear here.",
     "noLogsFiltered": "No notifications matching this filter",
     "retry": "Retry",
     "retryErrorMsg": "Error retrying",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -597,6 +597,7 @@
   "support": {
     "title": "Centro de Soporte",
     "subtitle": "Abre tickets y sigue las respuestas de nuestro equipo",
+    "slaHint": "Respondemos en un máximo de 24 horas hábiles.",
     "newTicket": "Nuevo ticket",
     "loading": "Cargando tickets...",
     "noTickets": "Aún no hay tickets abiertos.",
@@ -1415,7 +1416,8 @@
     "todayAt2": "Hoy a las 02:00",
     "cronHistory": "Historial de Cron Jobs",
     "processed": "{count} procesados",
-    "notificationsHistory": "Historial de Notificaciones"
+    "notificationsHistory": "Historial de Notificaciones",
+    "noNotifications": "Aún no se han enviado notificaciones"
   },
   "notificationsPage": {
     "title": "Notificaciones",
@@ -1430,6 +1432,7 @@
     "feedFailed": "{type} no entregada a {recipient} ({channel})",
     "feedErrorReason": "{reason}",
     "noLogs": "Sin notificaciones en los últimos 30 días",
+    "noLogsHint": "Cuando tus clientes reciban confirmaciones o recordatorios, aparecerán aquí.",
     "noLogsFiltered": "Sin notificaciones con este filtro",
     "retry": "Reenviar",
     "retryErrorMsg": "Error al reenviar",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -597,6 +597,7 @@
   "support": {
     "title": "Central de Suporte",
     "subtitle": "Abra chamados e acompanhe respostas da nossa equipe",
+    "slaHint": "Respondemos em até 24 horas úteis.",
     "newTicket": "Novo chamado",
     "loading": "Carregando chamados...",
     "noTickets": "Nenhum chamado aberto ainda.",
@@ -1415,7 +1416,8 @@
     "todayAt2": "Hoje às 02:00",
     "cronHistory": "Histórico de Cron Jobs",
     "processed": "{count} processados",
-    "notificationsHistory": "Histórico de Notificações"
+    "notificationsHistory": "Histórico de Notificações",
+    "noNotifications": "Nenhuma notificação enviada ainda"
   },
   "notificationsPage": {
     "title": "Notificações",
@@ -1430,6 +1432,7 @@
     "feedFailed": "{type} não entregue para {recipient} ({channel})",
     "feedErrorReason": "{reason}",
     "noLogs": "Nenhuma notificação nos últimos 30 dias",
+    "noLogsHint": "Quando seus clientes receberem confirmações ou lembretes, elas aparecerão aqui.",
     "noLogsFiltered": "Nenhuma notificação com este filtro",
     "retry": "Reenviar",
     "retryErrorMsg": "Erro ao reenviar",

--- a/src/app/[locale]/(dashboard)/automations/automations-manager.tsx
+++ b/src/app/[locale]/(dashboard)/automations/automations-manager.tsx
@@ -3,14 +3,10 @@
 import { useState } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import {
   Clock,
   Bell,
   CheckCircle2,
-  XCircle,
-  RefreshCw,
-  Calendar,
   MessageSquare
 } from 'lucide-react';
 
@@ -25,29 +21,27 @@ interface AutomationsManagerProps {
 }
 
 export function AutomationsManager({
-  professional,
-  cronLogs,
   notificationLogs,
   stats,
 }: AutomationsManagerProps) {
   const t = useTranslations('automations');
   const locale = useLocale();
-  const [activeTab, setActiveTab] = useState<'overview' | 'cron' | 'notifications'>('overview');
+  const [activeTab, setActiveTab] = useState<'overview' | 'notifications'>('overview');
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold">{t('title')}</h1>
-        <p className="text-gray-600 mt-1">{t('subtitle')}</p>
+        <p className="text-muted-foreground mt-1">{t('subtitle')}</p>
       </div>
 
       {/* Estatísticas */}
-      <div className="grid gap-4 md:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2">
         <Card className="p-6">
           <div className="flex items-center gap-3">
-            <Bell className="h-8 w-8 text-purple-600" />
+            <Bell className="h-8 w-8 text-purple-600 dark:text-purple-400" />
             <div>
-              <p className="text-sm text-gray-600">{t('totalNotifications')}</p>
+              <p className="text-sm text-muted-foreground">{t('totalNotifications')}</p>
               <p className="text-2xl font-bold">{stats.totalNotifications}</p>
             </div>
           </div>
@@ -55,34 +49,10 @@ export function AutomationsManager({
 
         <Card className="p-6">
           <div className="flex items-center gap-3">
-            <Clock className="h-8 w-8 text-orange-600" />
+            <Clock className="h-8 w-8 text-orange-600 dark:text-orange-400" />
             <div>
-              <p className="text-sm text-gray-600">{t('inQueue')}</p>
+              <p className="text-sm text-muted-foreground">{t('inQueue')}</p>
               <p className="text-2xl font-bold">{stats.pendingQueue}</p>
-            </div>
-          </div>
-        </Card>
-
-        <Card className="p-6">
-          <div className="flex items-center gap-3">
-            <CheckCircle2 className="h-8 w-8 text-green-600" />
-            <div>
-              <p className="text-sm text-gray-600">{t('cronOk')}</p>
-              <p className="text-2xl font-bold">
-                {cronLogs.filter((l) => l.status === 'success').length}
-              </p>
-            </div>
-          </div>
-        </Card>
-
-        <Card className="p-6">
-          <div className="flex items-center gap-3">
-            <XCircle className="h-8 w-8 text-red-600" />
-            <div>
-              <p className="text-sm text-gray-600">{t('errors')}</p>
-              <p className="text-2xl font-bold">
-                {cronLogs.filter((l) => l.status === 'error').length}
-              </p>
             </div>
           </div>
         </Card>
@@ -95,28 +65,18 @@ export function AutomationsManager({
             onClick={() => setActiveTab('overview')}
             className={`pb-2 px-1 border-b-2 transition-colors ${
               activeTab === 'overview'
-                ? 'border-purple-600 text-purple-600'
-                : 'border-transparent text-gray-600 hover:text-gray-900'
+                ? 'border-purple-600 text-purple-600 dark:border-purple-400 dark:text-purple-400'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
             }`}
           >
             {t('tabOverview')}
           </button>
           <button
-            onClick={() => setActiveTab('cron')}
-            className={`pb-2 px-1 border-b-2 transition-colors ${
-              activeTab === 'cron'
-                ? 'border-purple-600 text-purple-600'
-                : 'border-transparent text-gray-600 hover:text-gray-900'
-            }`}
-          >
-            {t('tabCron')}
-          </button>
-          <button
             onClick={() => setActiveTab('notifications')}
             className={`pb-2 px-1 border-b-2 transition-colors ${
               activeTab === 'notifications'
-                ? 'border-purple-600 text-purple-600'
-                : 'border-transparent text-gray-600 hover:text-gray-900'
+                ? 'border-purple-600 text-purple-600 dark:border-purple-400 dark:text-purple-400'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
             }`}
           >
             {t('tabNotifications')}
@@ -130,28 +90,28 @@ export function AutomationsManager({
           <Card className="p-6">
             <h3 className="text-lg font-semibold mb-4">{t('systemStatus')}</h3>
             <div className="space-y-3">
-              <div className="flex items-center justify-between p-3 bg-green-50 rounded-lg">
+              <div className="flex items-center justify-between p-3 bg-green-50 dark:bg-green-950/20 rounded-lg">
                 <div className="flex items-center gap-3">
-                  <CheckCircle2 className="h-5 w-5 text-green-600" />
+                  <CheckCircle2 className="h-5 w-5 text-green-600 dark:text-green-400" />
                   <span className="font-medium">{t('autoReminders')}</span>
                 </div>
-                <span className="text-sm text-green-600">{t('active')}</span>
+                <span className="text-sm text-green-600 dark:text-green-400">{t('active')}</span>
               </div>
 
-              <div className="flex items-center justify-between p-3 bg-green-50 rounded-lg">
+              <div className="flex items-center justify-between p-3 bg-green-50 dark:bg-green-950/20 rounded-lg">
                 <div className="flex items-center gap-3">
-                  <CheckCircle2 className="h-5 w-5 text-green-600" />
+                  <CheckCircle2 className="h-5 w-5 text-green-600 dark:text-green-400" />
                   <span className="font-medium">{t('autoConfirmations')}</span>
                 </div>
-                <span className="text-sm text-green-600">{t('active')}</span>
+                <span className="text-sm text-green-600 dark:text-green-400">{t('active')}</span>
               </div>
 
-              <div className="flex items-center justify-between p-3 bg-green-50 rounded-lg">
+              <div className="flex items-center justify-between p-3 bg-green-50 dark:bg-green-950/20 rounded-lg">
                 <div className="flex items-center gap-3">
-                  <CheckCircle2 className="h-5 w-5 text-green-600" />
+                  <CheckCircle2 className="h-5 w-5 text-green-600 dark:text-green-400" />
                   <span className="font-medium">{t('waitlist')}</span>
                 </div>
-                <span className="text-sm text-green-600">{t('active')}</span>
+                <span className="text-sm text-green-600 dark:text-green-400">{t('active')}</span>
               </div>
             </div>
           </Card>
@@ -160,15 +120,15 @@ export function AutomationsManager({
             <h3 className="text-lg font-semibold mb-4">{t('nextRuns')}</h3>
             <div className="space-y-2 text-sm">
               <div className="flex justify-between py-2 border-b">
-                <span className="text-gray-600">{t('sendReminders')}</span>
+                <span className="text-muted-foreground">{t('sendReminders')}</span>
                 <span className="font-medium">{t('todayAt10')}</span>
               </div>
               <div className="flex justify-between py-2 border-b">
-                <span className="text-gray-600">{t('updateAnalytics')}</span>
+                <span className="text-muted-foreground">{t('updateAnalytics')}</span>
                 <span className="font-medium">{t('tomorrowAt0')}</span>
               </div>
               <div className="flex justify-between py-2 border-b">
-                <span className="text-gray-600">{t('cleanTokens')}</span>
+                <span className="text-muted-foreground">{t('cleanTokens')}</span>
                 <span className="font-medium">{t('todayAt2')}</span>
               </div>
             </div>
@@ -176,72 +136,44 @@ export function AutomationsManager({
         </div>
       )}
 
-      {/* Cron Logs */}
-      {activeTab === 'cron' && (
-        <Card className="p-6">
-          <h3 className="text-lg font-semibold mb-4">{t('cronHistory')}</h3>
-          <div className="space-y-2">
-            {cronLogs.map((log) => (
-              <div
-                key={log.id}
-                className="flex items-center justify-between p-3 border rounded-lg"
-              >
-                <div className="flex items-center gap-3">
-                  {log.status === 'success' ? (
-                    <CheckCircle2 className="h-5 w-5 text-green-600" />
-                  ) : (
-                    <XCircle className="h-5 w-5 text-red-600" />
-                  )}
-                  <div>
-                    <p className="font-medium">{log.job_name}</p>
-                    <p className="text-sm text-gray-600">
-                      {new Date(log.created_at).toLocaleString(locale)}
-                    </p>
-                  </div>
-                </div>
-                <div className="text-right">
-                  <p className="text-sm font-medium">
-                    {t('processed', { count: log.records_processed })}
-                  </p>
-                  <p className="text-xs text-gray-500">{log.execution_time_ms}ms</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </Card>
-      )}
-
       {/* Notification Logs */}
       {activeTab === 'notifications' && (
         <Card className="p-6">
           <h3 className="text-lg font-semibold mb-4">{t('notificationsHistory')}</h3>
-          <div className="space-y-2">
-            {notificationLogs.map((log) => (
-              <div
-                key={log.id}
-                className="flex items-center justify-between p-3 border rounded-lg"
-              >
-                <div className="flex items-center gap-3">
-                  <MessageSquare className="h-5 w-5 text-purple-600" />
-                  <div>
-                    <p className="font-medium">{log.type}</p>
-                    <p className="text-sm text-gray-600">
-                      {log.recipient} · {new Date(log.created_at).toLocaleString(locale)}
-                    </p>
-                  </div>
-                </div>
-                <span
-                  className={`text-xs px-2 py-1 rounded-full ${
-                    log.status === 'sent'
-                      ? 'bg-green-100 text-green-700'
-                      : 'bg-red-100 text-red-700'
-                  }`}
+          {notificationLogs.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
+              <Bell className="h-8 w-8" />
+              <p className="text-sm">{t('noNotifications')}</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {notificationLogs.map((log) => (
+                <div
+                  key={log.id}
+                  className="flex items-center justify-between p-3 border rounded-lg"
                 >
-                  {log.status}
-                </span>
-              </div>
-            ))}
-          </div>
+                  <div className="flex items-center gap-3">
+                    <MessageSquare className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+                    <div>
+                      <p className="font-medium">{log.type}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {log.recipient} · {new Date(log.created_at).toLocaleString(locale)}
+                      </p>
+                    </div>
+                  </div>
+                  <span
+                    className={`text-xs px-2 py-1 rounded-full ${
+                      log.status === 'sent'
+                        ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300'
+                        : 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300'
+                    }`}
+                  >
+                    {log.status}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
         </Card>
       )}
     </div>

--- a/src/app/[locale]/(dashboard)/my-page-editor/page.tsx
+++ b/src/app/[locale]/(dashboard)/my-page-editor/page.tsx
@@ -54,7 +54,7 @@ export default async function MyPageEditorPage() {
           href={`/${professional.slug}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-sm text-blue-600 hover:underline mt-2 inline-block"
+          className="text-sm text-blue-600 dark:text-blue-400 hover:underline mt-2 inline-block"
         >
           {t('viewPage')} →
         </a>

--- a/src/app/[locale]/(dashboard)/support/page.tsx
+++ b/src/app/[locale]/(dashboard)/support/page.tsx
@@ -168,6 +168,7 @@ export default function SupportPage() {
         <div>
           <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
           <p className="text-muted-foreground text-sm mt-1">{t('subtitle')}</p>
+          <p className="text-xs text-muted-foreground mt-1">{t('slaHint')}</p>
         </div>
         <Button onClick={() => setShowNewTicket(true)}>
           <Plus className="h-4 w-4 mr-2" />

--- a/src/components/dashboard/email-notifications-manager.tsx
+++ b/src/components/dashboard/email-notifications-manager.tsx
@@ -176,7 +176,8 @@ export function EmailNotificationsManager({ logs }: EmailNotificationsManagerPro
           {localLogs.length === 0 ? (
             <div className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
               <Mail className="h-8 w-8" />
-              <p className="text-sm">{t('noLogs')}</p>
+              <p className="text-sm font-medium">{t('noLogs')}</p>
+              <p className="text-xs text-center max-w-xs">{t('noLogsHint')}</p>
             </div>
           ) : filteredLogs.length === 0 ? (
             <div className="flex flex-col items-center gap-2 py-12 text-muted-foreground">

--- a/src/components/dashboard/qr-code-download.tsx
+++ b/src/components/dashboard/qr-code-download.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { Download } from 'lucide-react';
+import { Download, ChevronDown, ChevronUp } from 'lucide-react';
 import QRCode from 'qrcode';
 import { useTranslations } from 'next-intl';
 
@@ -14,6 +14,7 @@ interface QrCodeDownloadProps {
 export function QrCodeDownload({ slug, businessName }: QrCodeDownloadProps) {
   const t = useTranslations('marketing');
   const [qrCodeUrl, setQrCodeUrl] = useState('');
+  const [expanded, setExpanded] = useState(false);
 
   const fullUrl = `https://circlehood-booking.vercel.app/${slug}`;
 
@@ -56,22 +57,48 @@ export function QrCodeDownload({ slug, businessName }: QrCodeDownloadProps) {
   }
 
   return (
-    <div className="flex items-center justify-between p-4 mb-4 bg-blue-50 border border-blue-200 rounded-lg">
-      <div className="flex items-center gap-3">
-        {qrCodeUrl && (
-          <div className="p-1 bg-white rounded border">
-            <img src={qrCodeUrl} alt="QR Code" className="w-12 h-12" />
+    <div className="mb-4 bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+      {/* Always visible header — clickable on mobile to expand */}
+      <div
+        className="flex items-center justify-between p-4 cursor-pointer sm:cursor-default"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div className="flex items-center gap-3">
+          {qrCodeUrl && (
+            <div className="hidden sm:block p-1 bg-white rounded border">
+              <img src={qrCodeUrl} alt="QR Code" className="w-12 h-12" />
+            </div>
+          )}
+          <div>
+            <p className="text-sm font-semibold text-blue-900 dark:text-blue-100">{t('qrPageTitle')}</p>
+            <p className="text-xs text-blue-700 dark:text-blue-300">{t('qrPageDesc')}</p>
           </div>
-        )}
-        <div>
-          <p className="text-sm font-semibold text-blue-900">{t('qrPageTitle')}</p>
-          <p className="text-xs text-blue-700">{t('qrPageDesc')}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); handleDownload(); }} disabled={!qrCodeUrl} className="hidden sm:flex">
+            <Download className="w-4 h-4 mr-2" />
+            {t('downloadBtn')}
+          </Button>
+          <span className="sm:hidden text-muted-foreground">
+            {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          </span>
         </div>
       </div>
-      <Button variant="outline" size="sm" onClick={handleDownload} disabled={!qrCodeUrl}>
-        <Download className="w-4 h-4 mr-2" />
-        {t('downloadBtn')}
-      </Button>
+
+      {/* Expanded on mobile */}
+      {expanded && (
+        <div className="px-4 pb-4 sm:hidden flex flex-col items-center gap-3">
+          {qrCodeUrl && (
+            <div className="p-1 bg-white rounded border">
+              <img src={qrCodeUrl} alt="QR Code" className="w-24 h-24" />
+            </div>
+          )}
+          <Button variant="outline" size="sm" onClick={handleDownload} disabled={!qrCodeUrl}>
+            <Download className="w-4 h-4 mr-2" />
+            {t('downloadBtn')}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **`/automations`**: Removed always-empty Cron Jobs tab (cron_logs inaccessible via RLS), fixed all `text-gray-*`/`bg-green-50` to use dark mode variants
- **`/my-page-editor`**: Link dark mode fix (`text-blue-600 dark:text-blue-400`), QR code now collapsible on mobile (no longer pushes editor down)
- **`/notifications`**: Added first-use empty state hint explaining what notifications are
- **`/support`**: Added SLA hint ("Respondemos em até 24h úteis")
- i18n: 3 new keys in all 3 locales

**Already resolved (no changes needed):**
- Onboarding links already navigate same-tab (no `target="_blank"`)
- Confetti already uses 30 spans (not 80)
- WhatsApp dark mode already has proper variants

Closes #432

## Test plan
- [ ] `/automations` — no Cron tab, dark mode colors correct
- [ ] `/my-page-editor` — QR collapsed on mobile, link readable in dark mode
- [ ] `/settings?tab=notificacoes` — empty state shows hint text
- [ ] `/support` — SLA hint visible under subtitle
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes (1441 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)