### PR TITLE
fix: [CRITICAL] bot_config sem professional_id + professional_id NULLABLE em 4 tabelas WhatsApp

### DIFF
--- a/src/__tests__/security/whatsapp-professional-id.test.ts
+++ b/src/__tests__/security/whatsapp-professional-id.test.ts
@@ -12,6 +12,16 @@ const MIGRATION_PATH = join(
   '20260304000005_add_professional_id_whatsapp_tables.sql'
 );
 
+const NOT_NULL_MIGRATION_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'supabase',
+  'migrations',
+  '20260309000001_bot_config_professional_id_and_not_null.sql'
+);
+
 const SEND_ROUTE_PATH = join(
   __dirname,
   '..',
@@ -67,12 +77,6 @@ describe('WhatsApp tables multi-tenant isolation (#109)', () => {
       const dropCount = (migration.match(/DROP POLICY IF EXISTS/g) || []).length;
       expect(dropCount).toBeGreaterThanOrEqual(3);
     });
-
-    it('preserves user_id fallback in RLS for backwards compatibility', () => {
-      // New policies should still allow user_id = auth.uid() as fallback
-      // for rows not yet back-filled
-      expect(migration).toContain('OR user_id = auth.uid()');
-    });
   });
 
   describe('whatsapp/send/route.ts uses correct column', () => {
@@ -83,6 +87,66 @@ describe('WhatsApp tables multi-tenant isolation (#109)', () => {
       const usesUserId = sendRoute.includes("eq('user_id', user.id)");
       const usesProfId = sendRoute.includes("eq('professional_id'");
       expect(usesUserId || usesProfId).toBe(true);
+    });
+  });
+});
+
+describe('bot_config + NOT NULL enforcement (#457)', () => {
+  it('hardening migration file exists', () => {
+    expect(existsSync(NOT_NULL_MIGRATION_PATH)).toBe(true);
+  });
+
+  describe('migration content', () => {
+    const migration = readFileSync(NOT_NULL_MIGRATION_PATH, 'utf-8');
+
+    it('adds professional_id to bot_config', () => {
+      expect(migration).toContain('ALTER TABLE bot_config');
+      expect(migration).toContain(
+        'professional_id UUID REFERENCES professionals(id) ON DELETE CASCADE'
+      );
+    });
+
+    it('backfills bot_config professional_id', () => {
+      expect(migration).toMatch(/UPDATE bot_config[\s\S]*?SET professional_id = p\.id/);
+    });
+
+    it('creates index on bot_config.professional_id', () => {
+      expect(migration).toContain('idx_bot_config_professional_id');
+    });
+
+    it('sets NOT NULL on professional_id for all 5 tables', () => {
+      const tables = [
+        'bot_config',
+        'whatsapp_config',
+        'whatsapp_conversations',
+        'ai_instructions',
+        'whatsapp_templates',
+      ];
+      for (const table of tables) {
+        expect(migration).toContain(
+          `ALTER TABLE ${table} ALTER COLUMN professional_id SET NOT NULL`
+        );
+      }
+    });
+
+    it('removes OR user_id fallback from RLS policies', () => {
+      // The hardening migration must NOT contain fallback
+      expect(migration).not.toContain('OR user_id = auth.uid()');
+    });
+
+    it('uses professional_id subquery in all new RLS policies', () => {
+      // Should have multiple policies using the subquery pattern
+      const policyCount = (
+        migration.match(/SELECT id FROM professionals WHERE user_id = auth\.uid\(\)/g) || []
+      ).length;
+      // bot_config (2: USING + WITH CHECK) + conversations (2) + ai_instructions (1) + templates (1) + notifications (1)
+      expect(policyCount).toBeGreaterThanOrEqual(7);
+    });
+
+    it('drops old policies before recreating', () => {
+      const dropCount = (migration.match(/DROP POLICY IF EXISTS/g) || []).length;
+      // bot_config (1) + conversations (2) + ai_instructions (1) + templates (1) + notifications (1)
+      expect(dropCount).toBeGreaterThanOrEqual(6);
     });
   });
 });

