### PR TITLE
fix: Stripe race condition, Connect validation, fee config, customer dedup (#477)

### DIFF
--- a/src/__tests__/payments/idempotency-key.test.ts
+++ b/src/__tests__/payments/idempotency-key.test.ts
@@ -114,6 +114,12 @@ function mockSupabase(overrides: Record<string, unknown> = {}) {
     if (table === 'payments') {
       return {
         insert: vi.fn().mockResolvedValue({ error: null }),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+        delete: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
       };
     }
     return {};

--- a/src/app/api/bookings/checkout/route.ts
+++ b/src/app/api/bookings/checkout/route.ts
@@ -6,6 +6,7 @@ import { calculateDeposit, toCents } from '@/lib/payment/calculate-deposit';
 import { bookingSchema, sanitizeString } from '@/lib/validation/booking-schema';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://booking.circlehood-tech.com';
+const APPLICATION_FEE_PERCENT = parseFloat(process.env.STRIPE_APPLICATION_FEE_PERCENT ?? '5') / 100;
 
 export async function POST(request: NextRequest) {
   // ─── 1. Parse + validação Zod ────────────────────────────────────────
@@ -163,7 +164,7 @@ export async function POST(request: NextRequest) {
   if (depositCents <= 0) {
     return NextResponse.json({ error: 'Valor do sinal inválido.' }, { status: 400 });
   }
-  const applicationFeeCents = Math.round(depositCents * 0.05);
+  const applicationFeeCents = Math.round(depositCents * APPLICATION_FEE_PERCENT);
 
   // ─── 9. Check double-booking ─────────────────────────────────────────────
   const { data: conflicts } = await supabase
@@ -216,6 +217,22 @@ export async function POST(request: NextRequest) {
 
   const currencyCode = (prof.currency as string)?.toLowerCase() || 'eur';
 
+  // ─── 10b. INSERT payment record immediately after booking (minimize inconsistency window)
+  const { error: paymentError } = await supabase.from('payments').insert({
+    professional_id,
+    booking_id: booking.id,
+    amount: depositAmount,
+    currency: currencyCode,
+    status: 'pending',
+    stripe_checkout_session_id: null,
+  });
+
+  if (paymentError) {
+    logger.error('[bookings/checkout] payment insert failed — rolling back booking', paymentError);
+    await supabase.from('bookings').update({ status: 'cancelled' }).eq('id', booking.id);
+    return NextResponse.json({ error: 'Erro ao registrar pagamento. Tente novamente.' }, { status: 500 });
+  }
+
   // Idempotency key baseada no booking.id: retry-safe (mesmo booking = mesma session)
   const idempotencyKey = `cs:${booking.id}`;
 
@@ -255,26 +272,17 @@ export async function POST(request: NextRequest) {
     );
   } catch (err) {
     logger.error('[bookings/checkout] Stripe session creation failed', err);
-    // Rollback: cancelar booking para liberar o slot
+    // Rollback: cancelar booking + payment para liberar o slot
+    await supabase.from('payments').delete().eq('booking_id', booking.id);
     await supabase.from('bookings').update({ status: 'cancelled' }).eq('id', booking.id);
     return NextResponse.json({ error: 'Falha ao criar sessão de pagamento. Tente novamente.' }, { status: 502 });
   }
 
-  // ─── 12. INSERT payment ──────────────────────────────────────────────────
-  const { error: paymentError } = await supabase.from('payments').insert({
-    professional_id,
-    booking_id: booking.id,
-    amount: depositAmount,
-    currency: currencyCode,
-    status: 'pending',
-    stripe_checkout_session_id: session.id,
-  });
-
-  if (paymentError) {
-    logger.error('[bookings/checkout] payment insert failed — rolling back booking', paymentError);
-    await supabase.from('bookings').update({ status: 'cancelled' }).eq('id', booking.id);
-    return NextResponse.json({ error: 'Erro ao registrar pagamento. Tente novamente.' }, { status: 500 });
-  }
+  // ─── 12. Update payment with Stripe session ID ─────────────────────────
+  await supabase
+    .from('payments')
+    .update({ stripe_checkout_session_id: session.id })
+    .eq('booking_id', booking.id);
 
   return NextResponse.json({ session_url: session.url });
 }

--- a/src/app/api/settings/payment/route.ts
+++ b/src/app/api/settings/payment/route.ts
@@ -12,7 +12,7 @@ export async function GET() {
   const { data: professional, error } = await supabase
     .from('professionals')
     .select(
-      'require_deposit, deposit_type, deposit_value, stripe_account_id, stripe_onboarding_completed'
+      'require_deposit, deposit_type, deposit_value, stripe_onboarding_completed'
     )
     .eq('user_id', user.id)
     .single();

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -35,11 +35,14 @@ export async function POST() {
   let customerId = professional.stripe_customer_id;
 
   if (!customerId) {
-    const customer = await stripe.customers.create({
-      email: user.email,
-      name: professional.business_name,
-      metadata: { professional_id: professional.id },
-    });
+    const customer = await stripe.customers.create(
+      {
+        email: user.email,
+        name: professional.business_name,
+        metadata: { professional_id: professional.id },
+      },
+      { idempotencyKey: `cust:${professional.id}` }
+    );
     customerId = customer.id;
 
     await supabase

--- a/src/app/api/webhooks/stripe-connect/route.ts
+++ b/src/app/api/webhooks/stripe-connect/route.ts
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
     case 'account.updated': {
       const account = event.data.object as Stripe.Account;
 
-      await supabase
+      const { data: updated } = await supabase
         .from('stripe_connect_accounts')
         .update({
           charges_enabled: account.charges_enabled,
@@ -57,7 +57,12 @@ export async function POST(request: NextRequest) {
           onboarding_complete: account.details_submitted,
           updated_at: new Date().toISOString(),
         })
-        .eq('stripe_account_id', account.id);
+        .eq('stripe_account_id', account.id)
+        .select('id');
+
+      if (!updated || updated.length === 0) {
+        logger.warn('[stripe-connect/webhook] account.updated for unknown account_id:', account.id);
+      }
 
       await supabase
         .from('professionals')


### PR DESCRIPTION
## Summary
- **M3**: Insert payment record immediately after booking insert (with null session ID), then update after Stripe session creation — eliminates race condition window where booking exists without payment
- **M4**: Validate `account.updated` webhook result — log warning for unknown Stripe account IDs
- **M5**: Application fee now configurable via `STRIPE_APPLICATION_FEE_PERCENT` env var (default 5%)
- **M6**: Idempotency key `cust:{professional.id}` on Stripe customer creation prevents duplicates
- **M9**: Removed `stripe_account_id` from GET `/api/settings/payment` response (sensitive data)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 102 files, 1453 tests pass
- [x] Idempotency key test updated for new payment insert→update flow

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)