### PR TITLE
fix: [HIGH] add rate limiting to auth, gallery upload and support tickets (#473)

### DIFF
--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -1,11 +1,11 @@
 import { logger } from '@/lib/logger';
+import { isRateLimited } from '@/lib/rate-limit';
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 
 /**
  * POST /api/auth/resend-verification
  * Resends the Supabase Auth confirmation email for the currently logged-in user.
- * Rate-limited by Supabase Auth (max 1 resend per 60s per email by default).
  */
 export async function POST() {
   try {
@@ -16,6 +16,10 @@ export async function POST() {
 
     if (!user) {
       return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+    }
+
+    if (await isRateLimited(`rl:resend-verification:${user.id}`, 3, 3600)) {
+      return NextResponse.json({ error: 'Too many attempts' }, { status: 429 });
     }
 
     if (user.email_confirmed_at) {

--- a/src/app/api/gallery/upload/route.ts
+++ b/src/app/api/gallery/upload/route.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/lib/logger';
+import { isRateLimited } from '@/lib/rate-limit';
 import { createClient } from '@/lib/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -53,6 +54,10 @@ export async function POST(request: NextRequest) {
 
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (await isRateLimited(`rl:gallery-upload:${user.id}`, 30, 60)) {
+    return NextResponse.json({ error: 'Too many uploads' }, { status: 429 });
   }
 
   // Get professional_id

--- a/src/app/api/support/tickets/route.ts
+++ b/src/app/api/support/tickets/route.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/lib/logger';
+import { isRateLimited } from '@/lib/rate-limit';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
@@ -43,6 +44,10 @@ export async function POST(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+
+  if (await isRateLimited(`rl:support-tickets:${user.id}`, 5, 3600)) {
+    return NextResponse.json({ error: 'Too many tickets' }, { status: 429 });
+  }
 
   const { data: professional } = await supabase
     .from('professionals')


### PR DESCRIPTION
## Summary
- `resend-verification`: 3 req/hour per user (prevents email spam)
- `gallery/upload`: 30 req/minute per user (prevents upload flood)
- `support/tickets` POST: 5 req/hour per user (prevents ticket spam)

All use `isRateLimited()` with Redis + in-memory fallback.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 102 files, 1453 tests passing
- [ ] CI green

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)