--- a/supabase/migrations/20260309000001_bot_config_professional_id_and_not_null.sql
+++ b/supabase/migrations/20260309000001_bot_config_professional_id_and_not_null.sql
@@ -1,0 +1,127 @@
+-- Fix #457: Add professional_id to bot_config + SET NOT NULL on all WhatsApp tables
+-- + Remove user_id fallback from RLS policies
+
+-- ============================================================
+-- 1. bot_config: add professional_id, backfill, index, RLS
+-- ============================================================
+ALTER TABLE bot_config
+  ADD COLUMN IF NOT EXISTS professional_id UUID REFERENCES professionals(id) ON DELETE CASCADE;
+
+UPDATE bot_config bc
+SET professional_id = p.id
+FROM professionals p
+WHERE bc.user_id = p.user_id
+  AND bc.professional_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_bot_config_professional_id
+  ON bot_config(professional_id);
+
+-- Delete orphan rows (no matching professional) before NOT NULL
+DELETE FROM bot_config WHERE professional_id IS NULL;
+
+ALTER TABLE bot_config ALTER COLUMN professional_id SET NOT NULL;
+
+-- Add unique constraint on professional_id (one config per professional)
+ALTER TABLE bot_config
+  ADD CONSTRAINT bot_config_professional_id_unique UNIQUE (professional_id);
+
+-- Update RLS to use professional_id
+DROP POLICY IF EXISTS "Users manage own bot_config" ON bot_config;
+
+CREATE POLICY "Users manage own bot_config"
+  ON bot_config FOR ALL
+  USING (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+  );
+
+-- ============================================================
+-- 2. SET NOT NULL on professional_id for 4 WhatsApp tables
+--    (column already exists, already backfilled)
+-- ============================================================
+
+-- Delete orphan rows first
+DELETE FROM whatsapp_config WHERE professional_id IS NULL AND user_id NOT IN (SELECT user_id FROM professionals);
+DELETE FROM whatsapp_conversations WHERE professional_id IS NULL AND user_id NOT IN (SELECT user_id FROM professionals);
+DELETE FROM ai_instructions WHERE professional_id IS NULL AND user_id NOT IN (SELECT user_id FROM professionals);
+DELETE FROM whatsapp_templates WHERE professional_id IS NULL AND user_id NOT IN (SELECT user_id FROM professionals);
+
+-- Re-backfill any stragglers
+UPDATE whatsapp_config wc SET professional_id = p.id FROM professionals p WHERE wc.user_id = p.user_id AND wc.professional_id IS NULL;
+UPDATE whatsapp_conversations wc SET professional_id = p.id FROM professionals p WHERE wc.user_id = p.user_id AND wc.professional_id IS NULL;
+UPDATE ai_instructions ai SET professional_id = p.id FROM professionals p WHERE ai.user_id = p.user_id AND ai.professional_id IS NULL;
+UPDATE whatsapp_templates wt SET professional_id = p.id FROM professionals p WHERE wt.user_id = p.user_id AND wt.professional_id IS NULL;
+
+-- Delete any remaining orphans
+DELETE FROM whatsapp_config WHERE professional_id IS NULL;
+DELETE FROM whatsapp_conversations WHERE professional_id IS NULL;
+DELETE FROM ai_instructions WHERE professional_id IS NULL;
+DELETE FROM whatsapp_templates WHERE professional_id IS NULL;
+
+ALTER TABLE whatsapp_config ALTER COLUMN professional_id SET NOT NULL;
+ALTER TABLE whatsapp_conversations ALTER COLUMN professional_id SET NOT NULL;
+ALTER TABLE ai_instructions ALTER COLUMN professional_id SET NOT NULL;
+ALTER TABLE whatsapp_templates ALTER COLUMN professional_id SET NOT NULL;
+
+-- ============================================================
+-- 3. Remove user_id fallback from RLS policies
+-- ============================================================
+
+-- whatsapp_conversations
+DROP POLICY IF EXISTS "Users can view own conversations" ON whatsapp_conversations;
+DROP POLICY IF EXISTS "Users can manage own conversations" ON whatsapp_conversations;
+
+CREATE POLICY "Users can view own conversations"
+  ON whatsapp_conversations FOR SELECT
+  USING (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can manage own conversations"
+  ON whatsapp_conversations FOR ALL
+  USING (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+  );
+
+-- ai_instructions
+DROP POLICY IF EXISTS "Users can manage own AI instructions" ON ai_instructions;
+
+CREATE POLICY "Users can manage own AI instructions"
+  ON ai_instructions FOR ALL
+  USING (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+  );
+
+-- whatsapp_templates
+DROP POLICY IF EXISTS "Users can manage own templates" ON whatsapp_templates;
+
+CREATE POLICY "Users can manage own templates"
+  ON whatsapp_templates FOR ALL
+  USING (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+  );
+
+-- notifications (also had fallback)
+DROP POLICY IF EXISTS "Users can manage own notifications" ON notifications;
+
+CREATE POLICY "Users can manage own notifications"
+  ON notifications FOR ALL
+  USING (
+    professional_id IN (
+      SELECT id FROM professionals WHERE user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- Adds `professional_id` column to `bot_config` table (was using `user_id` referencing `auth.users` directly, inconsistent with project pattern)
- Sets `NOT NULL` on `professional_id` for all 5 tables: `bot_config`, `whatsapp_config`, `whatsapp_conversations`, `ai_instructions`, `whatsapp_templates`
- Removes `OR user_id = auth.uid()` RLS fallback from all policies (no longer needed since column is NOT NULL and backfilled)
- Migration handles orphan rows safely (deletes rows with no matching professional before applying NOT NULL)
- Updates existing tests to verify hardening

Closes #457