### PR TITLE
fix: [PAYMENTS][BLOCKER] Payment status CHECK constraint não inclui partially_refunded, disputed, cancelled

### DIFF
--- a/src/__tests__/payments/payment-status-constraint.test.ts
+++ b/src/__tests__/payments/payment-status-constraint.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Issue #491: Payment status CHECK constraint must include all statuses
+ * used by the Stripe webhook handler.
+ */
+describe('Payment status CHECK constraint covers all webhook statuses (issue #491)', () => {
+  const migrationSource = readFileSync(
+    resolve('supabase/migrations/20260310000003_payments_status_check_expand.sql'),
+    'utf-8',
+  );
+
+  const webhookSource = readFileSync(
+    resolve('src/app/api/webhooks/stripe-deposit/route.ts'),
+    'utf-8',
+  );
+
+  // All payment statuses used by webhook (from .from('payments').update({ status: '...' }))
+  const PAYMENT_STATUSES = [
+    'pending', 'processing', 'succeeded', 'failed', 'refunded',
+    'partially_refunded', 'disputed', 'cancelled',
+  ];
+
+  it('migration contains all payment statuses used by stripe-deposit webhook', () => {
+    for (const status of PAYMENT_STATUSES) {
+      expect(
+        migrationSource,
+        `Migration missing status '${status}'`,
+      ).toContain(`'${status}'`);
+    }
+  });
+
+  it('webhook uses partially_refunded, disputed, and cancelled', () => {
+    expect(webhookSource).toContain("'partially_refunded'");
+    expect(webhookSource).toContain("'disputed'");
+    expect(webhookSource).toContain("'cancelled'");
+  });
+
+  it('migration has all core statuses', () => {
+    for (const status of ['pending', 'processing', 'succeeded', 'failed', 'refunded']) {
+      expect(migrationSource).toContain(`'${status}'`);
+    }
+  });
+
+  it('migration drops old constraint before adding new one', () => {
+    const dropIdx = migrationSource.indexOf('DROP CONSTRAINT');
+    const addIdx = migrationSource.indexOf('ADD CONSTRAINT');
+    expect(dropIdx).toBeGreaterThan(-1);
+    expect(addIdx).toBeGreaterThan(-1);
+    expect(dropIdx).toBeLessThan(addIdx);
+  });
+});

--- a/supabase/migrations/20260310000003_payments_status_check_expand.sql
+++ b/supabase/migrations/20260310000003_payments_status_check_expand.sql
@@ -1,0 +1,6 @@
+-- Expand payments status CHECK constraint to include all statuses used by webhooks
+-- Missing: partially_refunded (charge.refunded partial), disputed (charge.dispute.created), cancelled (payment_intent.canceled)
+
+ALTER TABLE payments DROP CONSTRAINT IF EXISTS payments_status_check;
+ALTER TABLE payments ADD CONSTRAINT payments_status_check
+  CHECK (status IN ('pending', 'processing', 'succeeded', 'failed', 'refunded', 'partially_refunded', 'disputed', 'cancelled'));


### PR DESCRIPTION
## Summary
Migration to expand the payments table CHECK constraint from 5 to 8 allowed statuses, adding `partially_refunded`, `disputed`, and `cancelled`.

## Problem
Stripe webhooks for partial refunds (`charge.refunded`), disputes (`charge.dispute.created`), and cancellations (`payment_intent.canceled`) crash with DB constraint violation (23514) because the CHECK constraint only allows: `pending, processing, succeeded, failed, refunded`.

## Fix
New migration `20260310000003_payments_status_check_expand.sql` drops and recreates the constraint with all 8 statuses.

## Test plan
- [x] Source verification: migration contains all 8 payment statuses
- [x] Source verification: webhook uses partially_refunded, disputed, cancelled
- [x] Migration drops old constraint before adding new one
- [x] 103 test files, 1472 tests pass

**Important**: Run `supabase db push` or apply migration in production before deploying.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)