### PR TITLE
fix: [HIGH] add ON DELETE SET NULL to imported_contacts.preferred_service_id FK (#475)

### DIFF
--- a/supabase/migrations/20260310000001_imported_contacts_fk_on_delete.sql
+++ b/supabase/migrations/20260310000001_imported_contacts_fk_on_delete.sql
@@ -1,0 +1,9 @@
+-- Fix imported_contacts.preferred_service_id FK to SET NULL on service deletion
+-- Prevents orphaned rows when a service is deleted (#475)
+
+ALTER TABLE imported_contacts
+  DROP CONSTRAINT IF EXISTS imported_contacts_preferred_service_id_fkey;
+
+ALTER TABLE imported_contacts
+  ADD CONSTRAINT imported_contacts_preferred_service_id_fkey
+    FOREIGN KEY (preferred_service_id) REFERENCES services(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- Add migration to recreate `imported_contacts.preferred_service_id` FK with `ON DELETE SET NULL`
- Prevents orphaned rows when a service is deleted

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 102 files, 1453 tests passing
- [ ] CI green
- [ ] Migration applies cleanly on Supabase

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)