### PR TITLE
fix: [HIGH] SECURITY DEFINER functions sem search_path + RPC sem auth check

### DIFF
--- a/src/__tests__/security/security-definer-search-path.test.ts
+++ b/src/__tests__/security/security-definer-search-path.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'supabase',
+  'migrations',
+  '20260309000002_security_definer_search_path.sql'
+);
+
+describe('SECURITY DEFINER functions hardening (#458)', () => {
+  it('migration file exists', () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true);
+  });
+
+  describe('migration content', () => {
+    const migration = readFileSync(MIGRATION_PATH, 'utf-8');
+
+    it('recreates all 4 SECURITY DEFINER functions', () => {
+      const functions = [
+        'initialize_default_sections',
+        'reschedule_booking',
+        'bulk_update_page_sections',
+        'cleanup_expired_verification_tokens',
+      ];
+      for (const fn of functions) {
+        expect(migration).toContain(`CREATE OR REPLACE FUNCTION ${fn}`);
+      }
+    });
+
+    it('all SECURITY DEFINER functions have SET search_path = public', () => {
+      // Count SECURITY DEFINER occurrences
+      const definerCount = (migration.match(/SECURITY DEFINER/g) || []).length;
+      expect(definerCount).toBe(4);
+
+      // Count SET search_path = public occurrences
+      const searchPathCount = (migration.match(/SET search_path = public/g) || []).length;
+      expect(searchPathCount).toBe(4);
+    });
+
+    it('bulk_update_page_sections has ownership check', () => {
+      expect(migration).toContain(
+        'WHERE id = p_professional_id AND user_id = auth.uid()'
+      );
+      expect(migration).toContain("RAISE EXCEPTION 'unauthorized'");
+    });
+
+    it('no SECURITY DEFINER without search_path', () => {
+      // Split by SECURITY DEFINER and check each occurrence is followed by SET search_path
+      const parts = migration.split('SECURITY DEFINER');
+      // First part is before any SECURITY DEFINER, skip it
+      for (let i = 1; i < parts.length; i++) {
+        const afterDefiner = parts[i].substring(0, 200); // check next 200 chars
+        expect(afterDefiner).toContain('search_path');
+      }
+    });
+  });
+});

