### PR TITLE
fix: [HIGH] Storage buckets (avatars, covers, qr-codes) sem owner verification

### DIFF
--- a/src/components/dashboard/image-upload.tsx
+++ b/src/components/dashboard/image-upload.tsx
@@ -51,12 +51,15 @@ export function ImageUpload({
 
       const compressedFile = await imageCompression(file, options);
 
-      // Generate unique filename
-      const fileExt = compressedFile.name.split('.').pop();
-      const fileName = `${Math.random().toString(36).substring(2)}-${Date.now()}.${fileExt}`;
-
       // Upload to Supabase Storage
       const supabase = createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Not authenticated');
+
+      // Generate unique filename with user folder for RLS isolation
+      const fileExt = compressedFile.name.split('.').pop();
+      const fileName = `${user.id}/${Math.random().toString(36).substring(2)}-${Date.now()}.${fileExt}`;
+
       const { data, error } = await supabase.storage
         .from(bucket)
         .upload(fileName, compressedFile, {

--- a/supabase/migrations/20260309000003_storage_owner_verification.sql
+++ b/supabase/migrations/20260309000003_storage_owner_verification.sql
@@ -1,0 +1,87 @@
+-- Fix #459: Add folder-based owner verification to storage buckets
+-- Pattern: uploads go to {user_id}/filename, RLS checks (storage.foldername(name))[1] = auth.uid()
+
+-- ============================================================
+-- 1. avatars bucket — replace permissive policies with folder-based
+-- ============================================================
+DROP POLICY IF EXISTS "Users can upload their own avatars" ON storage.objects;
+DROP POLICY IF EXISTS "Users can update their own avatars" ON storage.objects;
+DROP POLICY IF EXISTS "Users can delete their own avatars" ON storage.objects;
+-- Keep public read: DROP POLICY IF EXISTS "Public can view all avatars" ON storage.objects;
+
+CREATE POLICY "Users can upload their own avatars"
+ON storage.objects FOR INSERT TO authenticated
+WITH CHECK (
+  bucket_id = 'avatars' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can update their own avatars"
+ON storage.objects FOR UPDATE TO authenticated
+USING (
+  bucket_id = 'avatars' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can delete their own avatars"
+ON storage.objects FOR DELETE TO authenticated
+USING (
+  bucket_id = 'avatars' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+-- ============================================================
+-- 2. covers bucket — replace permissive policies with folder-based
+-- ============================================================
+DROP POLICY IF EXISTS "Users can upload their own covers" ON storage.objects;
+DROP POLICY IF EXISTS "Users can update their own covers" ON storage.objects;
+DROP POLICY IF EXISTS "Users can delete their own covers" ON storage.objects;
+
+CREATE POLICY "Users can upload their own covers"
+ON storage.objects FOR INSERT TO authenticated
+WITH CHECK (
+  bucket_id = 'covers' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can update their own covers"
+ON storage.objects FOR UPDATE TO authenticated
+USING (
+  bucket_id = 'covers' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can delete their own covers"
+ON storage.objects FOR DELETE TO authenticated
+USING (
+  bucket_id = 'covers' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+-- ============================================================
+-- 3. qr-codes bucket — replace permissive policies with folder-based
+-- ============================================================
+DROP POLICY IF EXISTS "Users can upload their own QR codes" ON storage.objects;
+DROP POLICY IF EXISTS "Users can update their own QR codes" ON storage.objects;
+DROP POLICY IF EXISTS "Users can delete their own QR codes" ON storage.objects;
+
+CREATE POLICY "Users can upload their own QR codes"
+ON storage.objects FOR INSERT TO authenticated
+WITH CHECK (
+  bucket_id = 'qr-codes' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can update their own QR codes"
+ON storage.objects FOR UPDATE TO authenticated
+USING (
+  bucket_id = 'qr-codes' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can delete their own QR codes"
+ON storage.objects FOR DELETE TO authenticated
+USING (
+  bucket_id = 'qr-codes' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);


### PR DESCRIPTION
## Summary
- Replaces permissive `auth.uid() IS NOT NULL` storage policies with folder-based isolation
- Uses `auth.uid()::text = (storage.foldername(name))[1]` pattern (same as gallery bucket)
- Updates `image-upload.tsx` to upload files to `{userId}/filename` path
- Applies to all 3 buckets: avatars, covers, qr-codes
- Public read policies unchanged (buckets are public for viewing)

**Note:** Existing files uploaded without user folder prefix will still be readable (public SELECT policy) but cannot be modified/deleted through client-side RLS. This is acceptable since old uploads are referenced by URL in the DB.

Closes #459