### PR TITLE
fix: [CRITICAL] Command injection via execSync em /api/admin/github/deploy

### DIFF
--- a/src/app/api/admin/github/deploy/route.ts
+++ b/src/app/api/admin/github/deploy/route.ts
@@ -50,6 +50,14 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // Prevent command injection via branch name
+  if (!/^[a-zA-Z0-9/_.-]+$/.test(branch)) {
+    return NextResponse.json(
+      { error: 'Invalid branch name' },
+      { status: 400 }
+    );
+  }
+
   const steps: string[] = [];
 
   try {


### PR DESCRIPTION
## Summary
- Validates `branch` parameter against `/^[a-zA-Z0-9/_.-]+$/` regex before passing to `execSync`
- Prevents command injection via malicious branch names (e.g., `main; rm -rf /`)

Closes #455