### PR TITLE
fix: low-severity validations, loading states and data trimming (#462)

### DIFF
--- a/src/app/[locale]/(auth)/loading.tsx
+++ b/src/app/[locale]/(auth)/loading.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function AuthLoading() {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-md space-y-6">
+        <Skeleton className="h-10 w-48 mx-auto" />
+        <div className="space-y-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(public)/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/[slug]/page.tsx
@@ -23,7 +23,7 @@ async function getProfessional(slug: string) {
 
   const { data: professional } = await supabase
     .from('professionals')
-    .select('*, stripe_account_id')
+    .select('*')
     .eq('slug', slug)
     .eq('is_active', true)
     .single();
@@ -260,7 +260,7 @@ export default async function PublicProfilePage({ params }: PageProps) {
                 requireDeposit={depositReady}
                 depositType={professional.deposit_type as 'percentage' | 'fixed' | null ?? null}
                 depositValue={professional.deposit_value ?? null}
-                stripeAccountId={(professional as any).stripe_account_id ?? null}
+                hasStripeConnect={!!(professional as any).stripe_account_id}
               />
               <SectionTestimonials
                 data={{ heading: 'Depoimentos', displayMode: 'grid', showRatings: true, showPhotos: true, maxToShow: 6 }}
@@ -358,7 +358,7 @@ export default async function PublicProfilePage({ params }: PageProps) {
               requireDeposit={depositReady}
               depositType={professional.deposit_type as 'percentage' | 'fixed' | null ?? null}
               depositValue={professional.deposit_value ?? null}
-              stripeAccountId={(professional as any).stripe_account_id ?? null}
+              hasStripeConnect={!!(professional as any).stripe_account_id}
             />
           </div>
         )}

--- a/src/app/[locale]/(public)/loading.tsx
+++ b/src/app/[locale]/(public)/loading.tsx
@@ -1,0 +1,27 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function PublicLoading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-2xl mx-auto pb-8">
+        {/* Cover */}
+        <Skeleton className="h-48 w-full rounded-none" />
+        {/* Avatar */}
+        <div className="flex justify-center -mt-12">
+          <Skeleton className="h-24 w-24 rounded-full" />
+        </div>
+        {/* Name + bio */}
+        <div className="mt-4 px-4 space-y-3">
+          <Skeleton className="h-7 w-48 mx-auto" />
+          <Skeleton className="h-4 w-64 mx-auto" />
+        </div>
+        {/* Services */}
+        <div className="mt-8 px-4 space-y-3">
+          <Skeleton className="h-20 w-full rounded-lg" />
+          <Skeleton className="h-20 w-full rounded-lg" />
+          <Skeleton className="h-20 w-full rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/inbox/route.ts
+++ b/src/app/api/admin/inbox/route.ts
@@ -31,7 +31,10 @@ export async function GET(req: NextRequest) {
 
   if (status) query = query.eq('status', status);
   if (type) query = query.eq('type', type);
-  if (search) query = query.ilike('title', `%${search}%`);
+  if (search) {
+    const escaped = search.replace(/%/g, '\\%').replace(/_/g, '\\_');
+    query = query.ilike('title', `%${escaped}%`);
+  }
 
   const { data, error } = await query;
 

--- a/src/app/api/loyalty/card/[token]/route.ts
+++ b/src/app/api/loyalty/card/[token]/route.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/lib/logger';
+import { isRateLimited } from '@/lib/rate-limit';
 import { createClient } from '@/lib/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -7,6 +8,12 @@ export async function GET(
   { params }: { params: Promise<{ token: string }> }
 ) {
   const { token } = await params;
+
+  // Rate limit by token to prevent enumeration
+  if (await isRateLimited(`loyalty-card:${token}`, 20, 60)) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   const supabase = await createClient();
 
   try {

--- a/src/app/api/packages/route.ts
+++ b/src/app/api/packages/route.ts
@@ -8,16 +8,17 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const professionalId = searchParams.get('professionalId');
 
+  if (!professionalId) {
+    return NextResponse.json({ error: 'professionalId is required' }, { status: 400 });
+  }
+
   try {
-    let query = supabase
+    const query = supabase
       .from('service_packages')
       .select('*')
       .eq('is_active', true)
+      .eq('professional_id', professionalId)
       .order('sort_order', { ascending: true });
-
-    if (professionalId) {
-      query = query.eq('professional_id', professionalId);
-    }
 
     const { data: packages, error } = await query;
 

--- a/src/app/api/reschedule/[token]/route.ts
+++ b/src/app/api/reschedule/[token]/route.ts
@@ -26,7 +26,7 @@ export async function GET(
           service_id,
           professional_id,
           services (name, price, duration_minutes),
-          professionals (business_name, slug, city, address, phone)
+          professionals (business_name, slug)
         )
       `
       )

--- a/src/components/booking/booking-section.tsx
+++ b/src/components/booking/booking-section.tsx
@@ -42,7 +42,7 @@ interface BookingSectionProps {
   requireDeposit?: boolean;
   depositType?: 'percentage' | 'fixed' | null;
   depositValue?: number | null;
-  stripeAccountId?: string | null;
+  hasStripeConnect?: boolean;
 }
 
 interface DepositInfo {
@@ -66,7 +66,7 @@ export function BookingSection({
   requireDeposit = false,
   depositType = null,
   depositValue = null,
-  stripeAccountId = null,
+  hasStripeConnect = false,
 }: BookingSectionProps) {
   const t = useTranslations('public');
   const availableDays = new Set(workingHours.map(wh => wh.day_of_week));
@@ -157,7 +157,7 @@ export function BookingSection({
     };
 
     // Com sinal + Stripe Connect: redirecionar para Checkout
-    if (stripeAccountId) {
+    if (hasStripeConnect) {
       try {
         const res = await fetch('/api/bookings/checkout', {
           method: 'POST',

--- a/src/components/settings/SimplifiedPaymentSetup.tsx
+++ b/src/components/settings/SimplifiedPaymentSetup.tsx
@@ -99,7 +99,8 @@ export function SimplifiedPaymentSetup({
     const day = parseInt(parts[0], 10);
     const month = parseInt(parts[1], 10);
     const year = parseInt(parts[2], 10);
-    if (year < 1900 || year > 2008) return 'Ano deve ser entre 1900 e 2008';
+    const maxYear = new Date().getFullYear() - 18;
+    if (year < 1900 || year > maxYear) return `Ano deve ser entre 1900 e ${maxYear}`;
     if (month < 1 || month > 12) return 'Mês inválido (01–12)';
     if (day < 1 || day > 31) return 'Dia inválido (01–31)';
     // Verifica se a data existe de fato (ex: 31/02 é inválido)

--- a/src/lib/payment/calculate-deposit.ts
+++ b/src/lib/payment/calculate-deposit.ts
@@ -14,7 +14,9 @@ export function calculateDeposit(
   if (depositType === 'percentage') {
     return Math.round((servicePrice * depositValue) / 100 * 100) / 100;
   }
-  return Math.round(depositValue * 100) / 100;
+  // Cap fixed deposit to service price
+  const capped = Math.min(depositValue, servicePrice);
+  return Math.round(capped * 100) / 100;
 }
 
 /**

--- a/src/lib/validators/__tests__/payment-account.test.ts
+++ b/src/lib/validators/__tests__/payment-account.test.ts
@@ -116,8 +116,8 @@ describe('validatePaymentAccount — PIX Brasil (BR)', () => {
     expect(validatePaymentAccount('123e4567-e89b-12d3-a456-426614174000', 'BR').valid).toBe(true);
   });
 
-  it('aceita dados bancários genéricos (>=5 chars)', () => {
-    expect(validatePaymentAccount('0001/12345', 'BR').valid).toBe(true);
+  it('rejeita dados bancários genéricos que não são PIX válido', () => {
+    expect(validatePaymentAccount('0001/12345', 'BR').valid).toBe(false);
   });
 
   it('rejeita chave PIX vazia', () => {

--- a/src/lib/validators/payment-account.ts
+++ b/src/lib/validators/payment-account.ts
@@ -22,8 +22,7 @@ function validatePIX(key: string): boolean {
   // CNPJ (14 dígitos)
   if (digits.length === 14) return true;
 
-  // Dados bancários: agência/conta (mínimo 5 chars)
-  return k.length >= 5;
+  return false;
 }
 
 /** Valida routing number + account number (US) — básico */


### PR DESCRIPTION
## Summary
- **L1**: Hide `stripe_account_id` from public page response (use boolean `hasStripeConnect`)
- **L2**: Dynamic DOB max year (`new Date().getFullYear() - 18`) instead of hardcoded 2007
- **L3**: Remove permissive PIX fallback — reject non-PIX formats instead of accepting ≥5 chars
- **L5**: Cap fixed deposit to service price with `Math.min(depositValue, servicePrice)`
- **L6**: Escape `%` and `_` in admin inbox `ilike` search to prevent pattern injection
- **L7**: Add `loading.tsx` skeleton for `(auth)` and `(public)` route groups
- **L9**: Require `professionalId` filter on `/api/packages` GET (was returning all packages)
- **L10**: Add rate limiting (20/60s) to `/api/loyalty/card/[token]` to prevent enumeration
- **L11**: Trim unnecessary fields (`address`, `phone`) from reschedule token response

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 102 files, 1453 tests passing
- [ ] CI green

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)