### PR TITLE
fix: [HIGH] reject webhook requests when secret not configured (#472)

### DIFF
--- a/src/__tests__/security/webhook-signatures.test.ts
+++ b/src/__tests__/security/webhook-signatures.test.ts
@@ -29,14 +29,14 @@ describe('validateEvolutionWebhook (issue #20)', () => {
     expect(validateEvolutionWebhook(null, 'my-secret-key')).toBe(false);
   });
 
-  it('returns true when secret is undefined (skip validation)', async () => {
+  it('returns false when secret is undefined (reject unconfigured)', async () => {
     const { validateEvolutionWebhook } = await import('@/lib/webhooks/signature');
-    expect(validateEvolutionWebhook('some-key', undefined)).toBe(true);
+    expect(validateEvolutionWebhook('some-key', undefined)).toBe(false);
   });
 
-  it('returns true when both are empty strings (no secret = skip validation)', async () => {
+  it('returns false when both are empty strings (no secret = reject)', async () => {
     const { validateEvolutionWebhook } = await import('@/lib/webhooks/signature');
-    expect(validateEvolutionWebhook('', '')).toBe(true);
+    expect(validateEvolutionWebhook('', '')).toBe(false);
   });
 
   it('is case-sensitive', async () => {

--- a/src/__tests__/security/whatsapp-support-webhook-signature.test.ts
+++ b/src/__tests__/security/whatsapp-support-webhook-signature.test.ts
@@ -69,12 +69,12 @@ describe('validateEvolutionWebhook implementation', () => {
     expect(sigSource).toContain('timingSafeEqual');
   });
 
-  it('skips validation when secret is not configured', () => {
+  it('rejects when secret is not configured', () => {
     const sigSource = readFileSync(
       resolve('src/lib/webhooks/signature.ts'),
       'utf-8'
     );
-    expect(sigSource).toContain('if (!secret) return true');
+    expect(sigSource).toContain('if (!secret) return false');
   });
 
   it('rejects when apikey header is missing', () => {

--- a/src/app/api/sales-bot/webhook/route.ts
+++ b/src/app/api/sales-bot/webhook/route.ts
@@ -236,6 +236,10 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     // ─── Signature validation (Evolution API apikey header) ─────────────
+    if (!process.env.SALES_WEBHOOK_SECRET) {
+      logger.error('[sales-bot/webhook] SALES_WEBHOOK_SECRET not configured — rejecting request');
+      return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 500 });
+    }
     const { validateEvolutionWebhook } = await import('@/lib/webhooks/signature');
     const apikeyHeader = request.headers.get('apikey');
     if (!validateEvolutionWebhook(apikeyHeader, process.env.SALES_WEBHOOK_SECRET)) {

--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -56,8 +56,10 @@ export async function POST(request: NextRequest) {
   // ── Validação de assinatura do webhook ──
   const apikeyHeader = request.headers.get('apikey');
   if (!process.env.WHATSAPP_WEBHOOK_SECRET) {
-    logger.warn('[whatsapp/webhook] WHATSAPP_WEBHOOK_SECRET not configured — skipping apikey validation');
-  } else if (!validateEvolutionWebhook(apikeyHeader, process.env.WHATSAPP_WEBHOOK_SECRET)) {
+    logger.error('[whatsapp/webhook] WHATSAPP_WEBHOOK_SECRET not configured — rejecting request');
+    return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 500 });
+  }
+  if (!validateEvolutionWebhook(apikeyHeader, process.env.WHATSAPP_WEBHOOK_SECRET)) {
     logger.warn('[whatsapp/webhook] Invalid or missing apikey header');
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }

--- a/src/lib/webhooks/signature.ts
+++ b/src/lib/webhooks/signature.ts
@@ -8,7 +8,7 @@ export function validateEvolutionWebhook(
   apikeyHeader: string | null,
   secret: string | undefined
 ): boolean {
-  if (!secret) return true; // secret not configured → skip validation (log warning at call site)
+  if (!secret) return false; // secret not configured → reject
   if (!apikeyHeader) return false;
 
   // Timing-safe comparison


### PR DESCRIPTION
## Summary
- WhatsApp webhook: return 500 instead of warn+continue when `WHATSAPP_WEBHOOK_SECRET` missing
- Sales bot webhook: same fix for `SALES_WEBHOOK_SECRET`
- `validateEvolutionWebhook`: return `false` (reject) instead of `true` when secret is undefined
- Updated tests to reflect stricter behavior

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 102 files, 1453 tests passing
- [ ] CI green

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)