### PR TITLE
fix: [HIGH] Evolution API token vazando no response + register sem Zod

### DIFF
--- a/src/app/api/admin/fix-triggers/route.ts
+++ b/src/app/api/admin/fix-triggers/route.ts
@@ -109,14 +109,11 @@ $$ LANGUAGE plpgsql;
   return NextResponse.json({
     success: false,
     error: `Management API requer PAT (não service_role): ${mgmtRes.status}`,
-    fix_sql: fixSQL,
     instructions: [
       `1. Abrir: https://supabase.com/dashboard/project/${projectRef}/sql/new`,
-      '2. Colar o conteúdo de fix_sql acima',
-      '3. Clicar Run',
-      '4. Voltar e re-executar o script de teste',
+      '2. Aplicar a migration de fix-triggers manualmente',
+      '3. Voltar e re-executar o script de teste',
     ],
-    mgmt_response: mgmtError.substring(0, 200),
   }, { status: 503 });
   } catch (err) {
     logger.error('[admin/fix-triggers]', err);

--- a/src/app/api/evolution/create-instance/route.ts
+++ b/src/app/api/evolution/create-instance/route.ts
@@ -139,7 +139,7 @@ export async function POST(request: NextRequest) {
         updated_at: new Date().toISOString(),
       }, { onConflict: 'user_id' });
 
-    return NextResponse.json({ instanceName, qrCode, pairingCode, token: instanceToken });
+    return NextResponse.json({ instanceName, qrCode, pairingCode });
   } catch (error) {
     logger.error('create-instance error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/src/app/api/notifications/send/route.ts
+++ b/src/app/api/notifications/send/route.ts
@@ -1,5 +1,5 @@
 import { logger } from '@/lib/logger';
-import { createClient } from '@/lib/supabase/server';
+import { createClient } from '@supabase/supabase-js';
 import { NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { formatTemplate } from '@/lib/notifications/templates';
@@ -12,7 +12,10 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const supabase = await createClient();
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
 
   try {
     // Buscar notificações pendentes (limite 10 por vez)

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,6 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { isRateLimited } from '@/lib/rate-limit';
+import { z } from 'zod';
+
+const registerSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  slug: z.string().min(1),
+  businessName: z.string().min(1),
+  category: z.string().optional(),
+  bio: z.string().optional(),
+  phone: z.string().optional(),
+  whatsapp: z.string().optional(),
+  instagram: z.string().optional(),
+  city: z.string().optional(),
+  country: z.string().optional(),
+  currency: z.string().optional(),
+});
 
 export async function POST(req: NextRequest) {
   const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
@@ -11,17 +27,19 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  let body: any;
+  let body: unknown;
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: 'Payload inválido' }, { status: 400 });
   }
-  const { email, password, slug, businessName, category, bio, phone, whatsapp, instagram, city, country, currency } = body;
 
-  if (!email || !password || !slug || !businessName) {
-    return NextResponse.json({ error: 'Campos obrigatórios faltando.' }, { status: 400 });
+  const parsed = registerSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Dados inválidos', details: parsed.error.flatten().fieldErrors }, { status: 400 });
   }
+
+  const { email, password, slug, businessName, category, bio, phone, whatsapp, instagram, city, country, currency } = parsed.data;
 
   const supabase = createAdminClient();
 
@@ -63,5 +81,5 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  return NextResponse.json({ success: true, userId: authData.user.id });
+  return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## Summary
- **H4**: Remove `token: instanceToken` from Evolution API create-instance response (token was giving full WhatsApp instance control)
- **H5**: Add Zod schema validation to `/api/register` with min 8 char password; remove `userId` from response
- **H6**: Switch `/api/notifications/send` from anon `createClient()` to service_role client (cron was returning 0 rows due to RLS)
- **H8**: Remove `fix_sql` from fix-triggers error response (was exposing DB schema)

Closes #460