### PR TITLE
fix: [MEDIUM] Zod validation, .single() error handling, content-length checks (#476)

### DIFF
--- a/src/app/api/admin/leads/[id]/toggle-bot/route.ts
+++ b/src/app/api/admin/leads/[id]/toggle-bot/route.ts
@@ -3,6 +3,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { validateAdminToken } from '@/lib/admin/session';
+import { z } from 'zod';
+
+const toggleBotSchema = z.object({
+  conversationId: z.string().uuid(),
+  botActive: z.boolean(),
+});
 
 export async function POST(
   request: NextRequest,
@@ -16,11 +22,11 @@ export async function POST(
 
   const { id: leadId } = await params;
   const body = await request.json();
-  const { conversationId, botActive } = body;
-
-  if (!conversationId || typeof botActive !== 'boolean') {
-    return NextResponse.json({ error: 'conversationId e botActive são obrigatórios' }, { status: 400 });
+  const parsed = toggleBotSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', issues: parsed.error.issues }, { status: 400 });
   }
+  const { conversationId, botActive } = parsed.data;
 
   const adminClient = createAdminClient();
 

--- a/src/app/api/admin/restore-account/route.ts
+++ b/src/app/api/admin/restore-account/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { validateAdminToken } from '@/lib/admin/session';
+import { z } from 'zod';
+
+const restoreSchema = z.object({
+  professional_id: z.string().uuid(),
+});
 
 export async function POST(request: NextRequest) {
   const cookieStore = await cookies();
@@ -9,10 +14,12 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { professional_id } = await request.json();
-  if (!professional_id) {
-    return NextResponse.json({ error: 'professional_id required' }, { status: 400 });
+  const body = await request.json();
+  const parsed = restoreSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid professional_id' }, { status: 400 });
   }
+  const { professional_id } = parsed.data;
 
   const supabase = createAdminClient();
 

--- a/src/app/api/page-sections/route.ts
+++ b/src/app/api/page-sections/route.ts
@@ -145,7 +145,14 @@ export async function GET(request: NextRequest) {
 }
 
 // POST - Criar ou atualizar uma seção
+const MAX_BODY_SIZE = 1_048_576; // 1 MB
+
 export async function POST(request: NextRequest) {
+  const contentLength = parseInt(request.headers.get('content-length') ?? '0', 10);
+  if (contentLength > MAX_BODY_SIZE) {
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+  }
+
   const supabase = await createClient();
 
   // Auth check

--- a/src/app/api/support/tickets/[id]/reply/route.ts
+++ b/src/app/api/support/tickets/[id]/reply/route.ts
@@ -3,11 +3,23 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { generateSupportResponse } from '@/lib/ai/support-bot';
+import { z } from 'zod';
+
+const MAX_BODY_SIZE = 1_048_576; // 1 MB
+
+const replySchema = z.object({
+  message: z.string().min(1, 'Mensagem obrigatória').max(10000),
+});
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const contentLength = parseInt(request.headers.get('content-length') ?? '0', 10);
+  if (contentLength > MAX_BODY_SIZE) {
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+  }
+
   const { id } = await params;
 
   const supabase = await createClient();
@@ -16,10 +28,12 @@ export async function POST(
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
 
-  const { message } = await request.json();
-  if (!message?.trim()) {
-    return NextResponse.json({ error: 'Mensagem obrigatória' }, { status: 400 });
+  const body = await request.json();
+  const parsed = replySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 });
   }
+  const { message } = parsed.data;
 
   // Verify ticket ownership via RLS (only the owner can select it)
   const { data: ticket } = await supabase

--- a/src/app/api/whatsapp/send/route.ts
+++ b/src/app/api/whatsapp/send/route.ts
@@ -4,17 +4,31 @@ import { createClient } from '@/lib/supabase/server';
 import { sendEvolutionMessage } from '@/lib/whatsapp/evolution';
 import { WhatsAppRateLimiter } from '@/lib/whatsapp/rate-limiter';
 import { decryptToken } from '@/lib/integrations/token-encryption';
+import { z } from 'zod';
+
+const sendSchema = z.object({
+  to: z.string().min(1).regex(/^\+?[0-9\s()-]{7,20}$/, 'Invalid phone format'),
+  message: z.string().min(1).max(4096),
+});
+
+const MAX_BODY_SIZE = 1_048_576; // 1 MB
 
 export async function POST(request: NextRequest) {
-  try {
-    const { to, message } = await request.json();
+  const contentLength = parseInt(request.headers.get('content-length') ?? '0', 10);
+  if (contentLength > MAX_BODY_SIZE) {
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+  }
 
-    if (!to || !message) {
+  try {
+    const body = await request.json();
+    const parsed = sendSchema.safeParse(body);
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: 'Missing required fields: to, message' },
+        { error: 'Invalid input', issues: parsed.error.issues },
         { status: 400 }
       );
     }
+    const { to, message } = parsed.data;
 
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();

--- a/src/lib/ai/chatbot.ts
+++ b/src/lib/ai/chatbot.ts
@@ -1394,7 +1394,7 @@ PROIBIDO ao rejeitar data/horário:
 
     // 3. Buscar info do negócio (professional + services + working_hours + botConfig + ai_instructions)
     const [
-      { data: professional },
+      { data: professional, error: profError },
       { data: botConfig },
       { data: aiInstructions },
     ] = await Promise.all([
@@ -1416,6 +1416,11 @@ PROIBIDO ao rejeitar data/horário:
         .limit(1)
         .maybeSingle(),
     ]);
+
+    if (profError || !professional) {
+      logger.error('[chatbot] professional not found for user:', businessId, profError);
+      return null as any;
+    }
 
     const [{ data: services }, { data: workingHours }] = await Promise.all([
       this.supabase


### PR DESCRIPTION
## Summary
- **M1**: Destructure error from `.single()` in chatbot `Promise.all` — prevents silent null-pointer on professional lookup failure
- **M2**: Add Zod schemas to:
  - `whatsapp/send` — phone format regex + message max 4096 chars
  - `admin/leads/toggle-bot` — UUID validation on conversationId
  - `admin/restore-account` — UUID validation on professional_id
  - `support/tickets/[id]/reply` — message min 1, max 10000
- **M7**: Add 1MB content-length limit to `whatsapp/send`, `page-sections`, `tickets/reply`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 102 files, 1453 tests passing
- [ ] CI green

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)