--- a/supabase/migrations/20260309000002_security_definer_search_path.sql
+++ b/supabase/migrations/20260309000002_security_definer_search_path.sql
@@ -1,0 +1,182 @@
+-- Fix #458: Add SET search_path to all security-definer functions
+-- + Add ownership check to bulk_update_page_sections
+
+-- ============================================================
+-- 1. initialize_default_sections — add search_path
+-- ============================================================
+CREATE OR REPLACE FUNCTION initialize_default_sections(p_professional_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  INSERT INTO page_sections (professional_id, section_type, order_index, is_visible, data)
+  VALUES (
+    p_professional_id, 'hero', 1, true,
+    '{"ctaText": "Agendar Agora", "showSocialLinks": false}'::jsonb
+  ) ON CONFLICT (professional_id, section_type) DO NOTHING;
+
+  INSERT INTO page_sections (professional_id, section_type, order_index, is_visible, data)
+  VALUES (
+    p_professional_id, 'about', 2, false,
+    '{"heading": "Sobre Mim", "description": "", "yearsExperience": 0}'::jsonb
+  ) ON CONFLICT (professional_id, section_type) DO NOTHING;
+
+  INSERT INTO page_sections (professional_id, section_type, order_index, is_visible, data)
+  VALUES (
+    p_professional_id, 'services', 3, true,
+    '{"heading": "Meus Serviços", "displayMode": "grid", "showPrices": true, "ctaText": "Agendar"}'::jsonb
+  ) ON CONFLICT (professional_id, section_type) DO NOTHING;
+
+  INSERT INTO page_sections (professional_id, section_type, order_index, is_visible, data)
+  VALUES (
+    p_professional_id, 'gallery', 4, false,
+    '{"heading": "Galeria de Trabalhos", "layout": "grid", "columns": 3, "showCategories": true}'::jsonb
+  ) ON CONFLICT (professional_id, section_type) DO NOTHING;
+
+  INSERT INTO page_sections (professional_id, section_type, order_index, is_visible, data)
+  VALUES (
+    p_professional_id, 'testimonials', 5, false,
+    '{"heading": "O que dizem meus clientes", "displayMode": "grid", "showRatings": true, "maxToShow": 6}'::jsonb
+  ) ON CONFLICT (professional_id, section_type) DO NOTHING;
+
+  INSERT INTO page_sections (professional_id, section_type, order_index, is_visible, data)
+  VALUES (
+    p_professional_id, 'faq', 6, false,
+    '{"heading": "Perguntas Frequentes", "items": []}'::jsonb
+  ) ON CONFLICT (professional_id, section_type) DO NOTHING;
+
+  INSERT INTO page_sections (professional_id, section_type, order_index, is_visible, data)
+  VALUES (
+    p_professional_id, 'contact', 7, true,
+    '{"heading": "Entre em Contato", "showPhone": true, "showWhatsApp": true, "showEmail": false}'::jsonb
+  ) ON CONFLICT (professional_id, section_type) DO NOTHING;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- ============================================================
+-- 2. reschedule_booking — add search_path
+-- ============================================================
+CREATE OR REPLACE FUNCTION reschedule_booking(
+  p_booking_id UUID,
+  p_professional_id UUID,
+  p_new_date DATE,
+  p_new_start_time TIME,
+  p_new_end_time TIME
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_existing RECORD;
+  v_new_id UUID;
+BEGIN
+  SELECT id, booking_date, start_time, service_id, client_name, client_phone,
+         client_email, notes, service_location, customer_address, status
+    INTO v_existing
+    FROM bookings
+   WHERE id = p_booking_id
+     AND professional_id = p_professional_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'not_found');
+  END IF;
+
+  IF v_existing.status != 'confirmed' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'not_confirmed', 'current_status', v_existing.status);
+  END IF;
+
+  UPDATE bookings
+     SET status = 'cancelled',
+         cancelled_by = 'client',
+         cancelled_at = NOW(),
+         cancellation_reason = 'Reagendado pelo cliente via WhatsApp'
+   WHERE id = p_booking_id;
+
+  INSERT INTO bookings (
+    professional_id, service_id, booking_date, start_time, end_time,
+    client_name, client_phone, client_email, notes,
+    service_location, customer_address, status
+  ) VALUES (
+    p_professional_id, v_existing.service_id, p_new_date, p_new_start_time, p_new_end_time,
+    v_existing.client_name, v_existing.client_phone, v_existing.client_email, v_existing.notes,
+    COALESCE(v_existing.service_location, 'in_salon'), v_existing.customer_address, 'confirmed'
+  )
+  RETURNING id INTO v_new_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'new_booking_id', v_new_id,
+    'old_date', v_existing.booking_date,
+    'old_time', v_existing.start_time
+  );
+
+EXCEPTION
+  WHEN unique_violation THEN
+    RETURN jsonb_build_object('success', false, 'error', 'slot_taken');
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object('success', false, 'error', 'unexpected', 'detail', SQLERRM);
+END;
+$$;
+
+COMMENT ON FUNCTION reschedule_booking IS
+  'Transactional reschedule: cancels old booking and creates new one atomically. If any step fails, everything rolls back.';
+
+-- ============================================================
+-- 3. bulk_update_page_sections — add search_path + ownership check
+-- ============================================================
+CREATE OR REPLACE FUNCTION bulk_update_page_sections(
+  p_professional_id UUID,
+  p_updates JSONB
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  item JSONB;
+BEGIN
+  -- Ownership check: caller must own this professional
+  IF NOT EXISTS (
+    SELECT 1 FROM professionals
+    WHERE id = p_professional_id AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_updates)
+  LOOP
+    UPDATE page_sections
+    SET
+      order_index = (item->>'order_index')::int,
+      is_visible = (item->>'is_visible')::boolean,
+      updated_at = now()
+    WHERE id = (item->>'id')::uuid
+      AND professional_id = p_professional_id;
+  END LOOP;
+END;
+$$;
+
+-- ============================================================
+-- 4. cleanup_expired_verification_tokens — add search_path
+-- ============================================================
+CREATE OR REPLACE FUNCTION cleanup_expired_verification_tokens()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  deleted_count INTEGER;
+BEGIN
+  DELETE FROM email_verification_tokens
+  WHERE expires_at < NOW() - INTERVAL '7 days';
+
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  RETURN deleted_count;
+END;
+$$;
+
+COMMENT ON FUNCTION cleanup_expired_verification_tokens() IS
+  'Deletes expired (>7 days old) email verification tokens. Call periodically via cron.';


### PR DESCRIPTION
## Summary
- Adds `SET search_path = public` to all 4 SECURITY DEFINER functions (prevents search_path injection)
- Adds `auth.uid()` ownership check to `bulk_update_page_sections` RPC (prevents cross-tenant page modification)
- Uses `CREATE OR REPLACE` in new migration to update existing functions without breaking anything

### Functions hardened:
1. `initialize_default_sections` — search_path
2. `reschedule_booking` — search_path
3. `bulk_update_page_sections` — search_path + ownership check
4. `cleanup_expired_verification_tokens` — search_path

Closes #458