### PR TITLE
fix: [LOW] Acessibilidade, key={index}, PII em logs, as any cleanup

### DIFF
--- a/src/app/api/bookings/cancel-notification/route.ts
+++ b/src/app/api/bookings/cancel-notification/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
       if (wc.provider === 'evolution' && wc.evolution_api_url && wc.evolution_instance) {
         const normalized = normalizePhoneForWhatsApp(booking.client_phone);
         const evoUrl = `${wc.evolution_api_url}/message/sendText/${wc.evolution_instance}`;
-        logger.info('[cancel-notification] WhatsApp attempt:', { raw: booking.client_phone, normalized, url: evoUrl, hasApiKey: !!wc.evolution_api_key });
+        logger.info('[cancel-notification] WhatsApp attempt:', { phoneLength: booking.client_phone.length, normalized: normalized.slice(0, 4) + '***', url: evoUrl, hasApiKey: !!wc.evolution_api_key });
         const res = await fetch(evoUrl, {
           method: 'POST',
           headers: { apikey: decryptToken(wc.evolution_api_key), 'Content-Type': 'application/json' },

--- a/src/app/api/integrations/instagram/callback/route.ts
+++ b/src/app/api/integrations/instagram/callback/route.ts
@@ -96,10 +96,10 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(
       `${process.env.NEXT_PUBLIC_BASE_URL}/integrations?success=instagram_connected`
     )
-  } catch (error: any) {
+  } catch (error: unknown) {
     logger.error('Instagram OAuth error:', error)
     return NextResponse.redirect(
-      `${process.env.NEXT_PUBLIC_BASE_URL}/integrations?error=${encodeURIComponent(error.message)}`
+      `${process.env.NEXT_PUBLIC_BASE_URL}/integrations?error=instagram_connection_failed`
     )
   }
 }

--- a/src/components/public-page/before-after-slider.tsx
+++ b/src/components/public-page/before-after-slider.tsx
@@ -61,6 +61,12 @@ export function BeforeAfterSlider({ beforeImage, afterImage, title, beforeLabel 
       {/* Slider Control */}
       <div
         className="absolute inset-0 cursor-ew-resize"
+        role="slider"
+        aria-label={title || 'Before and after comparison'}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(sliderPosition)}
+        tabIndex={0}
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseUp}
         onMouseMove={handleMouseMove}
@@ -68,6 +74,22 @@ export function BeforeAfterSlider({ beforeImage, afterImage, title, beforeLabel 
         onTouchStart={handleMouseDown}
         onTouchEnd={handleMouseUp}
         onTouchMove={handleTouchMove}
+        onKeyDown={(e) => {
+          const step = e.shiftKey ? 10 : 2;
+          if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
+            e.preventDefault();
+            setSliderPosition((prev) => Math.max(0, prev - step));
+          } else if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
+            e.preventDefault();
+            setSliderPosition((prev) => Math.min(100, prev + step));
+          } else if (e.key === 'Home') {
+            e.preventDefault();
+            setSliderPosition(0);
+          } else if (e.key === 'End') {
+            e.preventDefault();
+            setSliderPosition(100);
+          }
+        }}
       >
         {/* Slider Line */}
         <div

--- a/src/components/public-page/hero.tsx
+++ b/src/components/public-page/hero.tsx
@@ -23,7 +23,7 @@ export function Hero({ professional }: HeroProps) {
         {professional.cover_image_url && (
           <Image
             src={professional.cover_image_url}
-            alt=""
+            alt={`${professional.business_name} cover`}
             fill
             priority
             sizes="100vw"

--- a/src/components/public-page/section-about.tsx
+++ b/src/components/public-page/section-about.tsx
@@ -49,9 +49,9 @@ export function SectionAbout({ data, theme = 'default' }: SectionAboutProps) {
           <div className="mb-6">
             <h3 className="text-xl font-semibold mb-3">{t('specialties')}</h3>
             <div className="flex flex-wrap gap-2">
-              {data.specialties.map((specialty, index) => (
+              {data.specialties.map((specialty) => (
                 <span
-                  key={index}
+                  key={specialty}
                   className="bg-purple-100 text-purple-800 px-4 py-2 rounded-full text-sm font-medium"
                 >
                   {specialty}
@@ -68,9 +68,9 @@ export function SectionAbout({ data, theme = 'default' }: SectionAboutProps) {
               {t('certifications')}
             </h3>
             <div className="space-y-3">
-              {data.certifications.map((cert, index) => (
+              {data.certifications.map((cert) => (
                 <div
-                  key={index}
+                  key={`${cert.name}-${cert.institution}-${cert.year}`}
                   className="border-l-4 border-purple-500 pl-4 py-2"
                 >
                   <p className="font-semibold">{cert.name}</p>

--- a/src/components/public-page/section-faq.tsx
+++ b/src/components/public-page/section-faq.tsx
@@ -24,7 +24,7 @@ export function SectionFAQ({ data, theme = 'default' }: SectionFAQProps) {
         <div className="space-y-4">
           {data.items.map((item, index) => (
             <div
-              key={index}
+              key={`faq-${item.question.slice(0, 40)}`}
               className="bg-white rounded-lg shadow-sm overflow-hidden"
             >
               <button

--- a/src/components/public-page/section-gallery.tsx
+++ b/src/components/public-page/section-gallery.tsx
@@ -14,7 +14,7 @@ interface SectionGalleryProps {
 
 export function SectionGallery({ data, professionalId, theme = 'default' }: SectionGalleryProps) {
   const t = useTranslations('public');
-  const [images, setImages] = useState<any[]>([]);
+  const [images, setImages] = useState<{ id: string; image_url: string; title?: string; description?: string; is_before_after?: boolean; before_image_url?: string; after_image_url?: string }[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
   const [loading, setLoading] = useState(true);
 
@@ -108,7 +108,7 @@ export function SectionGallery({ data, professionalId, theme = 'default' }: Sect
                 <div className="relative overflow-hidden rounded-lg shadow-md hover:shadow-xl transition-shadow group">
                   <img
                     src={image.image_url}
-                    alt={image.title || ''}
+                    alt={image.title || 'Gallery image'}
                     className="w-full h-64 object-cover group-hover:scale-105 transition-transform duration-300"
                   />
                   {(image.title || image.description) && (

--- a/src/components/public-page/section-renderer.tsx
+++ b/src/components/public-page/section-renderer.tsx
@@ -1,4 +1,4 @@
-import { PageSection } from '@/lib/page-sections/types';
+import type { PageSection, AboutData, ServicesData, GalleryData, TestimonialsData, FAQData } from '@/lib/page-sections/types';
 import { Hero } from './hero';
 import { SectionAbout } from './section-about';
 import { ServicesList } from './services-list';
@@ -34,14 +34,14 @@ export function SectionRenderer({
       return <Hero professional={professional} />;
 
     case 'about':
-      return <SectionAbout data={section.data as any} theme={section.theme} />;
+      return <SectionAbout data={section.data as AboutData} theme={section.theme} />;
 
     case 'services':
       if (!services || services.length === 0) return null;
       return (
         <div className="py-8">
           <h2 className="text-2xl font-bold mb-6 text-center px-4">
-            {(section.data as any).heading || t('myServices')}
+            {(section.data as ServicesData).heading || t('myServices')}
           </h2>
           <ServicesList services={services} currency={currency || 'EUR'} />
         </div>
@@ -50,7 +50,7 @@ export function SectionRenderer({
     case 'gallery':
       return (
         <SectionGallery
-          data={section.data as any}
+          data={section.data as GalleryData}
           professionalId={professional.id}
           theme={section.theme}
         />
@@ -59,14 +59,14 @@ export function SectionRenderer({
     case 'testimonials':
       return (
         <SectionTestimonials
-          data={section.data as any}
+          data={section.data as TestimonialsData}
           professionalId={professional.id}
           theme={section.theme}
         />
       );
 
     case 'faq':
-      return <SectionFAQ data={section.data as any} theme={section.theme} />;
+      return <SectionFAQ data={section.data as FAQData} theme={section.theme} />;
 
     case 'contact':
       return <ContactFooter professional={professional} />;

--- a/src/lib/admin/session.ts
+++ b/src/lib/admin/session.ts
@@ -1,16 +1,24 @@
 import { createHmac, randomUUID } from 'crypto';
 import Redis from 'ioredis';
 import { parseRedisUrl } from '@/lib/redis/parse-url';
+import { logger } from '@/lib/logger';
 
 const SESSION_EXPIRY_HOURS = 8;
 const SESSION_EXPIRY_SECONDS = SESSION_EXPIRY_HOURS * 60 * 60;
+
+let warnedPasswordFallback = false;
 
 /**
  * Returns the HMAC signing secret for admin session tokens.
  * Prefers ADMIN_SESSION_SECRET (dedicated); falls back to ADMIN_PASSWORD.
  */
 function getSigningSecret(): string | undefined {
-  return process.env.ADMIN_SESSION_SECRET || process.env.ADMIN_PASSWORD;
+  const secret = process.env.ADMIN_SESSION_SECRET || process.env.ADMIN_PASSWORD;
+  if (secret && !process.env.ADMIN_SESSION_SECRET && !warnedPasswordFallback) {
+    logger.warn('[admin/session] Using password fallback for session signing — set ADMIN_SESSION_SECRET for better security');
+    warnedPasswordFallback = true;
+  }
+  return secret;
 }
 
 // ─── Redis / In-Memory Session Store ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **L1**: Replace `key={index}` with stable keys (specialty text, cert name+institution+year, faq question)
- **L2**: Meaningful alt text on cover image (`business_name cover`) and gallery images (`Gallery image` fallback)
- **L3**: Before/after slider keyboard accessibility: `role=slider`, `aria-valuemin/max/now`, arrow keys (±2, shift ±10), Home/End
- **L4**: Warning log when `ADMIN_PASSWORD` is used as session signing fallback instead of `ADMIN_SESSION_SECRET`
- **L5**: Phone number masked in cancel-notification logs (`+353***` instead of full number)
- **L6**: Instagram callback error redirect uses generic code instead of `error.message` in URL
- **L7**: `as any` → specific type assertions in section-renderer; typed gallery image state

## Test plan
- [x] `tsc --noEmit` clean
- [x] 102 test files, 1465 tests pass
- [x] Admin session test passes with warning log change

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)