### PR TITLE
fix: [ENHANCEMENT] Captcha em testimonials, audit log, Stripe config, npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "test:payment": "playwright test e2e/payment/04-payment-flow.spec.ts",
     "test:no-payment": "playwright test e2e/payment/03-booking-no-payment.spec.ts",
     "test:settings": "playwright test e2e/payment/02-payment-settings.spec.ts",
-    "test:deposit": "playwright test e2e/payment/"
+    "test:deposit": "playwright test e2e/payment/",
+    "audit": "npm audit --omit=dev",
+    "audit:fix": "npm audit fix --omit=dev"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",

--- a/src/__tests__/security/webhook-timestamp-validation.test.ts
+++ b/src/__tests__/security/webhook-timestamp-validation.test.ts
@@ -23,8 +23,9 @@ describe('Stripe webhook timestamp validation (issue #150)', () => {
     expect(source).toContain('EVENT_MAX_AGE_SECONDS');
   });
 
-  it('max age is 300 seconds (5 minutes)', () => {
-    expect(source).toContain('EVENT_MAX_AGE_SECONDS = 300');
+  it('max age defaults to 300 seconds (5 minutes)', () => {
+    expect(source).toContain("'300'");
+    expect(source).toContain('STRIPE_EVENT_MAX_AGE_SECONDS');
   });
 
   it('calculates event age from current time', () => {

--- a/src/app/api/settings/payment/route.ts
+++ b/src/app/api/settings/payment/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { logger } from '@/lib/logger';
 
 export async function GET() {
   const supabase = await createClient();
@@ -73,6 +74,13 @@ export async function PUT(request: NextRequest) {
   if (error) {
     return NextResponse.json({ error: 'Erro ao salvar configurações' }, { status: 500 });
   }
+
+  logger.info('[settings/payment] payment config updated', {
+    user_id: user.id,
+    require_deposit: require_deposit ?? false,
+    deposit_type: require_deposit ? deposit_type : null,
+    deposit_value: require_deposit ? deposit_value : null,
+  });
 
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/testimonials/route.ts
+++ b/src/app/api/testimonials/route.ts
@@ -113,6 +113,16 @@ export async function POST(request: NextRequest) {
 
   // ── Fluxo público (professional_id no body → visitante enviando depoimento) ──
   if (bodyProfessionalId) {
+    // Honeypot: if the hidden field is filled, it's a bot — silently accept
+    if (body.website || body.url || body.company) {
+      return NextResponse.json({ testimonial: { id: 'ok' } }, { status: 201 });
+    }
+
+    // Timing check: submissions faster than 3 seconds are likely bots
+    if (typeof body._t === 'number' && Date.now() - body._t < 3000) {
+      return NextResponse.json({ testimonial: { id: 'ok' } }, { status: 201 });
+    }
+
     // Validate UUID format
     if (!z.string().uuid().safeParse(bodyProfessionalId).success) {
       return NextResponse.json({ error: 'Invalid professional ID' }, { status: 400 });

--- a/src/app/api/webhooks/stripe-connect/route.ts
+++ b/src/app/api/webhooks/stripe-connect/route.ts
@@ -35,8 +35,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ received: true, deduplicated: true });
   }
 
-  // Reject events older than 5 minutes (replay attack protection)
-  const EVENT_MAX_AGE_SECONDS = 300;
+  // Reject stale events (replay attack protection)
+  const EVENT_MAX_AGE_SECONDS = parseInt(process.env.STRIPE_EVENT_MAX_AGE_SECONDS ?? '300', 10);
   const eventAge = Math.floor(Date.now() / 1000) - event.created;
   if (eventAge > EVENT_MAX_AGE_SECONDS) {
     logger.warn('[stripe-connect/webhook] rejected stale event', { id: event.id, age: eventAge });

--- a/src/app/api/webhooks/stripe-deposit/route.ts
+++ b/src/app/api/webhooks/stripe-deposit/route.ts
@@ -40,8 +40,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ received: true, deduplicated: true });
   }
 
-  // ─── Timestamp validation: reject events older than 5 minutes (replay attack) ─
-  const EVENT_MAX_AGE_SECONDS = 300; // 5 minutes
+  // ─── Timestamp validation: reject stale events (replay attack protection) ─
+  const EVENT_MAX_AGE_SECONDS = parseInt(process.env.STRIPE_EVENT_MAX_AGE_SECONDS ?? '300', 10);
   const eventAge = Math.floor(Date.now() / 1000) - event.created;
   if (eventAge > EVENT_MAX_AGE_SECONDS) {
     logger.warn('[Webhook] rejected stale event', { id: event.id, age: eventAge });


### PR DESCRIPTION
## Summary
- **E1**: Honeypot anti-spam for public testimonial submissions — hidden fields (`website`, `url`, `company`) and timing check (<3s) silently return 201 without DB insert
- **E2**: Audit log for payment config changes — `logger.info` with `user_id`, `deposit_type`, `deposit_value` on every PUT to `/api/settings/payment`
- **E3**: Stripe event max age configurable via `STRIPE_EVENT_MAX_AGE_SECONDS` env var (default 300s) in both `stripe-deposit` and `stripe-connect` webhooks
- **E4**: `npm run audit` and `npm run audit:fix` scripts added to `package.json`

## Env vars (optional)
- `STRIPE_EVENT_MAX_AGE_SECONDS` — max age in seconds for Stripe webhook events (default: 300)

## Test plan
- [x] `tsc --noEmit` clean
- [x] 102 test files, 1465 tests pass
- [x] Webhook timestamp test updated to verify configurable default

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)