### PR TITLE
fix: [BOOKINGS][BLOCKER] Checkout endpoint não limpa pending_payment expirados antes do conflict check

### DIFF
--- a/src/__tests__/payments/checkout-deposit.test.ts
+++ b/src/__tests__/payments/checkout-deposit.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { calculateDeposit, toCents } from '@/lib/payment/calculate-deposit';
 
 describe('calculateDeposit', () => {
@@ -54,5 +56,34 @@ describe('application_fee 5%', () => {
 
     expect(depositCents).toBe(100); // €1 em centavos
     expect(applicationFee).toBe(5); // 5 centavos (5% de €1)
+  });
+});
+
+describe('checkout endpoint expires stale pending_payment before conflict check (issue #492)', () => {
+  const checkoutSource = readFileSync(
+    resolve('src/app/api/bookings/checkout/route.ts'),
+    'utf-8',
+  );
+  const bookingsSource = readFileSync(
+    resolve('src/app/api/bookings/route.ts'),
+    'utf-8',
+  );
+
+  it('checkout has pending_payment expiration before conflict check', () => {
+    const expirationIdx = checkoutSource.indexOf("'expired'");
+    const conflictIdx = checkoutSource.indexOf('Check double-booking');
+    expect(expirationIdx).toBeGreaterThan(-1);
+    expect(conflictIdx).toBeGreaterThan(-1);
+    expect(expirationIdx).toBeLessThan(conflictIdx);
+  });
+
+  it('checkout uses 30-minute cutoff like bookings route', () => {
+    expect(checkoutSource).toContain('30 * 60 * 1000');
+    expect(bookingsSource).toContain('30 * 60 * 1000');
+  });
+
+  it('checkout filters by pending_payment status and created_at', () => {
+    expect(checkoutSource).toContain("'pending_payment'");
+    expect(checkoutSource).toContain('paymentCutoff');
   });
 });

--- a/src/__tests__/payments/idempotency-key.test.ts
+++ b/src/__tests__/payments/idempotency-key.test.ts
@@ -107,7 +107,13 @@ function mockSupabase(overrides: Record<string, unknown> = {}) {
           }),
         }),
         update: vi.fn().mockReturnValue({
-          eq: vi.fn().mockResolvedValue({ error: null }),
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                lt: vi.fn().mockResolvedValue({ error: null }),
+              }),
+            }),
+          }),
         }),
       };
     }

--- a/src/app/api/bookings/checkout/route.ts
+++ b/src/app/api/bookings/checkout/route.ts
@@ -166,7 +166,17 @@ export async function POST(request: NextRequest) {
   }
   const applicationFeeCents = Math.round(depositCents * APPLICATION_FEE_PERCENT);
 
-  // ─── 9. Check double-booking ─────────────────────────────────────────────
+  // ─── 9a. Expire stale pending_payment bookings (>30min) before conflict check ─
+  const paymentCutoff = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+  await supabase
+    .from('bookings')
+    .update({ status: 'expired' })
+    .eq('professional_id', professional_id)
+    .eq('booking_date', booking_date)
+    .eq('status', 'pending_payment')
+    .lt('created_at', paymentCutoff);
+
+  // ─── 9b. Check double-booking ─────────────────────────────────────────────
   const { data: conflicts } = await supabase
     .from('bookings')
     .select('id')


### PR DESCRIPTION
## Summary
Add inline cleanup of stale `pending_payment` bookings (>30min) before the double-booking conflict check in `/api/bookings/checkout` — matching the same cleanup already present in `/api/bookings/route.ts:149-158`.

## Problem
Abandoned checkout sessions block time slots for up to 30 minutes. New customers get 409 "Horario indisponível" for slots that will never be paid for.

## Fix
Expire `pending_payment` bookings older than 30 minutes before the conflict check, identical to the regular booking endpoint.

## Test plan
- [x] Source verification: expiration happens before conflict check
- [x] Source verification: uses same 30-min cutoff as bookings route
- [x] `tsc --noEmit` clean
- [x] 102 test files, 1468 tests pass

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)