### PR TITLE
fix: [MEDIUM] PII encryption sem key rotation policy (#478)

### DIFF
--- a/src/__tests__/integrations/token-encryption.test.ts
+++ b/src/__tests__/integrations/token-encryption.test.ts
@@ -1,16 +1,20 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { randomBytes } from 'crypto';
 
-// Generate a deterministic test key (32 bytes = 64 hex chars)
-const TEST_KEY = randomBytes(32).toString('hex');
+// Generate deterministic test keys (32 bytes = 64 hex chars)
+const TEST_KEY_V1 = randomBytes(32).toString('hex');
+const TEST_KEY_V2 = randomBytes(32).toString('hex');
 
 describe('token-encryption', () => {
   beforeAll(() => {
-    process.env.OAUTH_TOKEN_ENCRYPTION_KEY = TEST_KEY;
+    process.env.OAUTH_TOKEN_ENCRYPTION_KEY = TEST_KEY_V1;
+    delete process.env.ENCRYPTION_KEY_VERSION; // default to v1
   });
 
   afterAll(() => {
     delete process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+    delete process.env.ENCRYPTION_KEY_VERSION;
+    delete process.env.OAUTH_TOKEN_ENCRYPTION_KEY_V2;
   });
 
   // Dynamic import to pick up env var after setting it
@@ -33,10 +37,11 @@ describe('token-encryption', () => {
     expect(encrypted.startsWith('enc:')).toBe(true);
   });
 
-  it('encryptToken output has format enc:<iv>:<authTag>:<ciphertext>', async () => {
+  it('encryptToken output has versioned format enc:v1:<iv>:<authTag>:<ciphertext>', async () => {
     const { encryptToken } = await getModule();
     const encrypted = encryptToken('test_token');
-    const parts = encrypted.slice(4).split(':'); // remove 'enc:' prefix
+    expect(encrypted.startsWith('enc:v1:')).toBe(true);
+    const parts = encrypted.slice('enc:v1:'.length).split(':');
     expect(parts).toHaveLength(3);
     // IV = 12 bytes = 24 hex chars
     expect(parts[0]).toHaveLength(24);
@@ -56,6 +61,20 @@ describe('token-encryption', () => {
     const { decryptToken } = await getModule();
     const legacy = 'IGQVJWZAkFtV3BSZA0NlMF9xN2RlYTBG';
     expect(decryptToken(legacy)).toBe(legacy);
+  });
+
+  it('decryptToken handles legacy unversioned enc: format as v1', async () => {
+    // Manually craft a legacy format token (enc:<iv>:<authTag>:<ciphertext>)
+    const { createCipheriv } = await import('crypto');
+    const key = Buffer.from(TEST_KEY_V1, 'hex');
+    const iv = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', key, iv);
+    const encrypted = Buffer.concat([cipher.update('legacy_test', 'utf8'), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    const legacyToken = `enc:${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+
+    const { decryptToken } = await getModule();
+    expect(decryptToken(legacyToken)).toBe('legacy_test');
   });
 
   it('encrypting same token twice produces different ciphertexts (random IV)', async () => {
@@ -105,6 +124,117 @@ describe('token-encryption', () => {
     const { encryptToken, decryptToken } = await getModule();
     const raw = 'token_with_émojis_🔑_and_ñ';
     expect(decryptToken(encryptToken(raw))).toBe(raw);
+  });
+});
+
+describe('key rotation', () => {
+  beforeAll(() => {
+    process.env.OAUTH_TOKEN_ENCRYPTION_KEY = TEST_KEY_V1;
+    process.env.OAUTH_TOKEN_ENCRYPTION_KEY_V2 = TEST_KEY_V2;
+  });
+
+  afterAll(() => {
+    delete process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+    delete process.env.OAUTH_TOKEN_ENCRYPTION_KEY_V2;
+    delete process.env.ENCRYPTION_KEY_VERSION;
+  });
+
+  async function getModule() {
+    const mod = await import('@/lib/integrations/token-encryption');
+    return mod;
+  }
+
+  it('getCurrentKeyVersion defaults to 1', async () => {
+    delete process.env.ENCRYPTION_KEY_VERSION;
+    const { getCurrentKeyVersion } = await getModule();
+    expect(getCurrentKeyVersion()).toBe(1);
+  });
+
+  it('getCurrentKeyVersion reads ENCRYPTION_KEY_VERSION env', async () => {
+    process.env.ENCRYPTION_KEY_VERSION = '2';
+    const { getCurrentKeyVersion } = await getModule();
+    expect(getCurrentKeyVersion()).toBe(2);
+    process.env.ENCRYPTION_KEY_VERSION = '1';
+  });
+
+  it('getTokenKeyVersion returns 0 for plaintext', async () => {
+    const { getTokenKeyVersion } = await getModule();
+    expect(getTokenKeyVersion('plain_value')).toBe(0);
+  });
+
+  it('getTokenKeyVersion returns version from versioned token', async () => {
+    process.env.ENCRYPTION_KEY_VERSION = '1';
+    const { encryptToken, getTokenKeyVersion } = await getModule();
+    const encrypted = encryptToken('test');
+    expect(getTokenKeyVersion(encrypted)).toBe(1);
+  });
+
+  it('encrypts with v2 key when ENCRYPTION_KEY_VERSION=2', async () => {
+    process.env.ENCRYPTION_KEY_VERSION = '2';
+    const { encryptToken, decryptToken } = await getModule();
+
+    const encrypted = encryptToken('secret_data');
+    expect(encrypted.startsWith('enc:v2:')).toBe(true);
+    expect(decryptToken(encrypted)).toBe('secret_data');
+    process.env.ENCRYPTION_KEY_VERSION = '1';
+  });
+
+  it('decrypts v1 tokens even when current version is v2', async () => {
+    process.env.ENCRYPTION_KEY_VERSION = '1';
+    const { encryptToken } = await getModule();
+    const v1Token = encryptToken('data_from_v1');
+
+    // Now switch to v2
+    process.env.ENCRYPTION_KEY_VERSION = '2';
+    const { decryptToken } = await getModule();
+    expect(decryptToken(v1Token)).toBe('data_from_v1');
+    process.env.ENCRYPTION_KEY_VERSION = '1';
+  });
+
+  it('reEncryptToken re-encrypts from v1 to v2', async () => {
+    process.env.ENCRYPTION_KEY_VERSION = '1';
+    const { encryptToken } = await getModule();
+    const v1Token = encryptToken('rotate_me');
+
+    process.env.ENCRYPTION_KEY_VERSION = '2';
+    const { reEncryptToken, decryptToken, getTokenKeyVersion } = await getModule();
+    const v2Token = reEncryptToken(v1Token);
+
+    expect(v2Token).not.toBeNull();
+    expect(v2Token!.startsWith('enc:v2:')).toBe(true);
+    expect(getTokenKeyVersion(v2Token!)).toBe(2);
+    expect(decryptToken(v2Token!)).toBe('rotate_me');
+    process.env.ENCRYPTION_KEY_VERSION = '1';
+  });
+
+  it('reEncryptToken returns null if already on current version', async () => {
+    process.env.ENCRYPTION_KEY_VERSION = '1';
+    const { encryptToken, reEncryptToken } = await getModule();
+    const token = encryptToken('no_change');
+    expect(reEncryptToken(token)).toBeNull();
+  });
+
+  it('needsReEncryption returns true for old version', async () => {
+    process.env.ENCRYPTION_KEY_VERSION = '1';
+    const { encryptToken } = await getModule();
+    const v1Token = encryptToken('check_me');
+
+    process.env.ENCRYPTION_KEY_VERSION = '2';
+    const { needsReEncryption } = await getModule();
+    expect(needsReEncryption(v1Token)).toBe(true);
+    process.env.ENCRYPTION_KEY_VERSION = '1';
+  });
+
+  it('needsReEncryption returns false for current version', async () => {
+    process.env.ENCRYPTION_KEY_VERSION = '1';
+    const { encryptToken, needsReEncryption } = await getModule();
+    const token = encryptToken('current');
+    expect(needsReEncryption(token)).toBe(false);
+  });
+
+  it('needsReEncryption returns false for plaintext', async () => {
+    const { needsReEncryption } = await getModule();
+    expect(needsReEncryption('plain_value')).toBe(false);
   });
 });
 

--- a/src/app/api/admin/rotate-encryption-key/route.ts
+++ b/src/app/api/admin/rotate-encryption-key/route.ts
@@ -1,0 +1,206 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { timingSafeEqual } from 'crypto';
+import { logger } from '@/lib/logger';
+import {
+  getCurrentKeyVersion,
+  reEncryptToken,
+  isEncrypted,
+} from '@/lib/integrations/token-encryption';
+
+/**
+ * POST /api/admin/rotate-encryption-key
+ *
+ * Re-encrypts all PII fields (professionals + integrations + whatsapp_config)
+ * from their current key version to the active ENCRYPTION_KEY_VERSION.
+ *
+ * Steps to rotate:
+ * 1. Generate new 32-byte key, set as OAUTH_TOKEN_ENCRYPTION_KEY_V<N>
+ * 2. Set ENCRYPTION_KEY_VERSION=<N>
+ * 3. Keep old key(s) in env (OAUTH_TOKEN_ENCRYPTION_KEY for v1, _V2 for v2, etc.)
+ * 4. Call this endpoint to re-encrypt all data
+ * 5. After confirming success, old keys can be removed
+ *
+ * Body: { "secret": "<SETUP_SECRET>" }
+ */
+export async function POST(request: NextRequest) {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const { secret } = body;
+  const expected = process.env.SETUP_SECRET ?? '';
+  if (
+    !secret ||
+    !expected ||
+    typeof secret !== 'string' ||
+    secret.length !== expected.length ||
+    !timingSafeEqual(Buffer.from(secret), Buffer.from(expected))
+  ) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const targetVersion = getCurrentKeyVersion();
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  const stats = { rotated: 0, skipped: 0, errors: 0 };
+
+  // ─── 1. Professionals PII fields ────────────────────────────────────────
+  const piiFields = [
+    'payment_full_name',
+    'payment_dob',
+    'payment_iban',
+    'payment_address_line1',
+    'payment_address_line2',
+  ] as const;
+
+  const { data: professionals } = await supabase
+    .from('professionals')
+    .select('id, encryption_key_version, payment_full_name, payment_dob, payment_iban, payment_address_line1, payment_address_line2')
+    .neq('encryption_key_version', targetVersion);
+
+  for (const prof of (professionals ?? []) as Record<string, unknown>[]) {
+    const updates: Record<string, unknown> = {};
+    let hasUpdates = false;
+
+    for (const field of piiFields) {
+      const value = prof[field] as string | null;
+      if (!value || !isEncrypted(value)) continue;
+
+      const reEncrypted = reEncryptToken(value);
+      if (reEncrypted) {
+        updates[field] = reEncrypted;
+        hasUpdates = true;
+      }
+    }
+
+    if (hasUpdates) {
+      updates.encryption_key_version = targetVersion;
+      const { error } = await supabase
+        .from('professionals')
+        .update(updates as never)
+        .eq('id', prof.id as string);
+
+      if (error) {
+        logger.error('[rotate-encryption-key] professional update failed', { id: prof.id, error });
+        stats.errors++;
+      } else {
+        stats.rotated++;
+      }
+    } else {
+      // No encrypted PII fields but version mismatch — just bump version
+      await supabase
+        .from('professionals')
+        .update({ encryption_key_version: targetVersion } as never)
+        .eq('id', prof.id as string);
+      stats.skipped++;
+    }
+  }
+
+  // ─── 2. WhatsApp config tokens ──────────────────────────────────────────
+  const { data: waConfigs } = await supabase
+    .from('whatsapp_config')
+    .select('id, evolution_api_key, access_token, verify_token');
+
+  for (const config of waConfigs ?? []) {
+    const updates: Record<string, unknown> = {};
+    let hasUpdates = false;
+
+    for (const field of ['evolution_api_key', 'access_token', 'verify_token'] as const) {
+      const value = config[field] as string | null;
+      if (!value || !isEncrypted(value)) continue;
+
+      const reEncrypted = reEncryptToken(value);
+      if (reEncrypted) {
+        updates[field] = reEncrypted;
+        hasUpdates = true;
+      }
+    }
+
+    if (hasUpdates) {
+      const { error } = await supabase
+        .from('whatsapp_config')
+        .update(updates)
+        .eq('id', config.id);
+
+      if (error) {
+        logger.error('[rotate-encryption-key] whatsapp_config update failed', { id: config.id, error });
+        stats.errors++;
+      } else {
+        stats.rotated++;
+      }
+    } else {
+      stats.skipped++;
+    }
+  }
+
+  // ─── 3. Integration tokens (Instagram, Google Calendar) ─────────────────
+  const { data: integrations } = await supabase
+    .from('integrations')
+    .select('id, type, integration_type, access_token, credentials');
+
+  for (const integration of integrations ?? []) {
+    const updates: Record<string, unknown> = {};
+    let hasUpdates = false;
+
+    // Instagram: access_token column
+    if (integration.access_token && isEncrypted(integration.access_token)) {
+      const reEncrypted = reEncryptToken(integration.access_token);
+      if (reEncrypted) {
+        updates.access_token = reEncrypted;
+        hasUpdates = true;
+      }
+    }
+
+    // Google Calendar: credentials JSONB with access_token + refresh_token
+    if (integration.credentials && typeof integration.credentials === 'object') {
+      const creds = integration.credentials as Record<string, unknown>;
+      const newCreds = { ...creds };
+      let credsChanged = false;
+
+      for (const field of ['access_token', 'refresh_token'] as const) {
+        const val = creds[field] as string | undefined;
+        if (val && isEncrypted(val)) {
+          const reEncrypted = reEncryptToken(val);
+          if (reEncrypted) {
+            newCreds[field] = reEncrypted;
+            credsChanged = true;
+          }
+        }
+      }
+
+      if (credsChanged) {
+        updates.credentials = newCreds;
+        hasUpdates = true;
+      }
+    }
+
+    if (hasUpdates) {
+      const { error } = await supabase
+        .from('integrations')
+        .update(updates)
+        .eq('id', integration.id);
+
+      if (error) {
+        logger.error('[rotate-encryption-key] integration update failed', { id: integration.id, error });
+        stats.errors++;
+      } else {
+        stats.rotated++;
+      }
+    } else {
+      stats.skipped++;
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    target_version: targetVersion,
+    ...stats,
+  });
+}

--- a/src/app/api/settings/payment-setup/route.ts
+++ b/src/app/api/settings/payment-setup/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { validateIBAN } from '@/lib/validators/iban';
-import { encryptToken } from '@/lib/integrations/token-encryption';
+import { encryptToken, getCurrentKeyVersion } from '@/lib/integrations/token-encryption';
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
@@ -85,6 +85,7 @@ export async function POST(request: NextRequest) {
         payment_city: city.trim(),
         payment_postal_code: postal_code.trim(),
         payment_country: (country || 'IE').toUpperCase(),
+        encryption_key_version: getCurrentKeyVersion(),
         stripe_onboarding_status: 'pending',
       })
       .eq('id', professional.id);

--- a/src/lib/integrations/token-encryption.ts
+++ b/src/lib/integrations/token-encryption.ts
@@ -2,18 +2,31 @@ import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12; // GCM standard
-const AUTH_TAG_LENGTH = 16;
 const PREFIX = 'enc:';
+const VERSIONED_PREFIX = 'enc:v';
 
 /**
- * Returns the 32-byte encryption key from env var.
+ * Returns the current key version number from ENCRYPTION_KEY_VERSION env var.
+ * Defaults to 1 if not set.
+ */
+export function getCurrentKeyVersion(): number {
+  return parseInt(process.env.ENCRYPTION_KEY_VERSION ?? '1', 10);
+}
+
+/**
+ * Returns the 32-byte encryption key for a given version.
+ * - Version 1 (default): uses OAUTH_TOKEN_ENCRYPTION_KEY
+ * - Version N (N>1): uses OAUTH_TOKEN_ENCRYPTION_KEY_VN
  * Throws if not configured — fail loud, not silent.
  */
-function getKey(): Buffer {
-  const raw = process.env.OAUTH_TOKEN_ENCRYPTION_KEY;
+function getKeyForVersion(version: number): Buffer {
+  const envVar = version === 1
+    ? 'OAUTH_TOKEN_ENCRYPTION_KEY'
+    : `OAUTH_TOKEN_ENCRYPTION_KEY_V${version}`;
+  const raw = process.env[envVar];
   if (!raw) {
     throw new Error(
-      'OAUTH_TOKEN_ENCRYPTION_KEY env var is required for token encryption',
+      `${envVar} env var is required for token encryption (key version ${version})`,
     );
   }
   // Accept hex (64 chars) or base64 (44 chars) encoded 32-byte key
@@ -23,17 +36,26 @@ function getKey(): Buffer {
   const buf = Buffer.from(raw, 'base64');
   if (buf.length !== 32) {
     throw new Error(
-      'OAUTH_TOKEN_ENCRYPTION_KEY must be a 32-byte key (64 hex chars or 44 base64 chars)',
+      `${envVar} must be a 32-byte key (64 hex chars or 44 base64 chars)`,
     );
   }
   return buf;
 }
 
 /**
- * Encrypt a plaintext token → `enc:<iv>:<authTag>:<ciphertext>` (all hex).
+ * Returns the 32-byte encryption key from env var (current version).
+ * Throws if not configured — fail loud, not silent.
+ */
+function getKey(): Buffer {
+  return getKeyForVersion(getCurrentKeyVersion());
+}
+
+/**
+ * Encrypt a plaintext token → `enc:v<version>:<iv>:<authTag>:<ciphertext>` (all hex).
  */
 export function encryptToken(plaintext: string): string {
-  const key = getKey();
+  const version = getCurrentKeyVersion();
+  const key = getKeyForVersion(version);
   const iv = randomBytes(IV_LENGTH);
   const cipher = createCipheriv(ALGORITHM, key, iv);
 
@@ -43,11 +65,49 @@ export function encryptToken(plaintext: string): string {
   ]);
   const authTag = cipher.getAuthTag();
 
-  return `${PREFIX}${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+  return `${PREFIX}v${version}:${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+/**
+ * Parse an encrypted token string to extract version and components.
+ */
+function parseEncrypted(value: string): { version: number; iv: Buffer; authTag: Buffer; ciphertext: Buffer } {
+  const afterPrefix = value.slice(PREFIX.length);
+
+  // Versioned format: enc:v<N>:<iv>:<authTag>:<ciphertext>
+  if (afterPrefix.startsWith('v')) {
+    const parts = afterPrefix.split(':');
+    if (parts.length !== 4) {
+      throw new Error('Invalid versioned encrypted token format');
+    }
+    const version = parseInt(parts[0].slice(1), 10);
+    if (isNaN(version) || version < 1) {
+      throw new Error('Invalid encryption key version');
+    }
+    return {
+      version,
+      iv: Buffer.from(parts[1], 'hex'),
+      authTag: Buffer.from(parts[2], 'hex'),
+      ciphertext: Buffer.from(parts[3], 'hex'),
+    };
+  }
+
+  // Legacy unversioned format: enc:<iv>:<authTag>:<ciphertext> — treated as v1
+  const parts = afterPrefix.split(':');
+  if (parts.length !== 3) {
+    throw new Error('Invalid encrypted token format');
+  }
+  return {
+    version: 1,
+    iv: Buffer.from(parts[0], 'hex'),
+    authTag: Buffer.from(parts[1], 'hex'),
+    ciphertext: Buffer.from(parts[2], 'hex'),
+  };
 }
 
 /**
  * Decrypt an `enc:...` string back to plaintext.
+ * Supports both versioned (`enc:v1:...`) and legacy (`enc:...`) formats.
  * If the value is NOT prefixed with `enc:`, returns it as-is (legacy plaintext).
  */
 export function decryptToken(value: string): string {
@@ -56,16 +116,8 @@ export function decryptToken(value: string): string {
     return value;
   }
 
-  const key = getKey();
-  const parts = value.slice(PREFIX.length).split(':');
-  if (parts.length !== 3) {
-    throw new Error('Invalid encrypted token format');
-  }
-
-  const [ivHex, authTagHex, ciphertextHex] = parts;
-  const iv = Buffer.from(ivHex, 'hex');
-  const authTag = Buffer.from(authTagHex, 'hex');
-  const ciphertext = Buffer.from(ciphertextHex, 'hex');
+  const { version, iv, authTag, ciphertext } = parseEncrypted(value);
+  const key = getKeyForVersion(version);
 
   const decipher = createDecipheriv(ALGORITHM, key, iv);
   decipher.setAuthTag(authTag);
@@ -79,8 +131,42 @@ export function decryptToken(value: string): string {
 }
 
 /**
+ * Get the key version used to encrypt a token.
+ * Returns 0 for plaintext (unencrypted) values.
+ */
+export function getTokenKeyVersion(value: string): number {
+  if (!value.startsWith(PREFIX)) return 0;
+  const { version } = parseEncrypted(value);
+  return version;
+}
+
+/**
+ * Re-encrypt a token from its current key version to the current active version.
+ * Returns null if already on the current version.
+ */
+export function reEncryptToken(value: string): string | null {
+  const currentVersion = getCurrentKeyVersion();
+  const tokenVersion = getTokenKeyVersion(value);
+
+  // Already on current version (or plaintext)
+  if (tokenVersion === currentVersion) return null;
+
+  // Decrypt with old key, encrypt with new key
+  const plaintext = decryptToken(value);
+  return encryptToken(plaintext);
+}
+
+/**
  * Check if a token value is already encrypted.
  */
 export function isEncrypted(value: string): boolean {
   return value.startsWith(PREFIX);
+}
+
+/**
+ * Check if a token needs re-encryption (encrypted with an older key version).
+ */
+export function needsReEncryption(value: string): boolean {
+  if (!isEncrypted(value)) return false;
+  return getTokenKeyVersion(value) !== getCurrentKeyVersion();
 }

--- a/supabase/migrations/20260310000002_encryption_key_version.sql
+++ b/supabase/migrations/20260310000002_encryption_key_version.sql
@@ -1,0 +1,5 @@
+-- Add encryption_key_version to professionals for PII key rotation tracking
+ALTER TABLE professionals
+  ADD COLUMN IF NOT EXISTS encryption_key_version smallint NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN professionals.encryption_key_version IS 'Version of encryption key used for PII fields (payment_full_name, payment_dob, payment_iban, payment_address_line1, payment_address_line2)';


### PR DESCRIPTION
## Summary
- Added encryption key versioning: tokens now include version prefix `enc:v<N>:...`
- Backwards compatible with legacy `enc:...` format (treated as v1)
- Multiple keys supported via `OAUTH_TOKEN_ENCRYPTION_KEY_V<N>` env vars
- `ENCRYPTION_KEY_VERSION` env var controls active version (default: 1)
- Admin endpoint `POST /api/admin/rotate-encryption-key` re-encrypts all PII (professionals, whatsapp_config, integrations)
- Migration adds `encryption_key_version` column to professionals table
- `payment-setup` route stores key version when writing encrypted PII

## Key rotation procedure
1. Generate new 32-byte key → set as `OAUTH_TOKEN_ENCRYPTION_KEY_V2`
2. Set `ENCRYPTION_KEY_VERSION=2`
3. Keep old key (`OAUTH_TOKEN_ENCRYPTION_KEY`) in env
4. Call `POST /api/admin/rotate-encryption-key` with `{ "secret": "<SETUP_SECRET>" }`
5. After confirming success, old key can be removed

## Test plan
- [x] `tsc --noEmit` clean
- [x] 102 test files, 1465 tests pass (12 new key rotation tests)
- [x] Roundtrip v1 → v2 re-encryption verified
- [x] Legacy unversioned format backwards compat verified
- [x] needsReEncryption / getTokenKeyVersion helpers tested

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)