### PR TITLE
fix: [CRITICAL] remove hardcoded Stripe keys from source code

### DIFF
--- a/src/__tests__/security/no-hardcoded-secrets.test.ts
+++ b/src/__tests__/security/no-hardcoded-secrets.test.ts
@@ -20,6 +20,9 @@ const FORBIDDEN_PATTERNS = [
     label: 'Redis hostname',
   },
   { pattern: /re_iebgvquj/, label: 'Resend API key prefix' },
+  { pattern: /pk_test_51[A-Za-z0-9]{10,}/, label: 'Stripe publishable key (real)' },
+  { pattern: /sk_test_51[A-Za-z0-9]{10,}/, label: 'Stripe secret key (real)' },
+  { pattern: /whsec_[A-Za-z0-9]{20,}/, label: 'Stripe webhook secret (real)' },
 ];
 
 function readFileContent(filePath: string): string {

--- a/src/app/[locale]/(admin)/admin/handbook/page.tsx
+++ b/src/app/[locale]/(admin)/admin/handbook/page.tsx
@@ -102,7 +102,7 @@ const sections = [
     color: 'hover:border-violet-300 hover:bg-violet-50/50 dark:hover:bg-violet-950/20',
     iconColor: 'text-violet-500',
     previews: [
-      'Test mode: pk_test_51T5XUK...',
+      'Test mode: pk_test_••••••••••••',
       'CircleHood Pro: €25/mês + 14 dias trial',
       'Webhooks & Quick Links',
     ],


### PR DESCRIPTION
Closes #495

## Summary
- Redacted partial Stripe publishable key (`pk_test_51T5XUK...`) from handbook preview string
- Added Stripe key regex patterns (publishable, secret, webhook secret) to `no-hardcoded-secrets.test.ts` to prevent future regressions
- The main `stripe-config/page.tsx` was already cleaned in PR #471; this catches the remaining partial key in the parent handbook page

## Test plan
- [x] `no-hardcoded-secrets.test.ts` passes (61 tests)
- [x] `tsc --noEmit` clean
- [x] No real Stripe keys found in any tracked source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)